### PR TITLE
flush thanos receive retry peer state once no connection issue

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -800,26 +800,26 @@ func (h *Handler) fanoutForward(pctx context.Context, tenant string, wreqs map[e
 			})
 			if err != nil {
 				// Check if peer connection is unavailable, don't attempt to send requests constantly.
-				if st, ok := status.FromError(err); ok {
-					if st.Code() == codes.Unavailable {
-						h.mtx.Lock()
-						if b, ok := h.peerStates[writeTarget.endpoint]; ok {
-							b.attempt++
-							dur := h.expBackoff.ForAttempt(b.attempt)
-							b.nextAllowed = time.Now().Add(dur)
-							level.Debug(tLogger).Log("msg", "target unavailable backing off", "for", dur)
-						} else {
-							h.peerStates[writeTarget.endpoint] = &retryState{nextAllowed: time.Now().Add(h.expBackoff.ForAttempt(0))}
-						}
-						h.mtx.Unlock()
-						// For other error codes, we want to flush out the endpoint since it means connection is working.
-					} else {
-						h.mtx.Lock()
-						delete(h.peerStates, writeTarget.endpoint)
-						level.Info(tLogger).Log("msg", "flushing retry endpoint", "endpoint", writeTarget.endpoint)
-						h.mtx.Unlock()
-					}
-				}
+				//if st, ok := status.FromError(err); ok {
+				//	if st.Code() == codes.Unavailable {
+				//		h.mtx.Lock()
+				//		if b, ok := h.peerStates[writeTarget.endpoint]; ok {
+				//			b.attempt++
+				//			dur := h.expBackoff.ForAttempt(b.attempt)
+				//			b.nextAllowed = time.Now().Add(dur)
+				//			level.Debug(tLogger).Log("msg", "target unavailable backing off", "for", dur)
+				//		} else {
+				//			h.peerStates[writeTarget.endpoint] = &retryState{nextAllowed: time.Now().Add(h.expBackoff.ForAttempt(0))}
+				//		}
+				//		h.mtx.Unlock()
+				//	} else {
+				//		// For other error codes, we want to flush out the endpoint since it means connection is working.
+				//		h.mtx.Lock()
+				//		delete(h.peerStates, writeTarget.endpoint)
+				//		level.Info(tLogger).Log("msg", "flushing retry endpoint", "endpoint", writeTarget.endpoint)
+				//		h.mtx.Unlock()
+				//	}
+				//}
 				werr := errors.Wrapf(err, "forwarding request to endpoint %v", writeTarget.endpoint)
 				responses <- newWriteResponse(wreqs[writeTarget].seriesIDs, werr)
 				return


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
<!-- Enumerate changes you made -->
Currently, the thanos receive retry peerstates only flush when the write requests succeed.
However, there are a lot of 409 client side errors currently happening in thanos receive, but it means the server is still healthy. We should also flush the retry peerstate for those client errors since at least server is healthy.
The previous state will cause the server peerstate is not updated in time if there are a lot of client errors, since it will not be flushed.
## Verification

<!-- How you tested it? How do you know it works? -->
Pending deploy in nvirignia-dev
