### PR TITLE
[PLAT-108920] not skip samples during dedup

### DIFF
--- a/pkg/dedup/iter.go
+++ b/pkg/dedup/iter.go
@@ -277,7 +277,7 @@ type dedupSeriesIterator struct {
 	lastIter chunkenc.Iterator
 
 	penA, penB int64
-	useA       bool
+	useA, useB bool
 }
 
 func newDedupSeriesIterator(a, b adjustableSeriesIterator) *dedupSeriesIterator {
@@ -288,6 +288,7 @@ func newDedupSeriesIterator(a, b adjustableSeriesIterator) *dedupSeriesIterator 
 		lastIter: a,
 		aval:     a.Next(),
 		bval:     b.Next(),
+		useB:     true,
 	}
 }
 
@@ -304,16 +305,17 @@ func (it *dedupSeriesIterator) Next() chunkenc.ValueType {
 	}()
 
 	// Advance both iterators to at least the next highest timestamp plus the potential penalty.
-	if it.aval != chunkenc.ValNone {
+	if it.aval != chunkenc.ValNone && it.useA {
 		it.aval = it.a.Seek(it.lastT + 1 + it.penA)
 	}
-	if it.bval != chunkenc.ValNone {
+	if it.bval != chunkenc.ValNone && it.useB {
 		it.bval = it.b.Seek(it.lastT + 1 + it.penB)
 	}
 
 	// Handle basic cases where one iterator is exhausted before the other.
 	if it.aval == chunkenc.ValNone {
 		it.useA = false
+		it.useB = true
 		if it.bval != chunkenc.ValNone {
 			it.lastT = it.b.AtT()
 			it.lastIter = it.b
@@ -323,6 +325,7 @@ func (it *dedupSeriesIterator) Next() chunkenc.ValueType {
 	}
 	if it.bval == chunkenc.ValNone {
 		it.useA = true
+		it.useB = false
 		it.lastT = it.a.AtT()
 		it.lastIter = it.a
 		it.penA = 0
@@ -336,6 +339,7 @@ func (it *dedupSeriesIterator) Next() chunkenc.ValueType {
 	tb := it.b.AtT()
 
 	it.useA = ta <= tb
+	it.useB = ta >= tb
 
 	// For the series we didn't pick, add a penalty twice as high as the delta of the last two
 	// samples to the next seek against it.

--- a/pkg/dedup/iter_test.go
+++ b/pkg/dedup/iter_test.go
@@ -375,6 +375,27 @@ func TestDedupSeriesSet(t *testing.T) {
 			},
 		},
 		{
+			name: "Multi dedup labels - data points absent",
+			input: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
+					samples: []sample{{1, 1}, {4, 4}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
+					samples: []sample{{1, 1}, {2, 2}, {3, 3}, {5, 5}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
+					samples: []sample{{1, 1}, {8, 10}},
+				},
+			},
+			exp: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
+					samples: []sample{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
+				},
+			},
+		},
+		{
 			name: "Multi dedup label - some series don't have all dedup labels",
 			input: []series{
 				{

--- a/pkg/dedup/iter_test.go
+++ b/pkg/dedup/iter_test.go
@@ -97,6 +97,9 @@ func (s *mockedSeriesIterator) Seek(t int64) chunkenc.ValueType {
 }
 
 func (s *mockedSeriesIterator) At() (t int64, v float64) {
+	if s.cur >= len(s.samples) {
+		return 0, 0
+	}
 	sample := s.samples[s.cur]
 	return sample.t, sample.f
 }
@@ -379,19 +382,19 @@ func TestDedupSeriesSet(t *testing.T) {
 			input: []series{
 				{
 					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
-					samples: []sample{{1, 1}, {4, 4}},
+					samples: []sample{{10000, 1}, {30000, 3}, {40000, 4}},
 				}, {
 					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
-					samples: []sample{{1, 1}, {2, 2}, {3, 3}, {5, 5}},
+					samples: []sample{{10000, 1}, {20000, 2}, {30000, 3}, {50000, 5}},
 				}, {
 					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
-					samples: []sample{{1, 1}, {8, 10}},
+					samples: []sample{{10000, 1}, {80000, 10}},
 				},
 			},
 			exp: []series{
 				{
 					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
-					samples: []sample{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
+					samples: []sample{{10000, 1}, {20000, 2}, {30000, 3}, {40000, 4}, {50000, 5}, {80000, 10}},
 				},
 			},
 		},

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -198,10 +198,6 @@ func newQuerierInternal(
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	rl := make(map[string]struct{})
-	for _, replicaLabel := range replicaLabels {
-		rl[replicaLabel] = struct{}{}
-	}
 
 	partialResponseStrategy := storepb.PartialResponseStrategy_ABORT
 	if groupReplicaPartialResponseStrategy {

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -478,7 +478,7 @@ func TestQuerier_Select(t *testing.T) {
 			expectedAfterDedup: []series{{
 				lset: nil,
 				// We don't expect correctness here, it's just random non-replica data.
-				samples: []sample{{1, 1}, {2, 2}, {3, 3}, {5, 5}, {6, 6}, {7, 7}},
+				samples: []sample{{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}, {7, 7}},
 			}},
 			expectedWarning: "partial error",
 		},

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -590,7 +590,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	opts.EnableOverlappingCompaction = false
 	s, err := tsdb.Open(
 		dataDir,
-		logger,
+		level.NewFilter(logger, level.AllowError()), // warning is too verbose
 		reg,
 		&opts,
 		nil,


### PR DESCRIPTION
**A lot of unit tests broken to be fixed**, but the idea is currently both iters proceed and potentially skip data points in between. Instead, we only scan iterators and move forward if previous value is being used.

For example:
A: 1, 4, 5
B: 1, 2, 3, 4, 5

Before the change: dedup'ed result will be 1, 4, 5

After the change, the result will be 1, 2, 3, 4, 5

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
