### PR TITLE
Retain original timeout behavior for compact

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -291,7 +291,10 @@ func runCompact(
 			api.SetLoaded(blocks, err)
 		})
 
-		var syncMetasTimeout = conf.waitInterval
+		// Still use blockViewerSyncBlockTimeout to retain original behavior before this upstream change:
+		// https://github.com/databricks/thanos/commit/ab43b2b20cb42eca2668824a4084307216c6da2e#diff-6c2257b871fd1196514f664bc7e44cb21681215e0929710d0ad5ceea90b8e122R294
+		// Otherwise Azure won't work due to its high latency
+		var syncMetasTimeout = conf.blockViewerSyncBlockTimeout
 		if !conf.wait {
 			syncMetasTimeout = 0
 		}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

See code comments.

## Verification

<!-- How you tested it? How do you know it works? -->

Deployed this to `dev-azure-centralus` at around 1100AM, start compact after 1.5h~

<img width="782" alt="image" src="https://github.com/user-attachments/assets/e6cc2adf-3a8c-476c-9f28-dd774731a8f6">

https://grafana.cloud.databricks.com/d/JVQ7Qc5Iz/pantheon-dashboard-go-pantheon-dash?orgId=1&refresh=1h&var-datasource=dev-azure-centralus&var-cluster=All