### PR TITLE
expose 409 errors for other causes beyond timestamp conflicts

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -1240,11 +1240,6 @@ func (p *peerWorker) RemoteWriteAsync(ctx context.Context, req *storepb.WriteReq
 
 		tracing.DoInSpan(ctx, "receive_forward", func(ctx context.Context) {
 			_, err := storepb.NewWriteableStoreClient(p.cc).RemoteWrite(ctx, req)
-			if isConflict(err) && p.wp.Size() > 1 {
-				// conflict errors are valid in our dual scraping setup, worker pool size > 1 to bypass unit tests
-				// see original PR: https://github.com/databricks/thanos/pull/27
-				err = nil
-			}
 			responseWriter <- newWriteResponse(
 				seriesIDs,
 				errors.Wrapf(err, "forwarding request to endpoint %v", er.endpoint),

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -156,8 +156,8 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 			case storage.ErrDuplicateSampleForTimestamp:
 				// we don't care about duplicated sample for the same timestamp
 				continue
-				// numSamplesDuplicates++
-				// level.Debug(tLogger).Log("msg", "Duplicate sample for timestamp", "lset", lset, "value", s.Value, "timestamp", s.Timestamp)
+				//numSamplesDuplicates++
+				//level.Debug(tLogger).Log("msg", "Duplicate sample for timestamp", "lset", lset, "value", s.Value, "timestamp", s.Timestamp)
 			case storage.ErrOutOfBounds:
 				numSamplesOutOfBounds++
 				level.Debug(tLogger).Log("msg", "Out of bounds metric", "lset", lset, "value", s.Value, "timestamp", s.Timestamp)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
