### PR TITLE
[PLAT-112497] Fix rule evaluation failure during rollout

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -790,6 +790,7 @@ func runQuery(
 			statusProber.NotReady(err)
 			defer statusProber.NotHealthy(err)
 
+			time.Sleep(5 * time.Second)
 			srv.Shutdown(err)
 		})
 	}
@@ -845,6 +846,7 @@ func runQuery(
 			return s.ListenAndServe()
 		}, func(error) {
 			statusProber.NotReady(err)
+			time.Sleep(10 * time.Second)
 			s.Shutdown(err)
 		})
 	}

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -383,6 +383,7 @@ func runQueryFrontend(
 			statusProber.NotReady(err)
 			defer statusProber.NotHealthy(err)
 
+			time.Sleep(5 * time.Second)
 			srv.Shutdown(err)
 		})
 	}

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -313,6 +313,7 @@ func runReceive(
 			statusProber.NotReady(err)
 			defer statusProber.NotHealthy(err)
 
+			time.Sleep(5 * time.Second)
 			srv.Shutdown(err)
 		})
 	}
@@ -384,6 +385,7 @@ func runReceive(
 				statusProber.NotReady(err)
 				defer statusProber.NotHealthy(err)
 
+				time.Sleep(10 * time.Second)
 				srv.Shutdown(err)
 			},
 		)

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -300,6 +300,7 @@ func runStore(
 		statusProber.NotReady(err)
 		defer statusProber.NotHealthy(err)
 
+		time.Sleep(5 * time.Second)
 		srv.Shutdown(err)
 	})
 
@@ -529,6 +530,7 @@ func runStore(
 			return s.ListenAndServe()
 		}, func(err error) {
 			statusProber.NotReady(err)
+			time.Sleep(10 * time.Second)
 			s.Shutdown(err)
 		})
 	}


### PR DESCRIPTION
for some reason upstream sends query requests during a pod is in termination state. sleep a short duration between NotReady() and Shutdown() fixed the problem

see test results in https://github.com/databricks/universe/pull/653143