### PR TITLE
[PLAT-108920] adding another dedup iterator to merge samples instead of skipping them

### DIFF
--- a/pkg/dedup/iter.go
+++ b/pkg/dedup/iter.go
@@ -11,13 +11,20 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
-
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
+// For the series we didn't pick, add a penalty twice as high as the delta of the last two
+// samples to the next seek against it.
+// This ensures that we don't pick a sample too close, which would increase the overall
+// sample frequency. It also guards against clock drift and inaccuracies during
+// timestamp assignment.
+// If we don't know a delta yet, we pick 5000 as a constant, which is based on the knowledge
+// that timestamps are in milliseconds and sampling frequencies typically multiple seconds long.
+const initialPenalty = 5000
+
 type dedupSeriesSet struct {
-	set       storage.SeriesSet
-	isCounter bool
+	set storage.SeriesSet
 
 	replicas []storage.Series
 
@@ -103,12 +110,12 @@ func (o *overlapSplitSet) Err() error {
 // NewSeriesSet returns seriesSet that deduplicates the same series.
 // The series in series set are expected be sorted by all labels.
 func NewSeriesSet(set storage.SeriesSet, f string) storage.SeriesSet {
-	// TODO: remove dependency on knowing whether it is a counter.
-	s := &dedupSeriesSet{set: set, isCounter: isCounter(f), f: f}
+	s := &dedupSeriesSet{set: set, f: f}
 	s.ok = s.set.Next()
 	if s.ok {
 		s.peek = s.set.At()
 	}
+
 	return s
 }
 
@@ -153,7 +160,10 @@ func (s *dedupSeriesSet) At() storage.Series {
 	// Clients may store the series, so we must make a copy of the slice before advancing.
 	repl := make([]storage.Series, len(s.replicas))
 	copy(repl, s.replicas)
-
+	if s.f == UseMergedSeries {
+		// merge all samples which are ingested via receiver, no skips.
+		return NewMergedSeries(s.lset, repl)
+	}
 	return newDedupSeries(s.lset, repl, s.f)
 }
 
@@ -336,15 +346,6 @@ func (it *dedupSeriesIterator) Next() chunkenc.ValueType {
 	tb := it.b.AtT()
 
 	it.useA = ta <= tb
-
-	// For the series we didn't pick, add a penalty twice as high as the delta of the last two
-	// samples to the next seek against it.
-	// This ensures that we don't pick a sample too close, which would increase the overall
-	// sample frequency. It also guards against clock drift and inaccuracies during
-	// timestamp assignment.
-	// If we don't know a delta yet, we pick 5000 as a constant, which is based on the knowledge
-	// that timestamps are in milliseconds and sampling frequencies typically multiple seconds long.
-	const initialPenalty = 5000
 
 	if it.useA {
 		if it.lastT != math.MinInt64 {

--- a/pkg/dedup/merge_iter.go
+++ b/pkg/dedup/merge_iter.go
@@ -1,0 +1,109 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package dedup
+
+import (
+	"math"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+const UseMergedSeries = "use_merged_series"
+
+// mergedSeries is a storage.Series that implements a simple merge sort algorithm.
+// when replicas has conflict values at the same timestamp, the first replica will be selected.
+type mergedSeries struct {
+	lset     labels.Labels
+	replicas []storage.Series
+}
+
+func NewMergedSeries(lset labels.Labels, replicas []storage.Series) storage.Series {
+	return &mergedSeries{
+		lset:     lset,
+		replicas: replicas,
+	}
+}
+
+func (m *mergedSeries) Labels() labels.Labels {
+	return m.lset
+}
+func (m *mergedSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
+	iters := make([]chunkenc.Iterator, 0, len(m.replicas))
+	oks := make([]bool, 0, len(m.replicas))
+	for _, r := range m.replicas {
+		it := r.Iterator(nil)
+		ok := it.Next() != chunkenc.ValNone // iterate to the first value.
+		iters = append(iters, it)
+		oks = append(oks, ok)
+	}
+	return &mergedSeriesIterator{
+		iters:    iters,
+		oks:      oks,
+		lastT:    math.MinInt64,
+		lastIter: nil, // behavior is undefined if At() is called before Next(), here we panic if it happens.
+	}
+}
+
+type mergedSeriesIterator struct {
+	iters []chunkenc.Iterator
+	oks   []bool
+
+	lastT    int64
+	lastIter chunkenc.Iterator
+}
+
+func (m *mergedSeriesIterator) Next() chunkenc.ValueType {
+	return m.Seek(m.lastT + initialPenalty) // apply penalty to avoid selecting samples too close
+}
+
+func (m *mergedSeriesIterator) Seek(t int64) chunkenc.ValueType {
+	if len(m.iters) == 0 {
+		return chunkenc.ValNone
+	}
+
+	picked := int64(math.MaxInt64)
+	for i, it := range m.iters {
+		if !m.oks[i] {
+			continue
+		}
+		if it == m.lastIter || it.AtT() <= m.lastT {
+			m.oks[i] = it.Seek(t) != chunkenc.ValNone // move forward for last iterator.
+			if !m.oks[i] {
+				continue
+			}
+		}
+		currT := it.AtT()
+		if currT >= t && currT < picked {
+			picked = currT
+			m.lastIter = it
+		}
+	}
+	if picked == math.MaxInt64 {
+		return chunkenc.ValNone
+	}
+	m.lastT = picked
+	return chunkenc.ValFloat
+}
+func (m *mergedSeriesIterator) At() (t int64, v float64) {
+	return m.lastIter.At()
+}
+
+func (it *mergedSeriesIterator) AtHistogram(h *histogram.Histogram) (int64, *histogram.Histogram) {
+	return it.lastIter.AtHistogram(h)
+}
+
+func (it *mergedSeriesIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+	return it.lastIter.AtFloatHistogram(fh)
+}
+
+func (it *mergedSeriesIterator) AtT() int64 {
+	return it.lastT
+}
+
+func (m *mergedSeriesIterator) Err() error {
+	return m.lastIter.Err()
+}

--- a/pkg/dedup/merge_iter_test.go
+++ b/pkg/dedup/merge_iter_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package dedup
+
+import (
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+func TestMergedSeriesIterator(t *testing.T) {
+	for _, tcase := range []struct {
+		name      string
+		input     []series
+		exp       []series
+		isCounter bool
+	}{
+		// copied from dedup_test.go to make sure the result is correct if no overlaps
+		{
+			name: "Single dedup label",
+			input: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{60000, 3}, {70000, 4}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{200000, 5}, {210000, 6}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "2"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "2"}, {Name: "c", Value: "3"}},
+					samples: []sample{{60000, 3}, {70000, 4}},
+				},
+			},
+			exp: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}, {60000, 3}, {70000, 4}, {200000, 5}, {210000, 6}},
+				},
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				},
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				},
+				{
+					lset:    labels.Labels{{Name: "a", Value: "2"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}, {60000, 3}, {70000, 4}},
+				},
+			},
+		},
+		{
+			name: "Multi dedup label",
+			input: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{60000, 3}, {70000, 4}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{200000, 5}, {210000, 6}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "2"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "2"}, {Name: "c", Value: "3"}},
+					samples: []sample{{60000, 3}, {70000, 4}},
+				},
+			},
+			exp: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}, {60000, 3}, {70000, 4}, {200000, 5}, {210000, 6}},
+				},
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				},
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				},
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				},
+				{
+					lset:    labels.Labels{{Name: "a", Value: "2"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}, {60000, 3}, {70000, 4}},
+				},
+			},
+		},
+		{
+			name: "Multi dedup label - some series don't have all dedup labels",
+			input: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{60000, 3}, {70000, 4}},
+				},
+			},
+			exp: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}, {60000, 3}, {70000, 4}},
+				},
+			},
+		},
+		// additional tests
+		{
+			name:  "empty",
+			input: []series{},
+			exp:   []series{},
+		},
+		{
+			name: "Multi dedup labels - data points absent",
+			input: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
+					samples: []sample{{10000, 1}, {30000, 3}, {40000, 4}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
+					samples: []sample{{10000, 1}, {20000, 2}, {30000, 3}, {50000, 5}},
+				}, {
+					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
+					samples: []sample{{10000, 1}, {80000, 10}},
+				},
+			},
+			exp: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
+					samples: []sample{{10000, 1}, {20000, 2}, {30000, 3}, {40000, 4}, {50000, 5}, {80000, 10}},
+				},
+			},
+		},
+		{
+			name: "ignore sampling interval too small",
+			input: []series{
+				{
+					lset: labels.Labels{{Name: "a", Value: "1"}},
+					samples: []sample{
+						{10000, 8.0},
+						{20000, 9.0},
+						{50001, 9 + 1.0},
+						{60000, 9 + 2.0},
+						{70000, 9 + 3.0},
+						{80000, 9 + 4.0},
+						{90000, 9 + 5.0},
+						{100000, 9 + 6.0},
+					},
+				}, {
+					lset: labels.Labels{{Name: "a", Value: "1"}},
+					samples: []sample{
+						{10001, 8.0}, // Penalty 5000 will be added.
+						// 20001 was app reset. No sample, because stale marker but removed by downsample.CounterSeriesIterator. Penalty 2 * (20000 - 10000) will be added.
+						// 30001 no sample. Within penalty, ignored.
+						{45001, 8 + 1.0}, // Smaller timestamp, this will be chosen. CurrValue = 8.5 which is smaller than last chosen value.
+						{55001, 8 + 2.0},
+						{65001, 8 + 3.0},
+						// {Gap} app reset. No sample, because stale marker but removed by downsample.CounterSeriesIterator.
+					},
+				},
+			},
+			exp: []series{
+				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}},
+					samples: []sample{{10000, 8}, {20000, 9}, {45001, 9}, {50001, 10}, {55001, 10}, {65001, 11}, {80000, 13}, {90000, 14}, {100000, 15}},
+				},
+			},
+		},
+	} {
+		t.Run(tcase.name, func(t *testing.T) {
+			// If it is a counter then pass a function which expects a counter.
+			dedupSet := NewSeriesSet(&mockedSeriesSet{series: tcase.input}, UseMergedSeries)
+			var ats []storage.Series
+			for dedupSet.Next() {
+				ats = append(ats, dedupSet.At())
+			}
+			testutil.Ok(t, dedupSet.Err())
+			testutil.Equals(t, len(tcase.exp), len(ats))
+
+			for i, s := range ats {
+				testutil.Equals(t, tcase.exp[i].lset, s.Labels(), "labels mismatch for series %v", i)
+				res := expandSeries(t, s.Iterator(nil))
+				testutil.Equals(t, tcase.exp[i].samples, res, "values mismatch for series :%v", i)
+			}
+		})
+	}
+}

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -66,7 +66,7 @@ func newQueryableCreator(
 	proxy storepb.StoreServer,
 	maxConcurrentSelects int,
 	selectTimeout time.Duration,
-	groupReplicaPartialResponseStrategy bool,
+	opts Options,
 ) QueryableCreator {
 	gf := gate.NewGateFactory(extprom.WrapRegistererWithPrefix("concurrent_selects_", reg), maxConcurrentSelects, gate.Selects)
 
@@ -92,13 +92,18 @@ func newQueryableCreator(
 			gateProviderFn: func() gate.Gate {
 				return gf.New()
 			},
-			maxConcurrentSelects:                maxConcurrentSelects,
-			selectTimeout:                       selectTimeout,
-			shardInfo:                           shardInfo,
-			seriesStatsReporter:                 seriesStatsReporter,
-			groupReplicaPartialResponseStrategy: groupReplicaPartialResponseStrategy,
+			maxConcurrentSelects: maxConcurrentSelects,
+			selectTimeout:        selectTimeout,
+			shardInfo:            shardInfo,
+			seriesStatsReporter:  seriesStatsReporter,
+			opts:                 opts,
 		}
 	}
