### PR TITLE
add matcher cache for proxy store and tsdb store API

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -358,6 +358,7 @@ func runReceive(
 		options := []store.ProxyStoreOption{
 			store.WithProxyStoreDebugLogging(debugLogging),
 			store.WithoutDedup(),
+			store.WithMatcherConverter(conf.matcherConverterCacheCapacity, reg),
 		}
 
 		proxy := store.NewProxyStore(
@@ -932,9 +933,10 @@ type receiveConfig struct {
 
 	asyncForwardWorkerCount uint
 
-	numTopMetricsPerTenant       int
-	topMetricsMinimumCardinality uint64
-	topMetricsUpdateInterval     time.Duration
+	numTopMetricsPerTenant        int
+	topMetricsMinimumCardinality  uint64
+	topMetricsUpdateInterval      time.Duration
+	matcherConverterCacheCapacity int
 
 	featureList *[]string
 }
@@ -1097,6 +1099,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("10000").Uint64Var(&rc.topMetricsMinimumCardinality)
 	cmd.Flag("receive.top-metrics-update-interval", "The interval at which the top metrics are updated.").
 		Default("5m").DurationVar(&rc.topMetricsUpdateInterval)
+	cmd.Flag("receive.store-matcher-converter-cache-capacity", "The number of label matchers to cache in the matcher converter for the Store API.").
+		Default("1000").IntVar(&rc.matcherConverterCacheCapacity)
 	rc.featureList = cmd.Flag("enable-feature", "Comma separated experimental feature names to enable. The current list of features is "+metricNamesFilter+".").Default("").Strings()
 }
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -367,7 +367,9 @@ func runReceive(
 				// Set the Content-Type header and write the response
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				w.Write(jsonData)
+				if _, err := w.Write(jsonData); err != nil {
+					level.Error(logger).Log("msg", "failed to write matchers json", "err", err)
+				}
 			}
 		}))
 		g.Add(func() error {

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -350,6 +351,23 @@ func runReceive(
 				w.WriteHeader(http.StatusTooEarly)
 			} else {
 				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		srv.Handle("/-/matchers", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			if matcherConverter != nil {
+				labelMatchers := matcherConverter.Keys()
+				// Convert the slice to JSON
+				jsonData, err := json.Marshal(labelMatchers)
+				if err != nil {
+					http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
+					return
+				}
+
+				// Set the Content-Type header and write the response
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(jsonData)
 			}
 		}))
 		g.Add(func() error {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -76,6 +76,7 @@ func WithMetricNameFilterEnabled() MultiTSDBOption {
 	}
 }
 
+// WithMatcherConverter enables caching matcher converter consumed by children TSDB Stores.
 func WithMatcherConverter(mc *storepb.MatcherConverter) MultiTSDBOption {
 	return func(s *MultiTSDB) {
 		s.matcherConverter = mc
@@ -718,6 +719,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	if t.metricNameFilterEnabled {
 		options = append(options, store.WithCuckooMetricNameStoreFilter())
 	}
+	// Pass matcher converter to children TSDB Stores.
 	if t.matcherConverter != nil {
 		options = append(options, store.WithTSDBStoreMatcherConverter(t.matcherConverter))
 	}

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -134,10 +134,7 @@ func (s *LocalStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, s.extLabels)
-	if err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, s.extLabels)
 	if !match {
 		return nil
 	}

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -130,11 +130,10 @@ func ScanGRPCCurlProtoStreamMessages(data []byte, atEOF bool) (advance int, toke
 // Series returns all series for a requested time range and label matcher. The returned data may
 // exceed the requested time bounds.
 func (s *LocalStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
-	matchers, err := storepb.MatchersToPromMatchers(r.Matchers...)
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.extLabels, nil)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers := matchesExternalLabels(matchers, s.extLabels)
 	if !match {
 		return nil
 	}

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -130,7 +130,11 @@ func ScanGRPCCurlProtoStreamMessages(data []byte, atEOF bool) (advance int, toke
 // Series returns all series for a requested time range and label matcher. The returned data may
 // exceed the requested time bounds.
 func (s *LocalStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.extLabels)
+	matchers, err := storepb.MatchersToPromMatchers(r.Matchers...)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, s.extLabels)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -129,10 +129,7 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Sto
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, extLset)
-	if err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, extLset)
 	if !match {
 		return nil
 	}
@@ -492,9 +489,9 @@ func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, q *prompb.Que
 
 // matchesExternalLabels returns false if given matchers are not matching external labels.
 // If true, matchesExternalLabels also returns Prometheus matchers without those matching external labels.
-func matchesExternalLabels(tms []*labels.Matcher, externalLabels labels.Labels) (bool, []*labels.Matcher, error) {
+func matchesExternalLabels(tms []*labels.Matcher, externalLabels labels.Labels) (bool, []*labels.Matcher) {
 	if externalLabels.IsEmpty() {
-		return true, tms, nil
+		return true, tms
 	}
 
 	var newMatchers []*labels.Matcher
@@ -511,10 +508,10 @@ func matchesExternalLabels(tms []*labels.Matcher, externalLabels labels.Labels) 
 		if !tm.Matches(extValue) {
 			// External label does not match. This should not happen - it should be filtered out on query node,
 			// but let's do that anyway here.
-			return false, nil, nil
+			return false, nil
 		}
 	}
-	return true, newMatchers, nil
+	return true, newMatchers
 }
 
 // encodeChunk translates the sample pairs into a chunk.
@@ -540,10 +537,7 @@ func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesR
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, extLset)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, extLset)
 	if !match {
 		return &storepb.LabelNamesResponse{Names: nil}, nil
 	}
