### PR TITLE
[ES-1122621] fix receive connection re-establish taking too long (5m)

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -158,6 +158,7 @@ func runReceive(
 		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(conf.compression)))
 	}
 	if receiveMode == receive.RouterOnly {
+		dialOpts = append(dialOpts, grpc.WithIdleTimeout(time.Duration(*conf.maxBackoff)))
 		dialOpts = append(dialOpts, extgrpc.EndpointGroupGRPCOpts()...)
 	}
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -26,7 +26,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/alecthomas/units"
-	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/proto"
@@ -44,6 +43,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/resolver"
+
+	"github.com/efficientgo/core/testutil"
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/component"
@@ -1800,6 +1801,7 @@ func TestIngestorRestart(t *testing.T) {
 	}
 	resolver.Register(dnsBuilder)
 	dialOpts := []grpc.DialOption{
+		grpc.WithIdleTimeout(1 * time.Second), // set idle timeout to 1s will re-establish the connection quickly
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithResolvers(resolver.Get(dnsScheme)),
 	}


### PR DESCRIPTION
We've seen some 503 errors when quorum supposed to meet as the ingestor is in running state, however router still can't talk to it, able to reproduce this behavior locally:

<img width="1858" alt="Screenshot 2024-05-10 at 10 33 42 PM" src="https://github.com/databricks/thanos/assets/96499497/8aafa0a5-e40d-4108-aa6f-1ab7a3528ade">

I've introduced a unit test to mock the prod environment:
1. Setup 2 ingestors, 1 with fixed `ip1`, 1 with a DNS and resolve to `ip2`
2. Verify router can write data to 2 ingestors when quorum == 2
3. Shutdown 1 ingestor with `ip2`, and write requests start to fail
4. Spawn another ingestor with `ip3` and bind it to previous DNS which resolved to `ip2` to simulate ingestor restarts
5. OLD behavior without any changes in `handler.go`, the unit test won't succeed after a while
6. NEW behavior in `handler.go`, the unit test will succeed quickly

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

Before the change:
<img width="413" alt="Screenshot 2024-05-13 at 9 45 09 PM" src="https://github.com/databricks/thanos/assets/96499497/4019eb63-1279-49fd-ba2a-8dfea1fa6589">

After the change, reduced rollout operator with 5s delay between sts, still see small 503 but m3 write coordinator retries should help, extend to a bit longer delays like 1m and it should not have any 503:

<img width="415" alt="Screenshot 2024-05-13 at 11 43 39 PM" src="https://github.com/databricks/thanos/assets/96499497/399d8281-308c-41c2-a3ec-3659d4e81b5c">

