### PR TITLE
[PLAT-103822] support downsampler only mode

### DIFF
--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -591,6 +591,8 @@ func (f *BaseFetcher) fetch(ctx context.Context, metrics *FetcherMetrics, filter
 		if tenant, ok := m.Thanos.Labels[metadata.TenantLabel]; ok {
 			numBlocksByTenant[tenant]++
 		} else {
+			level.Error(f.logger).Log("msg", "found blocks without label "+metadata.TenantLabel,
+				"block", m.String(), "level", m.Compaction.Level, "labels", m.Thanos.GetLabels())
 			numBlocksByTenant[metadata.DefaultTenant]++
 		}
 	}
@@ -618,6 +620,8 @@ func (f *BaseFetcher) fetch(ctx context.Context, metrics *FetcherMetrics, filter
 			var ok bool
 			// tenant and replica will have the zero value ("") if the key is not in the map.
 			if tenant, ok = m.Thanos.Labels[metadata.TenantLabel]; !ok {
+				level.Error(f.logger).Log("msg", "found blocks without label "+metadata.TenantLabel,
+					"block", m.String(), "level", m.Compaction.Level, "labels", m.Thanos.GetLabels())
 				tenant = metadata.DefaultTenant
 			}
 			metrics.Assigned.WithLabelValues(tenant, strconv.Itoa(m.BlockMeta.Compaction.Level)).Inc()

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -9,6 +9,7 @@ package metadata
 // this package.
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -57,8 +58,7 @@ const (
 const (
 	TenantLabel = "__tenant__"
 
-	ObsoletedTenantLabel = "tenant_id"
-	DefaultTenant        = "__not_set__"
+	DefaultTenant = "__not_set__"
 )
 
 // Meta describes the a block's meta. It wraps the known TSDB meta structure and
@@ -113,6 +113,14 @@ type IndexStats struct {
 
 func (m *Thanos) ParseExtensions(v any) (any, error) {
 	return ConvertExtensions(m.Extensions, v)
+}
+
+func (m *Thanos) GetLabels() string {
+	b := new(bytes.Buffer)
+	for k, v := range m.Labels {
+		fmt.Fprintf(b, "%s=%s,", k, v)
+	}
+	return b.String()
 }
 
 // ConvertExtensions converts extensions with `any` type into specific type `v`

--- a/pkg/block/metadata/meta_test.go
+++ b/pkg/block/metadata/meta_test.go
@@ -341,6 +341,15 @@ func TestMeta_ReadWrite(t *testing.T) {
 	})
 }
 
+func TestMeta_GetLabels(t *testing.T) {
+	m := Meta{
+		Thanos: Thanos{
+			Labels: map[string]string{"a": "b", "c": "d"},
+		},
+	}
+	testutil.Equals(t, "a=b,c=d,", m.Thanos.GetLabels())
+}
+
 type TestExtensions struct {
 	Field1 int    `json:"field1"`
 	Field2 string `json:"field2"`


### PR DESCRIPTION
Also removed oneoff deleting obsolete blocks without `__tenant__` labels since the blocks was cleaned up confirmed with obsoleted blocks count metrics.

Filter out overlap labels from receiver to avoid invalid deletion.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
