### PR TITLE
[PLAT-104290] auto detect/remove overlapping blocks to be compacted to avoid compactor panics

### DIFF
--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -9,12 +9,13 @@ package metadata
 // this package.
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
@@ -124,11 +125,12 @@ func (m *Thanos) GetTenant() string {
 }
 
 func (m *Thanos) GetLabels() string {
-	b := new(bytes.Buffer)
+	res := make([]string, 0, len(m.Labels))
 	for k, v := range m.Labels {
-		fmt.Fprintf(b, "%s=%s,", k, v)
+		res = append(res, fmt.Sprintf("%s=%s", k, v))
 	}
-	return b.String()
+	sort.Strings(res)
+	return strings.Join(res, ",")
 }
 
 // ConvertExtensions converts extensions with `any` type into specific type `v`

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -115,6 +115,14 @@ func (m *Thanos) ParseExtensions(v any) (any, error) {
 	return ConvertExtensions(m.Extensions, v)
 }
 
+func (m *Thanos) GetTenant() string {
+	if tenant, ok := m.Labels[TenantLabel]; ok {
+		return tenant
+	} else {
+		return DefaultTenant
+	}
+}
+
 func (m *Thanos) GetLabels() string {
 	b := new(bytes.Buffer)
 	for k, v := range m.Labels {

--- a/pkg/block/metadata/meta_test.go
+++ b/pkg/block/metadata/meta_test.go
@@ -347,7 +347,7 @@ func TestMeta_GetLabels(t *testing.T) {
 			Labels: map[string]string{"a": "b", "c": "d"},
 		},
 	}
-	testutil.Equals(t, "a=b,c=d,", m.Thanos.GetLabels())
+	testutil.Equals(t, "a=b,c=d", m.Thanos.GetLabels())
 }
 
 type TestExtensions struct {

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -236,7 +236,6 @@ type DefaultGrouper struct {
 	compactionRunsCompleted       *prometheus.CounterVec
 	compactionFailures            *prometheus.CounterVec
 	verticalCompactions           *prometheus.CounterVec
-	overlappingBlocks             *prometheus.CounterVec
 	garbageCollectedBlocks        prometheus.Counter
 	blocksMarkedForDeletion       prometheus.Counter
 	blocksMarkedForNoCompact      prometheus.Counter
@@ -284,10 +283,6 @@ func NewDefaultGrouper(
 			Name: "thanos_compact_group_vertical_compactions_total",
 			Help: "Total number of group compaction attempts that resulted in a new block based on overlapping blocks.",
 		}, []string{"resolution"}),
-		overlappingBlocks: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "thanos_compact_group_overlapping_blocks_total",
-			Help: "Total number of blocks that are overlapping and to be deleted.",
-		}, []string{"resolution", "tenant"}),
 		blocksMarkedForNoCompact:      blocksMarkedForNoCompact,
 		garbageCollectedBlocks:        garbageCollectedBlocks,
 		blocksMarkedForDeletion:       blocksMarkedForDeletion,
