### PR TITLE
fix: capturing wrong references to loop variables from a goroutine

### DIFF
--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -612,6 +612,7 @@ func (e *EndpointSet) GetEndpointStatus() []EndpointStatus {
 
 	statuses := make([]EndpointStatus, 0, len(e.endpoints))
 	for _, v := range e.endpoints {
+		v := v
 		v.mtx.RLock()
 		defer v.mtx.RUnlock()
 

--- a/pkg/rules/manager.go
+++ b/pkg/rules/manager.go
@@ -159,6 +159,7 @@ func NewManager(
 // Run is non blocking, in opposite to TSDB manager, which is blocking.
 func (m *Manager) Run() {
 	for _, mgr := range m.mgrs {
+		mgr := mgr
 		go mgr.Run()
 	}
 }


### PR DESCRIPTION
## Changes

In file: manager.go, there is a function Run which has a goroutine running inside a loop while using the iteration variable of the enclosing loop. This may lead to a scenario in which the inner function may observe the wrong value of the iteration variable coming from a different iteration and may lead to a race condition. This scenario is likely to happen with go version 1.21 and prior to that.

##### Fix
according to [documentation](https://go.dev/doc/faq#closures_and_goroutines) one of the fix
> is just to create a new variable, using a declaration style

```go
for _, mgr := range m.mgrs {
	mgr := mgr
 	go mgr.Run()
}
```
from [go.mod](https://github.com/databricks/thanos/blob/db_main/go.mod) file
```
module github.com/thanos-io/thanos

go 1.21
```

so, this type of race condition problem is likely to happen with this go version.

same type of fix was suggested for [endpointset.go](pkg/query/endpointset.go) file as well.

##### Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
