### PR TITLE
Truncate labels for error messages

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -141,7 +141,7 @@ func (l *localClient) String() string {
 	mint, maxt := l.store.TimeRange()
 	return fmt.Sprintf(
 		"LabelSets: %v MinTime: %d MaxTime: %d",
-		labelpb.PromLabelSetsToStringN(l.LabelSets(), 10), mint, maxt,
+		labelpb.PromLabelSetsToStringN(l.LabelSets(), 500), mint, maxt,
 	)
 }
 

--- a/pkg/store/labelpb/label.go
+++ b/pkg/store/labelpb/label.go
@@ -303,15 +303,18 @@ func ExtendSortedLabels(lset, extend labels.Labels) labels.Labels {
 }
 
 func PromLabelSetsToString(lsets []labels.Labels) string {
-	return PromLabelSetsToStringN(lsets, 1000000)
+	return PromLabelSetsToStringN(lsets, 500)
 }
 
-func PromLabelSetsToStringN(lsets []labels.Labels, maxNumLabels int) string {
+func PromLabelSetsToStringN(lsets []labels.Labels, maxLength int) string {
+	if len(lsets) == 0 {
+		return ""
+	}
 	s := []string{}
 	for _, ls := range lsets {
 		s = append(s, ls.String())
-		maxNumLabels--
-		if maxNumLabels <= 0 {
+		maxLength -= len(ls.String())
+		if maxLength <= 0 {
 			break
 		}
 	}


### PR DESCRIPTION
## Before
<img width="1787" alt="image" src="https://github.com/user-attachments/assets/a25e01bb-e144-417e-b73e-c200befef098">

## After
<img width="2552" alt="image" src="https://github.com/user-attachments/assets/2ec22917-e801-4e6a-bb7d-f858e782224b">