@@ -607,10 +601,7 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, extLset)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, extLset)
 	if !match {
 		return &storepb.LabelValuesResponse{}, nil
 	}

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -125,7 +125,11 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Sto
 
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
+	matchers, err := storepb.MatchersToPromMatchers(r.Matchers...)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, extLset)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -488,12 +492,7 @@ func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, q *prompb.Que
 
 // matchesExternalLabels returns false if given matchers are not matching external labels.
 // If true, matchesExternalLabels also returns Prometheus matchers without those matching external labels.
-func matchesExternalLabels(ms []storepb.LabelMatcher, externalLabels labels.Labels) (bool, []*labels.Matcher, error) {
-	tms, err := storepb.MatchersToPromMatchers(ms...)
-	if err != nil {
-		return false, nil, err
-	}
-
+func matchesExternalLabels(tms []*labels.Matcher, externalLabels labels.Labels) (bool, []*labels.Matcher, error) {
 	if externalLabels.IsEmpty() {
 		return true, tms, nil
 	}
@@ -537,7 +536,11 @@ func (p *PrometheusStore) encodeChunk(ss []prompb.Sample) (storepb.Chunk_Encodin
 func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
+	matchers, err := storepb.MatchersToPromMatchers(r.Matchers...)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, extLset)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -600,7 +603,11 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
+	matchers, err := storepb.MatchersToPromMatchers(r.Matchers...)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, extLset)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -307,10 +307,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, s.selectorLabels)
-	if err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, s.selectorLabels)
 	if !match {
 		return nil
 	}
@@ -510,10 +507,7 @@ func (s *ProxyStore) LabelNames(ctx context.Context, originalRequest *storepb.La
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, s.selectorLabels)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, s.selectorLabels)
 	if !match {
 		return &storepb.LabelNamesResponse{}, nil
 	}
@@ -617,10 +611,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, s.selectorLabels)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, s.selectorLabels)
 	if !match {
 		return &storepb.LabelValuesResponse{}, nil
 	}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -286,7 +286,11 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 		reqLogger = log.With(reqLogger, "request", originalRequest.String())
 	}
 
