### PR TITLE
Improve query performance logging/instrumentation

### DIFF
--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -551,7 +551,13 @@ func (e *EndpointSet) Update(ctx context.Context) {
 func (e *EndpointSet) updateEndpoint(ctx context.Context, spec *GRPCEndpointSpec, er *endpointRef) {
 	metadata, err := er.Metadata(ctx, infopb.NewInfoClient(er.cc), storepb.NewStoreClient(er.cc))
 	if err != nil {
-		level.Warn(e.logger).Log("msg", "update of endpoint failed", "err", errors.Wrap(err, "getting metadata"), "address", spec.Addr())
+		level.Warn(e.logger).Log(
+			"msg", "update of endpoint failed",
+			"err", errors.Wrap(err, "getting metadata"),
+			"address", spec.Addr(),
+			"group_key", spec.groupKey,
+			"replica_key", spec.replicaKey,
+		)
 	}
 	er.update(e.now, metadata, err)
 }

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -99,6 +99,7 @@ type ProxyStore struct {
 
 type proxyStoreMetrics struct {
 	emptyStreamResponses prometheus.Counter
+	storeFailureCount    *prometheus.CounterVec
 }
 
 func newProxyStoreMetrics(reg prometheus.Registerer) *proxyStoreMetrics {
@@ -108,6 +109,10 @@ func newProxyStoreMetrics(reg prometheus.Registerer) *proxyStoreMetrics {
 		Name: "thanos_proxy_store_empty_stream_responses_total",
 		Help: "Total number of empty responses received.",
 	})
+	m.storeFailureCount = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "thanos_proxy_store_failure_total",
+		Help: "Total number of store failures.",
+	}, []string{"group", "replica"})
 
 	return &m
 }
@@ -431,7 +436,8 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 		if err != nil {
 			// NB: respSet is nil in case of error.
 			level.Error(reqLogger).Log("err", err)
-			level.Warn(s.logger).Log("msg", "Store failure", "group", st.GroupKey(), "replica", st.ReplicaKey())
+			level.Warn(s.logger).Log("msg", "Store failure", "group", st.GroupKey(), "replica", st.ReplicaKey(), "err", err)
+			s.metrics.storeFailureCount.WithLabelValues(st.GroupKey(), st.ReplicaKey()).Inc()
 			bumpCounter(st.GroupKey(), st.ReplicaKey(), failedStores)
 			totalFailedStores++
 			if r.PartialResponseStrategy == storepb.PartialResponseStrategy_GROUP_REPLICA {
@@ -466,7 +472,9 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 			totalFailedStores++
 			maxWarningBytes := 2000
 			warning := resp.GetWarning()[:min(maxWarningBytes, len(resp.GetWarning()))]
-			level.Error(s.logger).Log("msg", "Series: warning from store", "warning", warning)
+			level.Error(s.logger).Log("msg", "Store failure with warning", "warning", warning)
+			// Don't have group/replica keys here, so we can't attribute the warning to a specific store.
+			s.metrics.storeFailureCount.WithLabelValues("", "").Inc()
 			if r.PartialResponseStrategy == storepb.PartialResponseStrategy_GROUP_REPLICA {
 				// TODO: attribute the warning to the store(group key and replica key) that produced it.
 				// Each client streams a sequence of time series, so it's not trivial to attribute the warning to a specific client.


### PR DESCRIPTION
# Whay/Why
1. Add Store failure related counters to Querier
2. Log `error` from Store failure
3. Add slow/failed query counters to Query-frontend

# Tests
## Deployed to a dev shard
https://github.com/databricks/universe/pull/683614