### PR TITLE
[PLAT-105856] fix grpc retry strategy

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -157,6 +157,9 @@ func runReceive(
 	if conf.compression != compressionNone {
 		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(conf.compression)))
 	}
+	if receiveMode == receive.RouterOnly {
+		dialOpts = append(dialOpts, extgrpc.EndpointGroupGRPCOpts()...)
+	}
 
 	var bkt objstore.Bucket
 	confContentYaml, err := conf.objStoreConfig.Content()

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -829,6 +829,8 @@ func (h *Handler) sendLocalWrite(
 	defer span.Finish()
 	span.SetTag("endpoint", writeDestination.endpoint)
 	span.SetTag("replica", writeDestination.replica)
+	span.SetTag("tenant", tenant)
+	span.SetTag("samples", len(trackedSeries.timeSeries))
 	err := h.writer.Write(tracingCtx, tenant, &prompb.WriteRequest{
 		Timeseries: trackedSeries.timeSeries,
 	})

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
+	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
 // Appendable returns an Appender.
@@ -277,7 +278,8 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 		level.Info(tLogger).Log("msg", "Error on ingesting exemplars with label length exceeding maximum limit", "numDropped", numExemplarsLabelLength)
 		errs.Add(errors.Wrapf(storage.ErrExemplarLabelLength, "add %d exemplars", numExemplarsLabelLength))
 	}
-
+	span, _ := tracing.StartSpan(ctx, "receive_commit")
+	defer span.Finish()
 	if err := app.Commit(); err != nil {
 		errs.Add(errors.Wrap(err, "commit samples"))
 	}


### PR DESCRIPTION
GRPC will do [unlimited retries](https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto) for so-called tranisent errors (500 server unavailable). This is very bad when we rolling update pantheon-db. This pr just fall fast with max 3 backoff retries.

Tested it will have no ingestion API failures (last one), and little affects on memory usage:

<img width="413" alt="Screenshot 2024-04-10 at 9 37 31 PM" src="https://github.com/databricks/thanos/assets/96499497/34fa18e2-ab9a-4f06-bc91-841a0d806da4">

<img width="818" alt="Screenshot 2024-04-10 at 9 37 37 PM" src="https://github.com/databricks/thanos/assets/96499497/24611df4-ba7b-4df3-ad4b-1096f0ec6f51">

<img width="420" alt="Screenshot 2024-04-10 at 9 38 44 PM" src="https://github.com/databricks/thanos/assets/96499497/d7005b4c-3116-4133-80d0-32770af804ec">

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