-	match, matchers, err := matchesExternalLabels(originalRequest.Matchers, s.selectorLabels)
+	matchers, err := storepb.MatchersToPromMatchers(originalRequest.Matchers...)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, s.selectorLabels)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -485,7 +489,11 @@ func (s *ProxyStore) LabelNames(ctx context.Context, originalRequest *storepb.La
 	if s.debugLogging {
 		reqLogger = log.With(reqLogger, "request", originalRequest.String())
 	}
-	match, matchers, err := matchesExternalLabels(originalRequest.Matchers, s.selectorLabels)
+	matchers, err := storepb.MatchersToPromMatchers(originalRequest.Matchers...)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, s.selectorLabels)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -588,7 +596,11 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 		return nil, status.Error(codes.InvalidArgument, "label name parameter cannot be empty")
 	}
 
-	match, matchers, err := matchesExternalLabels(originalRequest.Matchers, s.selectorLabels)
+	matchers, err := storepb.MatchersToPromMatchers(originalRequest.Matchers...)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, s.selectorLabels)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -163,6 +163,7 @@ func WithoutDedup() ProxyStoreOption {
 	}
 }
 
+// WithProxyStoreMatcherConverter returns a ProxyStoreOption that enables caching matcher converter for ProxyStore.
 func WithProxyStoreMatcherConverter(mc *storepb.MatcherConverter) ProxyStoreOption {
 	return func(s *ProxyStore) {
 		s.matcherConverter = mc
@@ -272,6 +273,7 @@ func (s *ProxyStore) TSDBInfos() []infopb.TSDBInfo {
 	return infos
 }
 
+// MatchersToPromMatchers converts storepb label matchers to prometheus label matchers. It goes to cache if matcherConverter is set.
 func (s *ProxyStore) MatchersToPromMatchers(ms ...storepb.LabelMatcher) ([]*labels.Matcher, error) {
 	var tms []*labels.Matcher
 	var err error

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -278,6 +278,23 @@ func (s *ProxyStore) TSDBInfos() []infopb.TSDBInfo {
 	return infos
 }
 
+func (s *ProxyStore) MatchersToPromMatchers(ms ...storepb.LabelMatcher) ([]*labels.Matcher, error) {
+	var tms []*labels.Matcher
+	var err error
+	if s.matcherConverter == nil {
+		tms, err = storepb.MatchersToPromMatchers(ms...)
+		if err != nil {
+			return nil, err
+		}
+		return tms, nil
+	}
+	tms, err = s.matcherConverter.MatchersToPromMatchers(ms...)
+	if err != nil {
+		return nil, err
+	}
+	return tms, nil
+}
+
 func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
 	// TODO(bwplotka): This should be part of request logger, otherwise it does not make much sense. Also, could be
 	// triggered by tracing span to reduce cognitive load.
@@ -286,7 +303,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 		reqLogger = log.With(reqLogger, "request", originalRequest.String())
 	}
 
-	matchers, err := storepb.MatchersToPromMatchers(originalRequest.Matchers...)
+	matchers, err := s.MatchersToPromMatchers(originalRequest.Matchers...)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -489,7 +506,7 @@ func (s *ProxyStore) LabelNames(ctx context.Context, originalRequest *storepb.La
 	if s.debugLogging {
 		reqLogger = log.With(reqLogger, "request", originalRequest.String())
 	}
-	matchers, err := storepb.MatchersToPromMatchers(originalRequest.Matchers...)
+	matchers, err := s.MatchersToPromMatchers(originalRequest.Matchers...)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -596,7 +613,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 		return nil, status.Error(codes.InvalidArgument, "label name parameter cannot be empty")
 	}
 
-	matchers, err := storepb.MatchersToPromMatchers(originalRequest.Matchers...)
+	matchers, err := s.MatchersToPromMatchers(originalRequest.Matchers...)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -163,15 +163,9 @@ func WithoutDedup() ProxyStoreOption {
 	}
 }
 
-func WithMatcherConverter(cacheCapacity int, reg prometheus.Registerer) ProxyStoreOption {
+func WithProxyStoreMatcherConverter(mc *storepb.MatcherConverter) ProxyStoreOption {
 	return func(s *ProxyStore) {
-		matcherConverter, err := storepb.NewMatcherConverter(cacheCapacity, reg)
-		if err != nil {
-			level.Error(s.logger).Log("msg", "failed to create matcher converter", "err", err)
-			return
-		}
-		level.Info(s.logger).Log("msg", "created matcher converter", "cache_capacity", cacheCapacity)
-		s.matcherConverter = matcherConverter
+		s.matcherConverter = mc
 	}
 }
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -99,6 +99,7 @@ type ProxyStore struct {
 	tsdbSelector      *TSDBSelector
 	quorumChunkDedup  bool
 	enableDedup       bool
+	matcherConverter  *storepb.MatcherConverter
 }
 
 type proxyStoreMetrics struct {
@@ -159,6 +160,18 @@ func WithTSDBSelector(selector *TSDBSelector) ProxyStoreOption {
 func WithoutDedup() ProxyStoreOption {
 	return func(s *ProxyStore) {
 		s.enableDedup = false
+	}
+}
+
+func WithMatcherConverter(cacheCapacity int, reg prometheus.Registerer) ProxyStoreOption {
+	return func(s *ProxyStore) {
+		matcherConverter, err := storepb.NewMatcherConverter(cacheCapacity, reg)
+		if err != nil {
+			level.Error(s.logger).Log("msg", "failed to create matcher converter", "err", err)
+			return
+		}
+		level.Info(s.logger).Log("msg", "created matcher converter", "cache_capacity", cacheCapacity)
+		s.matcherConverter = matcherConverter
 	}
 }
 

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -468,6 +468,15 @@ func NewMatcherConverter(cacheCapacity int, reg prometheus.Registerer) (*Matcher
 func (c *MatcherConverter) MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
 	res := make([]*labels.Matcher, 0, len(ms))
 	for _, m := range ms {
+		if m.Type == LabelMatcher_EQ || m.Type == LabelMatcher_NEQ {
+			// EQ and NEQ are very cheap, so we don't cache them.
+			pm, err := MatcherToPromMatcher(m)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, pm)
+			continue
+		}
 		if pm, ok := c.cache.Get(m); ok {
 			// cache hit
 			c.metrics.cacheHitCount.Inc()

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -493,6 +493,11 @@ func (c *MatcherConverter) MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels
 	return res, nil
 }
 
+// Get all keys from the cache for debugging.
+func (c *MatcherConverter) Keys() []LabelMatcher {
+	return c.cache.Keys()
+}
+
 // MatchersToString converts label matchers to string format.
 // String should be parsable as a valid PromQL query metric selector.
 func MatchersToString(ms ...LabelMatcher) string {

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -7,8 +7,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,6 +14,8 @@ import (
 	"github.com/gogo/protobuf/types"
 	cache "github.com/hashicorp/golang-lru/v2"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
 	"google.golang.org/grpc/codes"
 

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -451,6 +451,7 @@ func newMatcherConverterMetrics(reg prometheus.Registerer) *matcherConverterMetr
 	return &m
 }
 
+// NewMatcherConverter creates a new MatcherConverter with given capacity.
 func NewMatcherConverter(cacheCapacity int, reg prometheus.Registerer) (*MatcherConverter, error) {
 	c, err := cache.New2Q[LabelMatcher, *labels.Matcher](cacheCapacity)
 	if err != nil {
@@ -460,6 +461,7 @@ func NewMatcherConverter(cacheCapacity int, reg prometheus.Registerer) (*Matcher
 	return &MatcherConverter{cache: c, cacheCapacity: cacheCapacity, metrics: metrics}, nil
 }
 
+// MatchersToPromMatchers converts proto label matchers to Prometheus label matchers. It caches regex conversions.
 func (c *MatcherConverter) MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
 	res := make([]*labels.Matcher, 0, len(ms))
 	for _, m := range ms {

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -384,7 +384,7 @@ func PromMatchersToMatchers(ms ...*labels.Matcher) ([]LabelMatcher, error) {
 	return res, nil
 }
 
-func MatcherToPromMatcher(m LabelMatcher) (*labels.Matcher, error) {
+func matcherToPromMatcher(m LabelMatcher) (*labels.Matcher, error) {
 	var t labels.MatchType
 
 	switch m.Type {
@@ -411,7 +411,7 @@ func MatcherToPromMatcher(m LabelMatcher) (*labels.Matcher, error) {
 func MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
 	res := make([]*labels.Matcher, 0, len(ms))
 	for _, m := range ms {
-		m, err := MatcherToPromMatcher(m)
+		m, err := matcherToPromMatcher(m)
 		if err != nil {
 			return nil, err
 		}
@@ -465,9 +465,9 @@ func NewMatcherConverter(cacheCapacity int, reg prometheus.Registerer) (*Matcher
 func (c *MatcherConverter) MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
 	res := make([]*labels.Matcher, 0, len(ms))
 	for _, m := range ms {
-		if m.Type == LabelMatcher_EQ || m.Type == LabelMatcher_NEQ {
+		if m.Type != LabelMatcher_RE && m.Type != LabelMatcher_NRE {
 			// EQ and NEQ are very cheap, so we don't cache them.
-			pm, err := MatcherToPromMatcher(m)
+			pm, err := matcherToPromMatcher(m)
 			if err != nil {
 				return nil, err
 			}
@@ -482,7 +482,7 @@ func (c *MatcherConverter) MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels
 			continue
 		}
 		// cache miss
-		pm, err := MatcherToPromMatcher(m)
+		pm, err := matcherToPromMatcher(m)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -740,7 +740,7 @@ func TestMatcherConverter_MatchersToPromMatchers(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			cacheHitsBefore := getMetricValue(converter.metrics.cacheHitCount)
-			cacheMissesBefore := getMetricValue(converter.metrics.cacheMissCount)
+			cacheTotalBefore := getMetricValue(converter.metrics.cacheTotalCount)
 
 			promMatchers, err := converter.MatchersToPromMatchers(c.inputMatchers...)
 
@@ -759,13 +759,13 @@ func TestMatcherConverter_MatchersToPromMatchers(t *testing.T) {
 
 			if c.expectCacheAction == CacheHit {
 				require.Equal(t, cacheHitsBefore+1, getMetricValue(converter.metrics.cacheHitCount))
-				require.Equal(t, cacheMissesBefore, getMetricValue(converter.metrics.cacheMissCount))
+				require.Equal(t, cacheTotalBefore+1, getMetricValue(converter.metrics.cacheTotalCount))
 			} else if c.expectCacheAction == CacheMiss {
 				require.Equal(t, cacheHitsBefore, getMetricValue(converter.metrics.cacheHitCount))
-				require.Equal(t, cacheMissesBefore+1, getMetricValue(converter.metrics.cacheMissCount))
+				require.Equal(t, cacheTotalBefore+1, getMetricValue(converter.metrics.cacheTotalCount))
 			} else {
 				require.Equal(t, cacheHitsBefore, getMetricValue(converter.metrics.cacheHitCount))
-				require.Equal(t, cacheMissesBefore, getMetricValue(converter.metrics.cacheMissCount))
+				require.Equal(t, cacheTotalBefore, getMetricValue(converter.metrics.cacheTotalCount))
 			}
 		})
 	}

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -11,8 +11,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/require"
 
 	"github.com/efficientgo/core/testutil"
 
@@ -668,6 +671,101 @@ func TestSeriesRequestToPromQL(t *testing.T) {
 			actual := tc.r.ToPromQL()
 			if tc.expected != actual {
 				t.Fatalf("invalid promql result, got %s, want %s", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func getMetricValue(m prometheus.Collector) float64 {
+	metric := &dto.Metric{}
+	if err := m.(prometheus.Metric).Write(metric); err != nil {
+		return 0
+	}
+	return metric.GetCounter().GetValue()
+}
+
+type CacheAction_Type int32
+
+const (
+	CacheHit  CacheAction_Type = 0
+	CacheMiss CacheAction_Type = 1
+	NoCache   CacheAction_Type = 2
+)
+
+func TestMatcherConverter_MatchersToPromMatchers(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	converter, err := NewMatcherConverter(2, reg)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name              string
+		inputMatchers     []LabelMatcher
+		expectCacheAction CacheAction_Type
+		expectMatchers    []*labels.Matcher
+		expectError       bool
+	}{
+		{
+			name: "Single EQ matcher, no cache",
+			inputMatchers: []LabelMatcher{
+				{Name: "__name__", Type: LabelMatcher_EQ, Value: "up"},
+			},
+			// EQ matchers are not cached
+			expectCacheAction: NoCache,
+		},
+		{
+			name: "Single RE matcher, cache miss",
+			inputMatchers: []LabelMatcher{
+				{Name: "job", Type: LabelMatcher_RE, Value: "test"},
+			},
+			expectCacheAction: CacheMiss,
+		},
+		{
+			name: "Single RE matcher, cache hit",
+			inputMatchers: []LabelMatcher{
+				{Name: "job", Type: LabelMatcher_RE, Value: "test"},
+			},
+			expectCacheAction: CacheHit,
+		},
+		{
+			name: "Multiple matchers, mixed cache",
+			inputMatchers: []LabelMatcher{
+				{Name: "__name__", Type: LabelMatcher_EQ, Value: "up"},
+				{Name: "job", Type: LabelMatcher_RE, Value: "test"},
+			},
+			// Only RE is cached, so cache hit expected for RE matcher
+			expectCacheAction: CacheHit,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cacheHitsBefore := getMetricValue(converter.metrics.cacheHitCount)
+			cacheMissesBefore := getMetricValue(converter.metrics.cacheMissCount)
+
+			promMatchers, err := converter.MatchersToPromMatchers(c.inputMatchers...)
+
+			if c.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, promMatchers, len(c.inputMatchers))
+
+			for i, m := range promMatchers {
+				require.Equal(t, c.inputMatchers[i].Name, m.Name)
+				require.Equal(t, c.inputMatchers[i].Value, m.Value)
+			}
+
+			if c.expectCacheAction == CacheHit {
+				require.Equal(t, cacheHitsBefore+1, getMetricValue(converter.metrics.cacheHitCount))
+				require.Equal(t, cacheMissesBefore, getMetricValue(converter.metrics.cacheMissCount))
+			} else if c.expectCacheAction == CacheMiss {
+				require.Equal(t, cacheHitsBefore, getMetricValue(converter.metrics.cacheHitCount))
+				require.Equal(t, cacheMissesBefore+1, getMetricValue(converter.metrics.cacheMissCount))
+			} else {
+				require.Equal(t, cacheHitsBefore, getMetricValue(converter.metrics.cacheHitCount))
+				require.Equal(t, cacheMissesBefore, getMetricValue(converter.metrics.cacheMissCount))
 			}
 		})
 	}

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -786,24 +786,21 @@ func BenchmarkMatcherConverter_REWithAndWithoutCache(b *testing.B) {
 
 	b.Run("Without Cache", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			for _, lm := range nonTrivialRegexes {
-				_, err := MatcherToPromMatcher(lm)
-				require.NoError(b, err)
-			}
+			_, err := MatchersToPromMatchers(nonTrivialRegexes...)
+			require.NoError(b, err)
 		}
 	})
 
 	b.Run("With Cache", func(b *testing.B) {
+		// cache warm-up
 		for _, lm := range nonTrivialRegexes {
 			_, err := converter.MatchersToPromMatchers(lm)
 			require.NoError(b, err)
 		}
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			for _, lm := range nonTrivialRegexes {
-				_, err := converter.MatchersToPromMatchers(lm)
-				require.NoError(b, err)
-			}
+			_, err := converter.MatchersToPromMatchers(nonTrivialRegexes...)
+			require.NoError(b, err)
 		}
 	})
 }

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -251,10 +251,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_Ser
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, s.getExtLset())
-	if err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, s.getExtLset())
 
 	if !match {
 		return nil
@@ -382,10 +379,7 @@ func (s *TSDBStore) LabelNames(ctx context.Context, r *storepb.LabelNamesRequest
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, s.getExtLset())
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, s.getExtLset())
 
 	if !match {
 		return &storepb.LabelNamesResponse{Names: nil}, nil
@@ -448,10 +442,7 @@ func (s *TSDBStore) LabelValues(ctx context.Context, r *storepb.LabelValuesReque
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	match, matchers, err := matchesExternalLabels(matchers, s.getExtLset())
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
+	match, matchers := matchesExternalLabels(matchers, s.getExtLset())
 	if !match {
 		return &storepb.LabelValuesResponse{}, nil
 	}

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -53,6 +53,12 @@ func WithCuckooMetricNameStoreFilter() TSDBStoreOption {
 	}
 }
 
+func WithTSDBStoreMatcherConverter(mc *storepb.MatcherConverter) TSDBStoreOption {
+	return func(s *TSDBStore) {
+		s.matcherConverter = mc
+	}
+}
+
 // TSDBStore implements the store API against a local TSDB instance.
 // It attaches the provided external labels to all results. It only responds with raw data
 // and does not support downsampling.
@@ -69,6 +75,7 @@ type TSDBStore struct {
 	mtx                    sync.RWMutex
 	close                  func()
 	storepb.UnimplementedStoreServer
+	matcherConverter *storepb.MatcherConverter
 }
 
 func (s *TSDBStore) Close() {

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -53,6 +53,7 @@ func WithCuckooMetricNameStoreFilter() TSDBStoreOption {
 	}
 }
 
+// WithTSDBStoreMatcherConverter returns a TSDBStoreOption that enables caching matcher converter for TSDBStore.
 func WithTSDBStoreMatcherConverter(mc *storepb.MatcherConverter) TSDBStoreOption {
 	return func(s *TSDBStore) {
 		s.matcherConverter = mc
@@ -244,6 +245,7 @@ func (s *TSDBStore) SeriesLocal(ctx context.Context, r *storepb.SeriesRequest) (
 	return rs.series, nil
 }
 
+// MatchersToPromMatchers converts storepb label matchers to prometheus label matchers. It goes to cache if matcherConverter is set.
 func (s *TSDBStore) MatchersToPromMatchers(ms ...storepb.LabelMatcher) ([]*labels.Matcher, error) {
 	var tms []*labels.Matcher
 	var err error

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -247,7 +247,11 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_Ser
 		srv = fs
 	}
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset())
+	matchers, err := storepb.MatchersToPromMatchers(r.Matchers...)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, s.getExtLset())
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -374,7 +378,11 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_Ser
 func (s *TSDBStore) LabelNames(ctx context.Context, r *storepb.LabelNamesRequest) (
 	*storepb.LabelNamesResponse, error,
 ) {
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset())
+	matchers, err := storepb.MatchersToPromMatchers(r.Matchers...)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, s.getExtLset())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -436,7 +444,11 @@ func (s *TSDBStore) LabelValues(ctx context.Context, r *storepb.LabelValuesReque
 		}
 	}
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset())
+	matchers, err := storepb.MatchersToPromMatchers(r.Matchers...)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	match, matchers, err := matchesExternalLabels(matchers, s.getExtLset())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}


### PR DESCRIPTION
bechmark shows 100x speedup if hit rate is 100%. More tests in https://github.com/databricks-eng/universe/pull/837859
goos: darwin
goarch: arm64
pkg: github.com/thanos-io/thanos/pkg/store/storepb
cpu: Apple M1 Max
BenchmarkMatcherConverter_REWithAndWithoutCache
BenchmarkMatcherConverter_REWithAndWithoutCache/Without_Cache
BenchmarkMatcherConverter_REWithAndWithoutCache/Without_Cache-10         	   29792	     42061 ns/op
BenchmarkMatcherConverter_REWithAndWithoutCache/With_Cache
BenchmarkMatcherConverter_REWithAndWithoutCache/With_Cache-10            	 3147709	       371.9 ns/op
PASS