### PR TITLE
Simplify merge iterator imp

### DIFF
--- a/pkg/dedup/merge_iter.go
+++ b/pkg/dedup/merge_iter.go
@@ -49,8 +49,8 @@ func (m *mergedSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
 }
 
 type quorumValuePicker struct {
-	currentValue  int64
-	cnt 		  int
+	currentValue int64
+	cnt          int
 }
 
 func NewQuorumValuePicker(v float64) *quorumValuePicker {
@@ -98,8 +98,8 @@ func (m *mergedSeriesIterator) Next() chunkenc.ValueType {
 			continue
 		}
 		// apply penalty to avoid selecting samples too close
-		m.oks[i] = it.Seek(m.lastT + initialPenalty) != chunkenc.ValNone
-		// The it.Seek() call above should garantee that it.AtT() > m.lastT.
+		m.oks[i] = it.Seek(m.lastT+initialPenalty) != chunkenc.ValNone
+		// The it.Seek() call above should guarantee that it.AtT() > m.lastT.
 		if m.oks[i] {
 			t, v := it.At()
 			if t < minT {
@@ -123,7 +123,8 @@ func (m *mergedSeriesIterator) Next() chunkenc.ValueType {
 
 func (m *mergedSeriesIterator) Seek(t int64) chunkenc.ValueType {
 	// Don't use underlying Seek, but iterate over next to not miss gaps.
-	for m.lastT < t && m.Next() != chunkenc.ValNone {}
+	for m.lastT < t && m.Next() != chunkenc.ValNone {
+	}
 	// Don't call m.Next() again!
 	if m.lastIter == nil {
 		return chunkenc.ValNone

--- a/pkg/dedup/merge_iter_test.go
+++ b/pkg/dedup/merge_iter_test.go
@@ -187,8 +187,7 @@ func TestMergedSeriesIterator(t *testing.T) {
 				}, {
 					lset:    labels.Labels{{Name: "a", Value: "5"}, {Name: "c", Value: "6"}},
 					samples: []sample{{10000, 1}, {20000, 2}, {30000, 3}, {50000, 5}},
-				},
-				{
+				}, {
 					lset:    labels.Labels{{Name: "b", Value: "5"}, {Name: "c", Value: "6"}},
 					samples: []sample{{10000, 1}, {20000, 2}, {30000, 3}, {50000, 5}},
 				}, {


### PR DESCRIPTION
I found an interesting comment in dedupSeriesIterator. It seems a dedup iterator can’t use its child iterators’ Seek() to implement its own Seek() . Otherwise, it will “miss gaps”.
I suspect mergedSeriesIterator needs to do the same by implementing Seek() using its Next(). 
![image](https://github.com/user-attachments/assets/969d88d5-e75f-43b0-a286-dcd95283ae89)
![image](https://github.com/user-attachments/assets/c5a2e466-14a7-4366-bc92-aac2fdf55370)

# Tests
Will test in a dev region
