### PR TITLE
Ignore 'The specified blob does not exist' error

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -430,8 +430,9 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 			// Don't have group/replica keys here, so we can't attribute the warning to a specific store.
 			s.metrics.storeFailureCount.WithLabelValues("", "").Inc()
 			if r.PartialResponseStrategy == storepb.PartialResponseStrategy_GROUP_REPLICA {
-				if strings.Contains(resp.GetWarning(), "The specified key does not exist") {
-					level.Warn(s.logger).Log("msg", "Ignore 'the specified key does not exist' error from Store")
+				// The first error message is from AWS S3 and the second one is from Azure Blob Storage.
+				if strings.Contains(resp.GetWarning(), "The specified key does not exist") || strings.Contains(resp.GetWarning(), "The specified blob does not exist") {
+					level.Warn(s.logger).Log("msg", "Ignore 'the specified key/blob does not exist' error from Store")
 					// Ignore this error for now because we know the missing block file is already deleted by compactor.
 					// There is no other reason for this error to occur.
 					s.metrics.missingBlockFileErrorCount.Inc()


### PR DESCRIPTION
"proxy Series(): rpc error: code = Aborted desc = receive series from Addr: 10.2.60.238:10901 LabelSets: {__replica__=\"pantheon-db-rep0-0\", __tenant__=\"Recording\"},{__replica__=\"pantheon-db-rep0-0\", __tenant__=\"eng-app-framework-team\"},{__replica__=\"pantheon-db-rep0-0\", __tenant__=\"eng-cluster-team\"},{__replica__=\"pantheon-db-rep0-0\", __tenant__=\"eng-data-security-team\"} MinTime: 1730772000000 MaxTime: 1730944800000: rpc error: code = Aborted desc = fetch postings for block 01JC2XMH9M8PCZQY8HXW7RGC5R: expanded matching posting: fetch and expand postings: get postings: read postings range: cannot download blob, address: %!D(MISSING): GET \n--------------------------------------------------------------------------------\nRESPONSE 404: 404 The specified blob does not exist.\nERROR CODE: BlobNotFound\n--------------------------------------------------------------------------------\n﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>BlobNotFound</Code><Message>The specified blob does not exist.\nRequestId:a76dac4f-601e-0051-7d7e-355d01000000\nTime:2024-11-13T03:48:46.9473298Z</Message></Error>\n--------------------------------------------------------------------------------\n; receive series from Addr: 10.2.169.127:10901 LabelSets: {__replica__=\"pantheon-db-rep0-0\", __tenant__=\"unknown\"},{__replica__=\"pantheon-db-rep0-1\", __tenant__=\"unknown\"},{__replica__=\"pantheon-db-rep0-10\", __tenant__=\"eng-app-infra-team\"},{__replica__=\"pantheon-db-rep0-10\", __tenant__=\"unknown\"} MinTime: 1729569600000 MaxTime: 1731067200000: rpc error: code = Unknown desc = receive series from 01JC3R4AP32NAGM87SNRECWRWK: load chunks: populate chunk: allocate chunk bytes: pool exhausted"
