### PR TITLE
Add query duration bucket in the metrics

### DIFF
--- a/internal/cortex/querier/queryrange/instrumentation.go
+++ b/internal/cortex/querier/queryrange/instrumentation.go
@@ -12,19 +12,24 @@ import (
 	"github.com/weaveworks/common/instrument"
 )
 
+const DAY = 24 * time.Hour
+const QUERYDURATIONBUCKET = "query_range_bucket"
+
 // InstrumentMiddleware can be inserted into the middleware chain to expose timing information.
 func InstrumentMiddleware(name string, metrics *InstrumentMiddlewareMetrics) Middleware {
-	var durationCol instrument.Collector
 
+	var durationCol instrument.Collector
 	// Support the case metrics shouldn't be tracked (ie. unit tests).
 	if metrics != nil {
-		durationCol = instrument.NewHistogramCollector(metrics.duration)
+		durationCol = NewDurationHistogramCollector(metrics.duration)
 	} else {
 		durationCol = &NoopCollector{}
 	}
 
 	return MiddlewareFunc(func(next Handler) Handler {
 		return HandlerFunc(func(ctx context.Context, req Request) (Response, error) {
+			queryRangeDurationBucket := getRangeBucket(req)
+			ctx = context.WithValue(ctx, QUERYDURATIONBUCKET, queryRangeDurationBucket)
 			var resp Response
 			err := instrument.CollectedRequest(ctx, name, durationCol, instrument.ErrorCode, func(ctx context.Context) error {
 				var err error
@@ -34,6 +39,32 @@ func InstrumentMiddleware(name string, metrics *InstrumentMiddlewareMetrics) Mid
 			return resp, err
 		})
 	})
+}
+
+func getRangeBucket(req Request) string {
+	queryRangeDuration := req.GetEnd() - req.GetStart()
+	var queryRangeDurationBucket string
+	switch {
+	case queryRangeDuration < 0:
+		return "Invalid"
+	case queryRangeDuration <= time.Hour.Milliseconds():
+		return "1h"
+	case queryRangeDuration <= 6*time.Hour.Milliseconds():
+		return "6h"
+	case queryRangeDuration <= 12*time.Hour.Milliseconds():
+		return "12h"
+	case queryRangeDuration <= DAY.Milliseconds():
+		return "1d"
+	case queryRangeDuration <= 2*DAY.Milliseconds():
+		return "2d"
+	case queryRangeDuration <= 7*DAY.Milliseconds():
+		return "7d"
+	case queryRangeDuration <= 30*DAY.Milliseconds():
+		return "30d"
+	default:
+		return "+INF"
+	}
+	return queryRangeDurationBucket
 }
 
 // InstrumentMiddlewareMetrics holds the metrics tracked by InstrumentMiddleware.
@@ -49,7 +80,7 @@ func NewInstrumentMiddlewareMetrics(registerer prometheus.Registerer) *Instrumen
 			Name:      "frontend_query_range_duration_seconds",
 			Help:      "Total time spent in seconds doing query range requests.",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"method", "status_code"}),
+		}, []string{"method", "status_code", QUERYDURATIONBUCKET}),
 	}
 }
 
@@ -65,3 +96,26 @@ func (c *NoopCollector) Before(ctx context.Context, method string, start time.Ti
 
 // After implements instrument.Collector.
 func (c *NoopCollector) After(ctx context.Context, method, statusCode string, start time.Time) {}
+
+// DurationHistogramCollector collects the duration of a request
+type DurationHistogramCollector struct {
+	metric *prometheus.HistogramVec
+}
+
+func (c *DurationHistogramCollector) Before(ctx context.Context, method string, start time.Time) {
+}
+
+func (c *DurationHistogramCollector) After(ctx context.Context, method, statusCode string, start time.Time) {
+	durationBucket, _ := ctx.Value(QUERYDURATIONBUCKET).(string)
+
+	if c.metric != nil {
+		instrument.ObserveWithExemplar(ctx, c.metric.WithLabelValues(method, statusCode, durationBucket), time.Since(start).Seconds())
+	}
+}
+func (c *DurationHistogramCollector) Register() {
+	prometheus.MustRegister(c.metric)
+}
+
+func NewDurationHistogramCollector(metric *prometheus.HistogramVec) *DurationHistogramCollector {
+	return &DurationHistogramCollector{metric}
+}

--- a/internal/cortex/querier/queryrange/roundtrip.go
+++ b/internal/cortex/querier/queryrange/roundtrip.go
@@ -157,11 +157,11 @@ func NewTripperware(
 
 	queryRangeMiddleware := []Middleware{NewLimitsMiddleware(limits)}
 	if cfg.AlignQueriesWithStep {
-		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("step_align", metrics), StepAlignMiddleware)
+		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("step_align", metrics, log), StepAlignMiddleware)
 	}
 	if cfg.SplitQueriesByInterval != 0 {
 		staticIntervalFn := func(_ Request) time.Duration { return cfg.SplitQueriesByInterval }
-		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("split_by_interval", metrics), SplitByIntervalMiddleware(staticIntervalFn, limits, codec, registerer))
+		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("split_by_interval", metrics, log), SplitByIntervalMiddleware(staticIntervalFn, limits, codec, registerer))
 	}
 
 	var c cache.Cache
