### PR TITLE
[PLAT-104290] mark no compaction if blocks are partially overlapping

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1115,7 +1115,6 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 	if err := compactionLifecycleCallback.PreCompactionCallback(ctx, cg.logger, cg, toCompact); err != nil {
 		return false, ulid.ULID{}, errors.Wrapf(err, "failed to run pre compaction callback for plan: %s", fmt.Sprintf("%v", toCompact))
 	}
-	toCompact = FilterRemovedBlocks(toCompact)
 	level.Info(cg.logger).Log("msg", "finished running pre compaction callback; downloading blocks", "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds(), "plan", fmt.Sprintf("%v", toCompact))
 
 	begin = time.Now()

--- a/pkg/compact/downsample/streamed_block_writer.go
+++ b/pkg/compact/downsample/streamed_block_writer.go
@@ -113,7 +113,7 @@ func (w *streamedBlockWriter) WriteSeries(lset labels.Labels, chunks []chunks.Me
 	}
 
 	if len(chunks) == 0 {
-		level.Warn(w.logger).Log("msg", "empty chunks happened, skip series", "series", strings.ReplaceAll(lset.String(), "\"", "'"))
+		level.Debug(w.logger).Log("msg", "empty chunks happened, skip series", "series", strings.ReplaceAll(lset.String(), "\"", "'"))
 		return nil
 	}
 

--- a/pkg/compact/overlapping_test.go
+++ b/pkg/compact/overlapping_test.go
@@ -5,6 +5,8 @@ package compact
 
 import (
 	"context"
+	"fmt"
+	"path"
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
@@ -16,36 +18,15 @@ import (
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
 )
 
-func TestFilterNilCompact(t *testing.T) {
-	blocks := []*metadata.Meta{nil, nil}
-	filtered := FilterRemovedBlocks(blocks)
-	testutil.Equals(t, 0, len(filtered))
-
-	meta := []*metadata.Meta{
-		createCustomBlockMeta(6, 1, 3, metadata.CompactorSource, 1),
-		nil,
-		createCustomBlockMeta(7, 3, 5, metadata.CompactorSource, 2),
-		createCustomBlockMeta(8, 5, 10, metadata.CompactorSource, 3),
-		nil,
-	}
-	testutil.Equals(t, 3, len(FilterRemovedBlocks(meta)))
-}
-
 func TestPreCompactionCallback(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	logger := log.NewNopLogger()
-	bkt := objstore.NewInMemBucket()
-	group := &Group{
-		logger: log.NewNopLogger(),
-		bkt:    bkt,
-	}
 	callback := NewOverlappingCompactionLifecycleCallback(reg, true)
 	for _, tcase := range []struct {
-		testName       string
-		input          []*metadata.Meta
-		expectedSize   int
-		expectedBlocks []*metadata.Meta
-		err            error
+		testName      string
+		input         []*metadata.Meta
+		expectedMarks map[int]int
+		expectedErr   error
 	}{
 		{
 			testName: "empty blocks",
@@ -57,7 +38,6 @@ func TestPreCompactionCallback(t *testing.T) {
 				createCustomBlockMeta(7, 3, 5, metadata.CompactorSource, 1),
 				createCustomBlockMeta(8, 5, 10, metadata.CompactorSource, 1),
 			},
-			expectedSize: 3,
 		},
 		{
 			testName: "duplicated blocks",
@@ -66,10 +46,7 @@ func TestPreCompactionCallback(t *testing.T) {
 				createCustomBlockMeta(7, 1, 7, metadata.CompactorSource, 1),
 				createCustomBlockMeta(8, 1, 7, metadata.CompactorSource, 1),
 			},
-			expectedSize: 1,
-			expectedBlocks: []*metadata.Meta{
-				createCustomBlockMeta(6, 1, 7, metadata.CompactorSource, 1),
-			},
+			expectedMarks: map[int]int{7: 2, 8: 2},
 		},
 		{
 			testName: "overlap non dup blocks",
@@ -78,11 +55,7 @@ func TestPreCompactionCallback(t *testing.T) {
 				createCustomBlockMeta(7, 1, 7, metadata.CompactorSource, 2),
 				createCustomBlockMeta(8, 1, 7, metadata.CompactorSource, 2),
 			},
-			expectedSize: 2,
-			expectedBlocks: []*metadata.Meta{
-				createCustomBlockMeta(6, 1, 7, metadata.CompactorSource, 1),
-				createCustomBlockMeta(7, 1, 7, metadata.CompactorSource, 2),
-			},
+			expectedMarks: map[int]int{8: 2},
 		},
 		{
 			testName: "receive blocks",
@@ -91,7 +64,6 @@ func TestPreCompactionCallback(t *testing.T) {
 				createCustomBlockMeta(7, 1, 7, metadata.ReceiveSource, 2),
 				createCustomBlockMeta(8, 1, 7, metadata.ReceiveSource, 3),
 			},
-			expectedSize: 3,
 		},
 		{
 			testName: "receive + compactor blocks",
@@ -100,11 +72,7 @@ func TestPreCompactionCallback(t *testing.T) {
 				createCustomBlockMeta(7, 2, 7, metadata.CompactorSource, 1),
 				createCustomBlockMeta(8, 2, 8, metadata.ReceiveSource, 1),
 			},
-			expectedSize: 2,
-			expectedBlocks: []*metadata.Meta{
-				createCustomBlockMeta(6, 1, 7, metadata.ReceiveSource, 1),
-				createCustomBlockMeta(8, 2, 8, metadata.ReceiveSource, 1),
-			},
+			expectedMarks: map[int]int{7: 2},
 		},
 		{
 			testName: "full overlapping blocks",
@@ -113,10 +81,7 @@ func TestPreCompactionCallback(t *testing.T) {
 				createCustomBlockMeta(7, 3, 6, metadata.CompactorSource, 1),
 				createCustomBlockMeta(8, 5, 8, metadata.CompactorSource, 1),
 			},
-			expectedSize: 1,
-			expectedBlocks: []*metadata.Meta{
-				createCustomBlockMeta(6, 1, 10, metadata.CompactorSource, 1),
-			},
+			expectedMarks: map[int]int{7: 2, 8: 2},
 		},
 		{
 			testName: "part overlapping blocks",
@@ -125,11 +90,7 @@ func TestPreCompactionCallback(t *testing.T) {
 				createCustomBlockMeta(2, 1, 6, metadata.CompactorSource, 1),
 				createCustomBlockMeta(3, 6, 8, metadata.CompactorSource, 1),
 			},
-			expectedSize: 2,
-			expectedBlocks: []*metadata.Meta{
-				createCustomBlockMeta(2, 1, 6, metadata.CompactorSource, 1),
-				createCustomBlockMeta(3, 6, 8, metadata.CompactorSource, 1),
-			},
+			expectedMarks: map[int]int{1: 2},
 		},
 		{
 			testName: "out of order blocks",
@@ -138,10 +99,7 @@ func TestPreCompactionCallback(t *testing.T) {
 				createCustomBlockMeta(7, 0, 5, metadata.CompactorSource, 1),
 				createCustomBlockMeta(8, 5, 8, metadata.CompactorSource, 1),
 			},
-			err: halt(errors.Errorf("later blocks has smaller minTime than previous block: %s -- %s",
-				createCustomBlockMeta(6, 2, 3, metadata.CompactorSource, 1).String(),
-				createCustomBlockMeta(7, 0, 5, metadata.CompactorSource, 1).String(),
-			)),
+			expectedErr: halt(errors.Errorf("some errors")),
 		},
 		{
 			testName: "partially overlapping blocks",
@@ -150,23 +108,33 @@ func TestPreCompactionCallback(t *testing.T) {
 				createCustomBlockMeta(7, 3, 6, metadata.CompactorSource, 1),
 				createCustomBlockMeta(8, 5, 8, metadata.CompactorSource, 1),
 			},
-			err: retry(errors.Errorf("found partially overlapping block: %s -- %s",
-				createCustomBlockMeta(6, 2, 4, metadata.CompactorSource, 1).String(),
-				createCustomBlockMeta(7, 3, 6, metadata.CompactorSource, 1).String(),
-			)),
+			expectedMarks: map[int]int{6: 1, 7: 1},
 		},
 	} {
 		if ok := t.Run(tcase.testName, func(t *testing.T) {
-			err := callback.PreCompactionCallback(context.Background(), logger, group, tcase.input)
-			if tcase.err != nil {
+			ctx := context.Background()
+			bkt := objstore.NewInMemBucket()
+			group := &Group{logger: log.NewNopLogger(), bkt: bkt}
+			err := callback.PreCompactionCallback(ctx, logger, group, tcase.input)
+			if tcase.expectedErr != nil || len(tcase.expectedMarks) != 0 {
 				testutil.NotOk(t, err)
-				testutil.Equals(t, tcase.err.Error(), err.Error())
-				return
+			} else {
+				testutil.Ok(t, err)
 			}
-			testutil.Equals(t, tcase.expectedSize, len(FilterRemovedBlocks(tcase.input)))
-			if tcase.expectedSize != len(tcase.input) {
-				testutil.Equals(t, tcase.expectedBlocks, FilterRemovedBlocks(tcase.input))
+			objs := bkt.Objects()
+			expectedSize := 0
+			for id, file := range tcase.expectedMarks {
+				expectedSize += file
+				_, noCompaction := objs[getFile(id, metadata.NoCompactMarkFilename)]
+				_, noDownsampling := objs[getFile(id, metadata.NoDownsampleMarkFilename)]
+				if file <= 2 {
+					testutil.Assert(t, noCompaction, fmt.Sprintf("expect %d has no compaction", id))
+				}
+				if file == 2 {
+					testutil.Assert(t, noDownsampling, fmt.Sprintf("expect %d has no downsampling", id))
+				}
 			}
+			testutil.Equals(t, expectedSize, len(objs))
 		}); !ok {
 			return
 		}
@@ -179,4 +147,8 @@ func createCustomBlockMeta(id uint64, minTime, maxTime int64, source metadata.So
 	m.Thanos.Source = source
 	m.Stats.NumSeries = numSeries
 	return m
+}
+
+func getFile(id int, mark string) string {
+	return path.Join(fmt.Sprintf("%010d", id)+fmt.Sprintf("%016d", 0), mark)
 }


### PR DESCRIPTION
Found another situation would cause compactor panics due to partially overlapping blocks, previously we let' it continue doing compaction without any manual intervetion, now we mark both blocks as non compaction so compactor can just skip them. This won't change how data being queries as store will dedup them.

<img width="1718" alt="Screenshot 2024-03-23 at 10 13 02 PM" src="https://github.com/databricks/thanos/assets/96499497/1dcc797e-9e76-4eb6-ad80-bba36b5a3c90">


* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification
Tested in `staging-aws-us-east-1` where the logs below discovered:

```
ts=2024-03-24T05:08:19.619373318Z caller=compact.go:1177 level=info name=pantheon-compactor group="300000@{__tenant__=\"eng-observability-team\"}" groupKey=300000@15266876196417835852 msg="downloaded and verified blocks; compacting blocks" duration=58.907119161s duration_ms=58907 plan="[/var/thanos/data/compact/300000@15266876196417835852/01HSN625Z6PXNB25TPR83KMPJD /var/thanos/data/compact/300000@15266876196417835852/01HRZEESG4GY25FQ1B4HDSABQE]"
ts=2024-03-24T05:09:24.968371993Z caller=compact.go:715 level=info name=pantheon-compactor msg="Found overlapping blocks during compaction" ulid=01HSQDQRC2S0F2AHVWKE58YHS2
ts=2024-03-24T05:09:24.969279578Z caller=compact.go:715 level=info name=pantheon-compactor msg="Found overlapping blocks during compaction" ulid=01HSQDR429FNZY6RWXNTP5K8JD
panic: unexpected seriesToChunkEncoder lack of iterations

goroutine 291 [running]:
github.com/prometheus/prometheus/storage.(*compactChunkIterator).Next(0xc0081dc000)
	/go/pkg/mod/github.com/prometheus/prometheus@v0.48.1-0.20231212213830-d0c2d9c0b9cc/storage/merge.go:778 +0x935
github.com/prometheus/prometheus/tsdb.DefaultBlockPopulator.PopulateBlock({}, {0x3617c50, 0xc000922cc0}, 0xc00003a230, {0x35f8f40, 0xc00058ed70}, {0x36070c0, 0xc00044f7c0}, 0x35e7b38?, {0xc0019e28e0, ...}, ...)
	/go/pkg/mod/github.com/prometheus/prometheus@v0.48.1-0.20231212213830-d0c2d9c0b9cc/tsdb/compact.go:788 +0x1543
github.com/prometheus/prometheus/tsdb.(*LeveledCompactor).write(0xc000932060, {0xc007600140, 0x34}, 0xc000eab810, {0x35f91e0, 0x4a1fe80}, {0xc0019e28e0, 0x2, 0x2})
	/go/pkg/mod/github.com/prometheus/prometheus@v0.48.1-0.20231212213830-d0c2d9c0b9cc/tsdb/compact.go:608 +0x7b3
github.com/prometheus/prometheus/tsdb.(*LeveledCompactor).CompactWithBlockPopulator(0xc000932060, {0xc007600140, 0x34}, {0xc0076080c0, 0x2, 0x4a1fe80?}, {0x0, 0x0, 0xc0015ad1a0?}, {0x35f91e0, ...})
	/go/pkg/mod/github.com/prometheus/prometheus@v0.48.1-0.20231212213830-d0c2d9c0b9cc/tsdb/compact.go:449 +0x6e5
github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func3({0x3617c50, 0xc000924390})
	/thanos/thanos/pkg/compact/compact.go:1185 +0x109
github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr({0x3617c50?, 0xc0076021e0?}, {0x26f3812?, 0x2?}, 0xc0015adaa8, {0x0?, 0xc001ac49a0?, 0x1?})
	/thanos/thanos/pkg/tracing/tracing.go:82 +0xbf
github.com/thanos-io/thanos/pkg/compact.(*Group).compact(0xc0017ee8c0, {0x3617c50, 0xc0076021e0}, {0xc007600140, 0x34}, {0x35f89e0?, 0xc000922ff0}, {0x360d8e8?, 0xc000932060}, {0x35f8a00, ...}, ...)
	/thanos/thanos/pkg/compact/compact.go:1180 +0x1205
github.com/thanos-io/thanos/pkg/compact.(*Group).Compact.func2({0x3617c50, 0xc0076021e0?})
	/thanos/thanos/pkg/compact/compact.go:877 +0x9d
github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr({0x3617c88?, 0xc000998050?}, {0x2700e48?, 0x9?}, 0xc009499e10, {0xc001ac47b0?, 0x7f8cf65a3d28?, 0x60?})
	/thanos/thanos/pkg/tracing/tracing.go:82 +0xbf
github.com/thanos-io/thanos/pkg/compact.(*Group).Compact(0xc0017ee8c0, {0x3617c88, 0xc000998050}, {0xc0007eee40, 0x18}, {0x35f89e0?, 0xc000922ff0}, {0x360d8e8?, 0xc000932060}, {0x35f8a00, ...}, ...)
	/thanos/thanos/pkg/compact/compact.go:876 +0x3cb
github.com/thanos-io/thanos/pkg/compact.(*BucketCompactor).Compact.func2()
	/thanos/thanos/pkg/compact/compact.go:1425 +0x179
created by github.com/thanos-io/thanos/pkg/compact.(*BucketCompactor).Compact in goroutine 258
	/thanos/thanos/p
```
