### PR TITLE
Updated counter to counter vec and added counter vec tests: FIX the cached_failed_queries_count metric 

### DIFF
--- a/internal/cortex/frontend/transport/handler.go
+++ b/internal/cortex/frontend/transport/handler.go
@@ -62,7 +62,6 @@ type Handler struct {
 	querySeconds *prometheus.CounterVec
 	querySeries  *prometheus.CounterVec
 	queryBytes   *prometheus.CounterVec
-	cachedHits   *prometheus.CounterVec
 	activeUsers  *util.ActiveUsersCleanupService
 }
 
@@ -75,7 +74,7 @@ func NewHandler(cfg HandlerConfig, roundTripper http.RoundTripper, log log.Logge
 	}
 
 	if cfg.FailedQueryCacheCapacity > 0 {
-		FailedQueryCache, errQueryCache := utils.NewFailedQueryCache(cfg.FailedQueryCacheCapacity)
+		FailedQueryCache, errQueryCache := utils.NewFailedQueryCache(cfg.FailedQueryCacheCapacity, reg)
 		if errQueryCache != nil {
 			level.Warn(log).Log(errQueryCache.Error())
 		}
@@ -107,11 +106,6 @@ func NewHandler(cfg HandlerConfig, roundTripper http.RoundTripper, log log.Logge
 		// If cleaner stops or fail, we will simply not clean the metrics for inactive users.
 		_ = h.activeUsers.StartAsync(context.Background())
 	}
-
-	h.cachedHits = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "cached_failed_queries_count",
-		Help: "Total number of queries that hit the failed query cache.",
-	}, []string{"total"})
 
 	return h
 }
@@ -148,7 +142,6 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if cached {
 			w.WriteHeader(http.StatusForbidden)
 			level.Info(util_log.WithContext(r.Context(), f.log)).Log(message)
-			f.cachedHits.WithLabelValues("total").Inc()
 			return
 		}
 	}


### PR DESCRIPTION
This PR updates the counter metric to a counter vec metric. It has one intended label, "total". This measures the total number of times the cache is hit.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Changed cacheHits from Counter to CounterVec. Added label "total".

## Verification

I tested the CounterVec standalone in the test file. The CounterVec w/ appropriate label shows correct expected values when incremented.