@@ -174,11 +174,11 @@ func NewTripperware(
 			return nil, nil, err
 		}
 		c = cache
-		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("results_cache", metrics), queryCacheMiddleware)
+		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("results_cache", metrics, log), queryCacheMiddleware)
 	}
 
 	if cfg.MaxRetries > 0 {
-		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("retry", metrics), NewRetryMiddleware(log, cfg.MaxRetries, NewRetryMiddlewareMetrics(registerer)))
+		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("retry", metrics, log), NewRetryMiddleware(log, cfg.MaxRetries, NewRetryMiddlewareMetrics(registerer)))
 	}
 
 	// Start cleanup. If cleaner stops or fail, we will simply not clean the metrics for inactive users.

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -164,7 +164,7 @@ func newQueryRangeTripperware(
 	if config.AlignRangeWithStep {
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,
-			queryrange.InstrumentMiddleware("step_align", m),
+			queryrange.InstrumentMiddleware("step_align", m, logger),
 			queryrange.StepAlignMiddleware,
 		)
 	}
@@ -172,7 +172,7 @@ func newQueryRangeTripperware(
 	if config.RequestDownsampled {
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,
-			queryrange.InstrumentMiddleware("downsampled", m),
+			queryrange.InstrumentMiddleware("downsampled", m, logger),
 			DownsampledMiddleware(codec, reg),
 		)
 	}
@@ -182,7 +182,7 @@ func newQueryRangeTripperware(
 
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,
-			queryrange.InstrumentMiddleware("split_by_interval", m),
+			queryrange.InstrumentMiddleware("split_by_interval", m, logger),
 			SplitByIntervalMiddleware(queryIntervalFn, limits, codec, reg),
 		)
 	}
@@ -213,7 +213,7 @@ func newQueryRangeTripperware(
 
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,
-			queryrange.InstrumentMiddleware("results_cache", m),
+			queryrange.InstrumentMiddleware("results_cache", m, logger),
 			queryCacheMiddleware,
 		)
 	}
@@ -221,7 +221,7 @@ func newQueryRangeTripperware(
 	if config.MaxRetries > 0 {
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,
-			queryrange.InstrumentMiddleware("retry", m),
+			queryrange.InstrumentMiddleware("retry", m, logger),
 			queryrange.NewRetryMiddleware(logger, config.MaxRetries, queryrange.NewRetryMiddlewareMetrics(reg)),
 		)
 	}
@@ -276,7 +276,7 @@ func newLabelsTripperware(
 	if config.SplitQueriesByInterval != 0 {
 		labelsMiddleware = append(
 			labelsMiddleware,
-			queryrange.InstrumentMiddleware("split_interval", m),
+			queryrange.InstrumentMiddleware("split_interval", m, logger),
 			SplitByIntervalMiddleware(queryIntervalFn, limits, codec, reg),
 		)
 	}
@@ -300,7 +300,7 @@ func newLabelsTripperware(
 
 		labelsMiddleware = append(
 			labelsMiddleware,
-			queryrange.InstrumentMiddleware("results_cache", m),
+			queryrange.InstrumentMiddleware("results_cache", m, logger),
 			queryCacheMiddleware,
 		)
 	}
@@ -308,7 +308,7 @@ func newLabelsTripperware(
 	if config.MaxRetries > 0 {
 		labelsMiddleware = append(
 			labelsMiddleware,
-			queryrange.InstrumentMiddleware("retry", m),
+			queryrange.InstrumentMiddleware("retry", m, logger),
 			queryrange.NewRetryMiddleware(logger, config.MaxRetries, queryrange.NewRetryMiddlewareMetrics(reg)),
 		)
 	}
@@ -333,7 +333,7 @@ func newInstantQueryTripperware(
 		analyzer := querysharding.NewQueryAnalyzer()
 		instantQueryMiddlewares = append(
 			instantQueryMiddlewares,
-			queryrange.InstrumentMiddleware("sharding", m),
+			queryrange.InstrumentMiddleware("sharding", m, log.NewNopLogger()),
 			PromQLShardingMiddleware(analyzer, numShards, limits, codec, reg),
 		)
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Tested in the integration test cluster
<img width="1664" alt="Screen Shot 2023-04-03 at 2 33 57 PM" src="https://user-images.githubusercontent.com/35881640/229635356-efe89c51-7883-4505-b0c8-2cfae6c5cd13.png">
<img width="1581" alt="Screen Shot 2023-04-03 at 2 34 16 PM" src="https://user-images.githubusercontent.com/35881640/229635361-54e3c754-50cb-4bfb-9d00-f6c30411ee83.png">

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