@@ -308,7 +303,6 @@ func NewDefaultGrouperWithMetrics(
 	compactionRunsCompleted *prometheus.CounterVec,
 	compactionFailures *prometheus.CounterVec,
 	verticalCompactions *prometheus.CounterVec,
-	overrlappingBlocks *prometheus.CounterVec,
 	blocksMarkedForDeletion prometheus.Counter,
 	garbageCollectedBlocks prometheus.Counter,
 	blocksMarkedForNoCompact prometheus.Counter,
@@ -326,7 +320,6 @@ func NewDefaultGrouperWithMetrics(
 		compactionRunsCompleted:       compactionRunsCompleted,
 		compactionFailures:            compactionFailures,
 		verticalCompactions:           verticalCompactions,
-		overlappingBlocks:             overrlappingBlocks,
 		blocksMarkedForNoCompact:      blocksMarkedForNoCompact,
 		garbageCollectedBlocks:        garbageCollectedBlocks,
 		blocksMarkedForDeletion:       blocksMarkedForDeletion,
@@ -359,7 +352,6 @@ func (g *DefaultGrouper) Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*Gro
 				g.compactionRunsCompleted.WithLabelValues(resolutionLabel),
 				g.compactionFailures.WithLabelValues(resolutionLabel),
 				g.verticalCompactions.WithLabelValues(resolutionLabel),
-				g.overlappingBlocks.WithLabelValues(resolutionLabel, m.Thanos.GetLabels()),
 				g.garbageCollectedBlocks,
 				g.blocksMarkedForDeletion,
 				g.blocksMarkedForNoCompact,
@@ -400,7 +392,6 @@ type Group struct {
 	compactionRunsCompleted       prometheus.Counter
 	compactionFailures            prometheus.Counter
 	verticalCompactions           prometheus.Counter
-	overlappingBlocks             prometheus.Counter
 	groupGarbageCollectedBlocks   prometheus.Counter
 	blocksMarkedForDeletion       prometheus.Counter
 	blocksMarkedForNoCompact      prometheus.Counter
@@ -424,7 +415,6 @@ func NewGroup(
 	compactionRunsCompleted prometheus.Counter,
 	compactionFailures prometheus.Counter,
 	verticalCompactions prometheus.Counter,
-	overlappingBlocks prometheus.Counter,
 	groupGarbageCollectedBlocks prometheus.Counter,
 	blocksMarkedForDeletion prometheus.Counter,
 	blocksMarkedForNoCompact prometheus.Counter,
@@ -453,7 +443,6 @@ func NewGroup(
 		compactionRunsCompleted:       compactionRunsCompleted,
 		compactionFailures:            compactionFailures,
 		verticalCompactions:           verticalCompactions,
-		overlappingBlocks:             overlappingBlocks,
 		groupGarbageCollectedBlocks:   groupGarbageCollectedBlocks,
 		blocksMarkedForDeletion:       blocksMarkedForDeletion,
 		blocksMarkedForNoCompact:      blocksMarkedForNoCompact,

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1357,7 +1357,7 @@ func NewBucketCompactor(
 		planner,
 		comp,
 		DefaultBlockDeletableChecker{},
-		NewOverlappingCompactionLifecycleCallback(),
+		DefaultCompactionLifecycleCallback{},
 		compactDir,
 		bkt,
 		concurrency,

--- a/pkg/compact/overlapping.go
+++ b/pkg/compact/overlapping.go
@@ -1,0 +1,92 @@
+package compact
+
+import (
+	"context"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"os"
+	"path/filepath"
+)
+
+type OverlappingCompactionLifecycleCallback struct {
+	overlappingBlocks prometheus.Counter
+	metaDir           string
+}
+
+func NewOverlappingCompactionLifecycleCallback() *OverlappingCompactionLifecycleCallback {
+	return &OverlappingCompactionLifecycleCallback{}
+}
+
+// PreCompactionCallback given the assumption that toCompact is sorted by MinTime in ascending order from Planner
+// (not guaranteed on MaxTime order), we will detect overlapping blocks and delete them while retaining all others.
+func (c *OverlappingCompactionLifecycleCallback) PreCompactionCallback(ctx context.Context, logger log.Logger, cg *Group, toCompact []*metadata.Meta) error {
+	if len(toCompact) == 0 {
+		return nil
+	}
+	previous := 0
+	for i, m := range toCompact {
+		kept := toCompact[previous]
+		if previous == 0 || m.Thanos.Source == metadata.ReceiveSource || kept.MaxTime <= m.MinTime {
+			// no  overlapping with previous blocks, skip it
+			previous = i
+			continue
+		} else if m.MinTime < kept.MinTime {
+			// halt when the assumption is broken, need manual investigation
+			return halt(errors.Errorf("later blocks has smaller minTime than previous block: %s -- %s", kept.String(), m.String()))
+		}
+		if kept.MaxTime >= m.MaxTime {
+			level.Warn(logger).Log("msg", "found overlapping block in plan",
+				"toKeep", kept.String(), "toDelete", m.String())
+			cg.overlappingBlocks.Inc()
+			if err := DeleteBlockNow(ctx, logger, cg.bkt, m, c.metaDir); err != nil {
+				return retry(err)
+			}
+			toCompact[i] = nil
+		} else {
+			err := errors.Errorf("found partially overlapping block: %s -- %s", kept.String(), m.String())
+			if cg.enableVerticalCompaction {
+				level.Error(logger).Log("msg", "best effort to vertical compact", "err", err)
+				previous = i // move to next block
+			} else {
+				return halt(err)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *OverlappingCompactionLifecycleCallback) PostCompactionCallback(_ context.Context, _ log.Logger, _ *Group, _ ulid.ULID) error {
+	return nil
+}
+
+func (c *OverlappingCompactionLifecycleCallback) GetBlockPopulator(_ context.Context, _ log.Logger, _ *Group) (tsdb.BlockPopulator, error) {
+	return tsdb.DefaultBlockPopulator{}, nil
+}
+
+func FilterNilBlocks(blocks []*metadata.Meta) (res []*metadata.Meta) {
+	for _, b := range blocks {
+		if b != nil {
+			res = append(res, b)
+		}
+	}
+	return res
+}
+
+func DeleteBlockNow(ctx context.Context, logger log.Logger, bkt objstore.Bucket, m *metadata.Meta, dir string) error {
+	level.Warn(logger).Log("msg", "delete polluted block immediately", "block", m.String(),
+		"level", m.Compaction.Level, "source", m.Thanos.Source, "labels", m.Thanos.GetLabels())
+	if err := block.Delete(ctx, logger, bkt, m.ULID); err != nil {
+		return errors.Wrapf(err, "delete overlapping block %s", m.String())
+	}
+	if err := os.RemoveAll(filepath.Join(dir, m.ULID.String())); err != nil {
+		return errors.Wrapf(err, "remove old block dir %s", m.String())
+	}
+	return nil
+}

--- a/pkg/compact/overlapping_test.go
+++ b/pkg/compact/overlapping_test.go
@@ -1,13 +1,179 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package compact
 
 import (
-	"github.com/efficientgo/core/testutil"
-	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"context"
 	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/compact/downsample"
 )
 
 func TestFilterNilCompact(t *testing.T) {
 	blocks := []*metadata.Meta{nil, nil}
-	filtered := FilterNilBlocks(blocks)
+	filtered := FilterRemovedBlocks(blocks)
 	testutil.Equals(t, 0, len(filtered))
+
+	meta := []*metadata.Meta{
+		createBlockMeta(6, 1, int64(time.Now().Add(-6*30*24*time.Hour).Unix()*1000), map[string]string{"a": "1"}, downsample.ResLevel0, []uint64{}),
+		nil,
+		createBlockMeta(7, 1, int64(time.Now().Add(-4*30*24*time.Hour).Unix()*1000), map[string]string{"b": "2"}, downsample.ResLevel1, []uint64{}),
+		createBlockMeta(8, 1, int64(time.Now().Add(-7*30*24*time.Hour).Unix()*1000), map[string]string{"a": "1", "b": "2"}, downsample.ResLevel2, []uint64{}),
+		nil,
+	}
+	testutil.Equals(t, 3, len(FilterRemovedBlocks(meta)))
+}
+
+func TestPreCompactionCallback(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	logger := log.NewNopLogger()
+	bkt := objstore.NewInMemBucket()
+	temp := promauto.With(reg).NewCounter(prometheus.CounterOpts{Name: "test_metric_for_group", Help: "this is a test metric for overlapping blocks"})
+	group := &Group{
+		logger:            log.NewNopLogger(),
+		bkt:               bkt,
+		overlappingBlocks: temp,
+	}
+	labels := map[string]string{"a": "1"}
+	callback := NewOverlappingCompactionLifecycleCallback()
+	for _, tcase := range []struct {
+		testName                 string
+		input                    []*metadata.Meta
+		enableVerticalCompaction bool
+		expectedSize             int
+		expectedBlocks           []*metadata.Meta
+		err                      error
+	}{
+		{
+			testName: "empty blocks",
+		},
+		{
+			testName: "no overlapping blocks",
+			input: []*metadata.Meta{
+				createBlockMeta(6, 1, 3, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(7, 3, 5, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(8, 5, 10, labels, downsample.ResLevel0, []uint64{}),
+			},
+			expectedSize: 3,
+		},
+		{
+			testName: "duplicated blocks",
+			input: []*metadata.Meta{
+				createBlockMeta(6, 1, 7, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(7, 1, 7, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(8, 1, 7, labels, downsample.ResLevel0, []uint64{}),
+			},
+			expectedSize: 3,
+		},
+		{
+			testName: "receive blocks",
+			input: []*metadata.Meta{
+				createReceiveBlockMeta(6, 1, 7, labels),
+				createReceiveBlockMeta(7, 1, 7, labels),
+				createReceiveBlockMeta(8, 1, 7, labels),
+			},
+			expectedSize: 3,
+		},
+		{
+			testName: "receive + compactor blocks",
+			input: []*metadata.Meta{
+				createReceiveBlockMeta(6, 1, 7, labels),
+				createBlockMeta(7, 2, 7, labels, downsample.ResLevel0, []uint64{}),
+				createReceiveBlockMeta(8, 2, 8, labels),
+			},
+			expectedSize: 2,
+			expectedBlocks: []*metadata.Meta{
+				createReceiveBlockMeta(6, 1, 7, labels),
+				createReceiveBlockMeta(8, 2, 8, labels),
+			},
+		},
+		{
+			testName: "full overlapping blocks",
+			input: []*metadata.Meta{
+				createBlockMeta(6, 1, 10, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(7, 3, 6, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(8, 5, 8, labels, downsample.ResLevel0, []uint64{}),
+			},
+			expectedSize: 1,
+			expectedBlocks: []*metadata.Meta{
+				createBlockMeta(6, 1, 10, labels, downsample.ResLevel0, []uint64{}),
+			},
+		},
+		{
+			testName: "part overlapping blocks",
+			input: []*metadata.Meta{
+				createBlockMeta(1, 1, 2, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(2, 1, 6, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(3, 6, 8, labels, downsample.ResLevel0, []uint64{}),
+			},
+			expectedSize: 2,
+			expectedBlocks: []*metadata.Meta{
+				createBlockMeta(2, 1, 6, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(3, 6, 8, labels, downsample.ResLevel0, []uint64{}),
+			},
+		},
+		{
+			testName: "out of order blocks",
+			input: []*metadata.Meta{
+				createBlockMeta(6, 2, 3, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(7, 0, 5, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(8, 5, 8, labels, downsample.ResLevel0, []uint64{}),
+			},
+			err: halt(errors.Errorf("expect halt error")),
+		},
+		{
+			testName: "partially overlapping blocks with vertical compaction off",
+			input: []*metadata.Meta{
+				createBlockMeta(6, 2, 4, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(7, 3, 5, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(8, 5, 8, labels, downsample.ResLevel0, []uint64{}),
+			},
+			err: halt(errors.Errorf("expect halt error")),
+		},
+		{
+			testName: "partially overlapping blocks with vertical compaction on",
+			input: []*metadata.Meta{
+				createBlockMeta(6, 2, 4, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(7, 3, 6, labels, downsample.ResLevel0, []uint64{}),
+				createBlockMeta(8, 5, 8, labels, downsample.ResLevel0, []uint64{}),
+			},
+			enableVerticalCompaction: true,
+			expectedSize:             3,
+		},
+	} {
+		if ok := t.Run(tcase.testName, func(t *testing.T) {
+			group.enableVerticalCompaction = tcase.enableVerticalCompaction
+			err := callback.PreCompactionCallback(context.Background(), logger, group, tcase.input)
+			if tcase.err != nil {
+				testutil.NotOk(t, err)
+				if IsHaltError(tcase.err) {
+					testutil.Assert(t, IsHaltError(err), "expected halt error")
+				} else if IsRetryError(tcase.err) {
+					testutil.Assert(t, IsRetryError(err), "expected retry error")
+				}
+				return
+			}
+			testutil.Equals(t, tcase.expectedSize, len(FilterRemovedBlocks(tcase.input)))
+			if tcase.expectedSize != len(tcase.input) {
+				testutil.Equals(t, tcase.expectedBlocks, FilterRemovedBlocks(tcase.input))
+			}
+		}); !ok {
+			return
+		}
+	}
+}
+
+func createReceiveBlockMeta(id uint64, minTime, maxTime int64, labels map[string]string) *metadata.Meta {
+	m := createBlockMeta(id, minTime, maxTime, labels, downsample.ResLevel0, []uint64{})
+	m.Thanos.Source = metadata.ReceiveSource
+	return m
 }

--- a/pkg/compact/overlapping_test.go
+++ b/pkg/compact/overlapping_test.go
@@ -1,0 +1,13 @@
+package compact
+
+import (
+	"github.com/efficientgo/core/testutil"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"testing"
+)
+
+func TestFilterNilCompact(t *testing.T) {
+	blocks := []*metadata.Meta{nil, nil}
+	filtered := FilterNilBlocks(blocks)
+	testutil.Equals(t, 0, len(filtered))
+}


### PR DESCRIPTION
Adding a flag  `enableOverlappingRemoval` to control this.

This will replace the `DefaultCompactionLifecycleCallback` as a new callback.

This handles overlapping blocks before actually doing the compaction which could potentially causing halting or panic like https://github.com/thanos-io/thanos/issues/6775

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

Deployed to dev, no panics, and overlapped blocks got deleted:

<img width="1112" alt="Screenshot 2024-03-21 at 5 45 46 PM" src="https://github.com/databricks/thanos/assets/96499497/2aaff1bf-f3ac-4912-aa9b-dddfa6e3907a">

<img width="1086" alt="Screenshot 2024-03-21 at 5 45 59 PM" src="https://github.com/databricks/thanos/assets/96499497/70071733-0270-4836-90fe-7f04870d72da">

