### PR TITLE
silence conflict samples

### DIFF
--- a/pkg/receive/writer_errors.go
+++ b/pkg/receive/writer_errors.go
@@ -58,7 +58,8 @@ func (a *writeErrorTracker) addSampleError(err error, tLogger log.Logger, lset l
 		a.numSamplesOutOfOrder++
 		level.Debug(tLogger).Log("msg", "Out of order sample", "lset", lset, "value", v, "timestamp", t)
 	case errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
-		a.numSamplesDuplicates++
+		// we don't consider this is an error
+		//a.numSamplesDuplicates++
 		level.Debug(tLogger).Log("msg", "Duplicate sample for timestamp", "lset", lset, "value", v, "timestamp", t)
 	case errors.Is(err, storage.ErrOutOfBounds):
 		a.numSamplesOutOfBounds++
@@ -80,7 +81,7 @@ func (a *writeErrorTracker) addHistogramError(err error, tLogger log.Logger, lse
 		a.numSamplesOutOfOrder++
 		level.Debug(tLogger).Log("msg", "Out of order histogram", "lset", lset, "timestamp", timestamp)
 	case errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
-		a.numSamplesDuplicates++
+		//a.numSamplesDuplicates++
 		level.Debug(tLogger).Log("msg", "Duplicate histogram for timestamp", "lset", lset, "timestamp", timestamp)
 	case errors.Is(err, storage.ErrOutOfBounds):
 		a.numSamplesOutOfBounds++
@@ -103,7 +104,7 @@ func (a *writeErrorTracker) addExemplarError(err error, exLogger log.Logger) {
 		a.numExemplarsOutOfOrder++
 		level.Debug(exLogger).Log("msg", "Out of order exemplar")
 	case errors.Is(err, storage.ErrDuplicateExemplar):
-		a.numExemplarsDuplicate++
+		//a.numExemplarsDuplicate++
 		level.Debug(exLogger).Log("msg", "Duplicate exemplar")
 	case errors.Is(err, storage.ErrExemplarLabelLength):
 		a.numExemplarsLabelLength++


### PR DESCRIPTION
<img width="463" alt="Screenshot 2024-11-13 at 4 52 08 PM" src="https://github.com/user-attachments/assets/c57c3cae-6d5e-45e7-bf75-9ac759b1bb97">

```
ts=2024-11-13T03:58:14.13671956Z caller=handler.go:631 level=error name=pantheon-writer component=receive component=receive-handler tenant=unknown err="5 errors: backing off forward request for endpoint {{pantheon-db-rep1-2.pantheon-db-svc.pantheon.svc.cluster.local:10901 pantheon-db-rep1-2.pantheon-db-svc.pantheon.svc.cluster.local:19391 pantheon-db-rep1} 0}: target not available; backing off forward request for endpoint {{pantheon-db-rep1-2.pantheon-db-svc.pantheon.svc.cluster.local:10901 pantheon-db-rep1-2.pantheon-db-svc.pantheon.svc.cluster.local:19391 pantheon-db-rep1} 1}: target not available; backing off forward request for endpoint {{pantheon-db-rep1-2.pantheon-db-svc.pantheon.svc.cluster.local:10901 pantheon-db-rep1-2.pantheon-db-svc.pantheon.svc.cluster.local:19391 pantheon-db-rep1} 2}: target not available; forwarding request to endpoint {pantheon-db-rep0-0.pantheon-db-svc.pantheon.svc.cluster.local:10901 pantheon-db-rep0-0.pantheon-db-svc.pantheon.svc.cluster.local:19391 pantheon-db-rep0}: rpc error: code = AlreadyExists desc = add 2 samples: duplicate sample for timestamp; forwarding request to endpoint {pantheon-db-rep0-6.pantheon-db-svc.pantheon.svc.cluster.local:10901 pantheon-db-rep0-6.pantheon-db-svc.pantheon.svc.cluster.local:19391 pantheon-db-rep0}: rpc error: code = AlreadyExists desc = add 1 samples: duplicate sample for timestamp" msg="internal server error"
```

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
