### PR TITLE
Fix group/replica summary error report logging

### DIFF
--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -609,6 +609,8 @@ func (e *EndpointSet) GetStoreClients() []store.Client {
 				StoreClient: storepb.NewStoreClient(er.cc),
 				addr:        er.addr,
 				metadata:    er.metadata,
+				groupKey:    er.GroupKey(),
+				replicaKey:  er.ReplicaKey(),
 			})
 			er.mtx.RUnlock()
 		}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -397,7 +397,10 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 
 	logGroupReplicaErrors := func() {
 		if len(failedStores) > 0 {
-			level.Warn(s.logger).Log("msg", "Group/replica errors", "errors", failedStores)
+			level.Warn(s.logger).Log("msg", "Group/replica errors",
+				"errors", fmt.Sprintf("%+v", failedStores),
+				"total_failed_stores", totalFailedStores,
+			)
 		}
 	}
 	defer logGroupReplicaErrors()
@@ -411,6 +414,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 		respSet, err := newAsyncRespSet(ctx, st, r, s.responseTimeout, s.retrievalStrategy, &s.buffers, r.ShardInfo, reqLogger, s.metrics.emptyStreamResponses)
 		if err != nil {
 			level.Error(reqLogger).Log("err", err)
+			level.Warn(s.logger).Log("msg", "Store failure", "group", st.GroupKey(), "replica", st.ReplicaKey())
 			bumpCounter(st.GroupKey(), st.ReplicaKey(), failedStores)
 			totalFailedStores++
 			if r.PartialResponseStrategy == storepb.PartialResponseStrategy_GROUP_REPLICA {


### PR DESCRIPTION
This only impacts logging.
Before this change
```
level=warn name=pantheon-instant-querier msg="Group/replica errors" errors="unsupported value type"
```
After this change
```
level=warn name=pantheon-range-querier msg="Store failure" group=range-store-api replica=range-store-api
level=warn name=pantheon-range-querier msg="Group/replica errors" errors=map[range-store-api:map[range-store-api:1]] total_failed_stores=1
```