### PR TITLE
Add more logs to Store Gateway block syncing

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -617,6 +617,7 @@ func (s *BucketStore) Close() (err error) {
 // SyncBlocks synchronizes the stores state with the Bucket bucket.
 // It will reuse disk space as persistent cache based on s.dir param.
 func (s *BucketStore) SyncBlocks(ctx context.Context) error {
+	level.Info(s.logger).Log("msg", "started to sync blocks")
 	metas, _, metaFetchErr := s.fetcher.Fetch(ctx)
 	// For partial view allow adding new blocks at least.
 	if metaFetchErr != nil && metas == nil {


### PR DESCRIPTION
The Store Gateway is quite quiet during startup. Add more logs for better visibility.
