### PR TITLE
Fix blocking failed queries

### DIFF
--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -326,7 +326,7 @@ func runQueryFrontend(
 	roundTripper = tripperWare(roundTripper)
 
 	// Create the query frontend transport.
-	handler := transport.NewHandler(*cfg.CortexHandlerConfig, roundTripper, logger, nil)
+	handler := transport.NewHandler(*cfg.CortexHandlerConfig, roundTripper, logger, reg)
 	if cfg.CompressResponses {
 		handler = gzhttp.GzipHandler(handler)
 	}


### PR DESCRIPTION
1. Make the metrics work.
2. Add a gauge for cache size.
3. Don't block APIs other than query/range_query
4. Avoid parsing URL parameters twice.

Test in https://github.com/databricks/universe/pull/666485