### PR TITLE
Add chunk stats to a tracing span tag

### DIFF
--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -333,6 +333,9 @@ func newLazyRespSet(
 			l.span.SetTag("processed.chunks", seriesStats.Chunks)
 			l.span.SetTag("processed.samples", seriesStats.Samples)
 			l.span.SetTag("processed.bytes", bytesProcessed)
+			if len(seriesStats.ChunkSt) > 0 {
+				l.span.SetTag("processed.chunk_stats", seriesStats.ChunkSt)
+			}
 			l.span.Finish()
 		}()
 
@@ -491,6 +494,7 @@ func newAsyncRespSet(
 
 	switch retrievalStrategy {
 	case LazyRetrieval:
+		span.SetTag("retrival_strategy", LazyRetrieval)
 		return newLazyRespSet(
 			span,
 			frameTimeout,
@@ -503,6 +507,7 @@ func newAsyncRespSet(
 			emptyStreamResponses,
 		), nil
 	case EagerRetrieval:
+		span.SetTag("retrival_strategy", EagerRetrieval)
 		return newEagerRespSet(
 			span,
 			frameTimeout,
@@ -596,6 +601,9 @@ func newEagerRespSet(
 			l.span.SetTag("processed.chunks", seriesStats.Chunks)
 			l.span.SetTag("processed.samples", seriesStats.Samples)
 			l.span.SetTag("processed.bytes", bytesProcessed)
+			if len(seriesStats.ChunkSt) > 0 {
+				l.span.SetTag("processed.chunk_stats", seriesStats.ChunkSt)
+			}
 			l.span.Finish()
 			ret.wg.Done()
 		}()


### PR DESCRIPTION
This is to help debug query issues. The chunks in the tag are from a single Store (DB or Store).
Tested in a dev region.
[Jaeger link](https://tracing-aws-us-west-2.staging.cloud.databricks.com/trace/3b26d08e968fd745fb88d05e48b6bc4d?uiFind=ab46c9f088868837)
<img width="1753" alt="image" src="https://github.com/user-attachments/assets/c08d384c-c9d4-4883-97c7-3b20318655b8">
