### PR TITLE
sleep 30 sec before http srv shutdown

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -845,6 +845,8 @@ func runQuery(
 			return s.ListenAndServe()
 		}, func(error) {
 			statusProber.NotReady(err)
+			level.Info(logger).Log("msg", "sleeping 10 seconds before querier http server shutdown")
+			time.Sleep(10 * time.Second)
 			s.Shutdown(err)
 		})
 	}

--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -5,6 +5,9 @@ package http
 
 import (
 	"context"
+	"net/http"
+	"net/http/pprof"
+
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -14,8 +17,6 @@ import (
 	toolkit_web "github.com/prometheus/exporter-toolkit/web"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"net/http"
-	"net/http/pprof"
 
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/prober"
@@ -101,6 +102,7 @@ func (s *Server) Shutdown(err error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.opts.gracePeriod)
 	defer cancel()
+
 	if err := s.srv.Shutdown(ctx); err != nil {
 		level.Error(s.logger).Log("msg", "internal server shut down failed", "err", err)
 		return

--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -5,10 +5,6 @@ package http
 
 import (
 	"context"
-	"net/http"
-	"net/http/pprof"
-	"time"
-
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -18,6 +14,8 @@ import (
 	toolkit_web "github.com/prometheus/exporter-toolkit/web"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	"net/http"
+	"net/http/pprof"
 
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/prober"
@@ -103,9 +101,6 @@ func (s *Server) Shutdown(err error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.opts.gracePeriod)
 	defer cancel()
-	// https://go-review.googlesource.com/c/go/+/565277
-	level.Info(s.logger).Log("msg", "sleeping 300 seconds before shutting down internal server")
-	time.Sleep(300 * time.Second)
 	if err := s.srv.Shutdown(ctx); err != nil {
 		level.Error(s.logger).Log("msg", "internal server shut down failed", "err", err)
 		return

--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -104,8 +104,8 @@ func (s *Server) Shutdown(err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.opts.gracePeriod)
 	defer cancel()
 	// https://go-review.googlesource.com/c/go/+/565277
-	level.Info(s.logger).Log("msg", "sleeping 30 seconds before shutting down internal server")
-	time.Sleep(30 * time.Second)
+	level.Info(s.logger).Log("msg", "sleeping 300 seconds before shutting down internal server")
+	time.Sleep(300 * time.Second)
 	if err := s.srv.Shutdown(ctx); err != nil {
 		level.Error(s.logger).Log("msg", "internal server shut down failed", "err", err)
 		return

--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/pprof"
+	"time"
 
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/log"
@@ -102,7 +103,9 @@ func (s *Server) Shutdown(err error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.opts.gracePeriod)
 	defer cancel()
-
+	// https://go-review.googlesource.com/c/go/+/565277
+	level.Info(s.logger).Log("msg", "sleeping 30 seconds before shutting down internal server")
+	time.Sleep(30 * time.Second)
 	if err := s.srv.Shutdown(ctx); err != nil {
 		level.Error(s.logger).Log("msg", "internal server shut down failed", "err", err)
 		return


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Querier and query frontend initialization is good but termination is problematic. HTTP graceful shutdown has data race issue that might be related to https://go-review.googlesource.com/c/go/+/565277. A brief sleep here should help avoid the race condition.

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