+}
+
+type Options struct {
+	GroupReplicaPartialResponseStrategy bool
+	EnableDedupMerge                    bool
 }
 
 func NewQueryableCreator(
@@ -108,21 +113,23 @@ func NewQueryableCreator(
 	maxConcurrentSelects int,
 	selectTimeout time.Duration,
 ) QueryableCreator {
-	return newQueryableCreator(
+	return NewQueryableCreatorWithOptions(
 		logger,
 		reg,
 		proxy,
 		maxConcurrentSelects,
 		selectTimeout,
-		false,
+		Options{},
 	)
 }
-func NewQueryableCreatorWithGroupReplicaPartialResponseStrategy(
+
+func NewQueryableCreatorWithOptions(
 	logger log.Logger,
 	reg prometheus.Registerer,
 	proxy storepb.StoreServer,
 	maxConcurrentSelects int,
 	selectTimeout time.Duration,
+	opts Options,
 ) QueryableCreator {
 	return newQueryableCreator(
 		logger,
@@ -130,34 +137,30 @@ func NewQueryableCreatorWithGroupReplicaPartialResponseStrategy(
 		proxy,
 		maxConcurrentSelects,
 		selectTimeout,
-		true,
+		opts,
 	)
 }
 
 type queryable struct {
-	logger                              log.Logger
-	replicaLabels                       []string
-	storeDebugMatchers                  [][]*labels.Matcher
-	proxy                               storepb.StoreServer
-	deduplicate                         bool
-	maxResolutionMillis                 int64
-	partialResponse                     bool
-	skipChunks                          bool
-	gateProviderFn                      func() gate.Gate
-	maxConcurrentSelects                int
-	selectTimeout                       time.Duration
-	shardInfo                           *storepb.ShardInfo
-	seriesStatsReporter                 seriesStatsReporter
-	groupReplicaPartialResponseStrategy bool
+	logger               log.Logger
+	replicaLabels        []string
+	storeDebugMatchers   [][]*labels.Matcher
+	proxy                storepb.StoreServer
+	deduplicate          bool
+	maxResolutionMillis  int64
+	partialResponse      bool
+	skipChunks           bool
+	gateProviderFn       func() gate.Gate
+	maxConcurrentSelects int
+	selectTimeout        time.Duration
+	shardInfo            *storepb.ShardInfo
+	seriesStatsReporter  seriesStatsReporter
+	opts                 Options
 }
 
 // Querier returns a new storage querier against the underlying proxy store API.
 func (q *queryable) Querier(mint, maxt int64) (storage.Querier, error) {
-	if q.groupReplicaPartialResponseStrategy {
-		return newQuerierWithGroupReplicaPartialResponseStrategy(q.logger, mint, maxt, q.replicaLabels, q.storeDebugMatchers, q.proxy, q.deduplicate, q.maxResolutionMillis, q.partialResponse, q.skipChunks, q.gateProviderFn(), q.selectTimeout, q.shardInfo, q.seriesStatsReporter), nil
-	} else {
-		return newQuerier(q.logger, mint, maxt, q.replicaLabels, q.storeDebugMatchers, q.proxy, q.deduplicate, q.maxResolutionMillis, q.partialResponse, q.skipChunks, q.gateProviderFn(), q.selectTimeout, q.shardInfo, q.seriesStatsReporter), nil
-	}
+	return newQuerierWithOpts(q.logger, mint, maxt, q.replicaLabels, q.storeDebugMatchers, q.proxy, q.deduplicate, q.maxResolutionMillis, q.partialResponse, q.skipChunks, q.gateProviderFn(), q.selectTimeout, q.shardInfo, q.seriesStatsReporter, q.opts), nil
 }
 
 type querier struct {
@@ -174,11 +177,13 @@ type querier struct {
 	selectTimeout           time.Duration
 	shardInfo               *storepb.ShardInfo
 	seriesStatsReporter     seriesStatsReporter
+	enableDedupMerge        bool
 }
 
 // newQuerier creates implementation of storage.Querier that fetches data from the proxy
 // store API endpoints.
-func newQuerierInternal(
+// nolint:unparam
+func newQuerier(
 	logger log.Logger,
 	mint,
 	maxt int64,
@@ -193,7 +198,26 @@ func newQuerierInternal(
 	selectTimeout time.Duration,
 	shardInfo *storepb.ShardInfo,
 	seriesStatsReporter seriesStatsReporter,
-	groupReplicaPartialResponseStrategy bool,
+) *querier {
+	return newQuerierWithOpts(logger, mint, maxt, replicaLabels, storeDebugMatchers, proxy, deduplicate, maxResolutionMillis, partialResponse, skipChunks, selectGate, selectTimeout, shardInfo, seriesStatsReporter, Options{})
+}
+
+func newQuerierWithOpts(
+	logger log.Logger,
+	mint,
+	maxt int64,
+	replicaLabels []string,
+	storeDebugMatchers [][]*labels.Matcher,
+	proxy storepb.StoreServer,
+	deduplicate bool,
+	maxResolutionMillis int64,
+	partialResponse,
+	skipChunks bool,
+	selectGate gate.Gate,
+	selectTimeout time.Duration,
+	shardInfo *storepb.ShardInfo,
+	seriesStatsReporter seriesStatsReporter,
+	opts Options,
 ) *querier {
 	if logger == nil {
 		logger = log.NewNopLogger()
@@ -204,7 +228,7 @@ func newQuerierInternal(
 	}
 
 	partialResponseStrategy := storepb.PartialResponseStrategy_ABORT
-	if groupReplicaPartialResponseStrategy {
+	if opts.GroupReplicaPartialResponseStrategy {
 		level.Debug(logger).Log("msg", "Enabled group-replica partial response strategy in newQuerierInternal")
 		partialResponseStrategy = storepb.PartialResponseStrategy_GROUP_REPLICA
 	} else if partialResponse {
@@ -226,76 +250,8 @@ func newQuerierInternal(
 		skipChunks:              skipChunks,
 		shardInfo:               shardInfo,
 		seriesStatsReporter:     seriesStatsReporter,
+		enableDedupMerge:        opts.EnableDedupMerge,
 	}
-}
-
-func newQuerier(
-	logger log.Logger,
-	mint,
-	maxt int64,
-	replicaLabels []string,
-	storeDebugMatchers [][]*labels.Matcher,
-	proxy storepb.StoreServer,
-	deduplicate bool,
-	maxResolutionMillis int64,
-	partialResponse,
-	skipChunks bool,
-	selectGate gate.Gate,
-	selectTimeout time.Duration,
-	shardInfo *storepb.ShardInfo,
-	seriesStatsReporter seriesStatsReporter,
-) *querier {
-	return newQuerierInternal(
-		logger,
-		mint,
-		maxt,
-		replicaLabels,
-		storeDebugMatchers,
-		proxy,
-		deduplicate,
-		maxResolutionMillis,
-		partialResponse,
-		skipChunks,
-		selectGate,
-		selectTimeout,
-		shardInfo,
-		seriesStatsReporter,
-		false,
-	)
-}
-func newQuerierWithGroupReplicaPartialResponseStrategy(
-	logger log.Logger,
-	mint,
-	maxt int64,
-	replicaLabels []string,
-	storeDebugMatchers [][]*labels.Matcher,
-	proxy storepb.StoreServer,
-	deduplicate bool,
-	maxResolutionMillis int64,
-	partialResponse,
-	skipChunks bool,
-	selectGate gate.Gate,
-	selectTimeout time.Duration,
-	shardInfo *storepb.ShardInfo,
-	seriesStatsReporter seriesStatsReporter,
-) *querier {
-	return newQuerierInternal(
-		logger,
-		mint,
-		maxt,
-		replicaLabels,
-		storeDebugMatchers,
-		proxy,
-		deduplicate,
-		maxResolutionMillis,
-		partialResponse,
-		skipChunks,
-		selectGate,
-		selectTimeout,
-		shardInfo,
-		seriesStatsReporter,
-		true,
-	)
 }
 
 func (q *querier) isDedupEnabled() bool {
@@ -497,8 +453,11 @@ func (q *querier) selectFn(ctx context.Context, hints *storage.SelectHints, ms .
 		aggrs,
 		warns,
 	)
-
-	return dedup.NewSeriesSet(set, hints.Func), resp.seriesSetStats, nil
+	f := hints.Func
+	if q.enableDedupMerge {
+		f = dedup.UseMergedSeries
+	}
+	return dedup.NewSeriesSet(set, f), resp.seriesSetStats, nil
 }
 
 // LabelValues returns all potential values for a label name.


### PR DESCRIPTION
Raw data has 3 copies, one has missing data points
<img width="1889" alt="Screenshot 2024-05-29 at 7 25 36 PM" src="https://github.com/databricks/thanos/assets/96499497/67a4fb3c-30ce-43ec-ae42-df7398e17126">

Before this change, dips in data points:

<img width="1896" alt="Screenshot 2024-05-29 at 7 25 43 PM" src="https://github.com/databricks/thanos/assets/96499497/7fa88c4a-96aa-41da-a252-1252d738c313">

After this change:

<img width="1892" alt="Screenshot 2024-05-29 at 8 35 57 PM" src="https://github.com/databricks/thanos/assets/96499497/ca5ab1e6-0e72-410b-8119-27b9263eb085">


<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

More tests, especially during rolling update and the histogram used to have large spikes:

<img width="464" alt="Screenshot 2024-05-30 at 9 06 49 AM" src="https://github.com/databricks/thanos/assets/96499497/d9433ef1-dc2c-465c-b8aa-deccddae5e72">

After the change it is gone:

<img width="420" alt="Screenshot 2024-05-30 at 10 35 05 AM" src="https://github.com/databricks/thanos/assets/96499497/dd9c3a3f-818b-4719-b5e4-b60c0e928acc">
