### PR TITLE
Reject series/write requests when max pending request limit is hit

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -420,20 +420,8 @@ func runReceive(
 			store.LazyRetrieval,
 			options...,
 		)
-		if conf.maxPendingGrpcReadRequests > 0 {
-			level.Info(logger).Log(
-				"msg", "set max pending gRPC read request in instrumented store server",
-				"max_pending_requests", conf.maxPendingGrpcReadRequests,
-			)
-		}
-		mts := store.NewLimitedStoreServerWithOptions(
-			store.NewInstrumentedStoreServer(reg, proxy),
-			reg,
-			conf.storeRateLimits,
-			store.LimitsOptions{
-				MaxPendingSeriesRequests: int32(conf.maxPendingGrpcReadRequests),
-			},
-		)
+
+		mts := store.NewLimitedStoreServer(store.NewInstrumentedStoreServer(reg, proxy), reg, conf.storeRateLimits)
 		rw := store.ReadWriteTSDBStore{
 			StoreServer:          mts,
 			WriteableStoreServer: webHandler,
@@ -999,7 +987,6 @@ type receiveConfig struct {
 	topMetricsMinimumCardinality  uint64
 	topMetricsUpdateInterval      time.Duration
 	matcherConverterCacheCapacity int
-	maxPendingGrpcReadRequests    int
 	maxPendingGrpcWriteRequests   int
 
 	featureList *[]string
@@ -1165,9 +1152,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("5m").DurationVar(&rc.topMetricsUpdateInterval)
 	cmd.Flag("receive.store-matcher-converter-cache-capacity", "The number of label matchers to cache in the matcher converter for the Store API. Set to 0 to disable to cache. Default is 0.").
 		Default("0").IntVar(&rc.matcherConverterCacheCapacity)
-	cmd.Flag("receive.max-pending-grcp-read-requests", "Throttle gRPC read requests when this number of requests are pending. Value 0 disables this feature.").
-		Default("0").IntVar(&rc.maxPendingGrpcReadRequests)
-	cmd.Flag("receive.max-pending-grcp-write-requests", "Throttle gRPC write requests when this number of requests are pending. Value 0 disables this feature.").
+	cmd.Flag("receive.max-pending-grcp-write-requests", "Reject right away gRPC write requests when this number of requests are pending. Value 0 disables this feature.").
 		Default("0").IntVar(&rc.maxPendingGrpcWriteRequests)
 	rc.featureList = cmd.Flag("enable-feature", "Comma separated experimental feature names to enable. The current list of features is "+metricNamesFilter+".").Default("").Strings()
 }

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -36,7 +36,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -142,9 +141,6 @@ type Handler struct {
 	writeTimeseriesTotal *prometheus.HistogramVec
 	writeE2eLatency      *prometheus.HistogramVec
 
-	pendingWriteRequests        prometheus.Gauge
-	pendingWriteRequestsCounter atomic.Int32
-
 	Limiter *Limiter
 }
 
@@ -234,12 +230,6 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 				Help:      "The end-to-end latency of write requests.",
 				Buckets:   []float64{1, 5, 10, 20, 30, 40, 50, 60, 90, 120, 300, 600, 900, 1200, 1800, 3600},
 			}, []string{"code", "tenant", "rollup"},
-		),
-		pendingWriteRequests: promauto.With(registerer).NewGauge(
-			prometheus.GaugeOpts{
-				Name: "thanos_receive_pending_write_requests",
-				Help: "The number of pending write requests.",
-			},
 		),
 	}
 
@@ -1083,11 +1073,14 @@ func quorumReached(successes []int, successThreshold int) bool {
 
 // RemoteWrite implements the gRPC remote write handler for storepb.WriteableStore.
 func (h *Handler) RemoteWrite(ctx context.Context, r *storepb.WriteRequest) (*storepb.WriteResponse, error) {
+	if h.Limiter.ShouldRejectNewRequest() {
+		return nil, status.Error(codes.ResourceExhausted, "too many pending write requests")
+	}
+	// NB: ShouldRejectNewRequest() increments the number of pending requests only when it returns false.
+	defer h.Limiter.DecrementPendingRequests()
+
 	span, ctx := tracing.StartSpan(ctx, "receive_grpc")
 	defer span.Finish()
-
-	h.pendingWriteRequests.Set(float64(h.pendingWriteRequestsCounter.Add(1)))
-	defer h.pendingWriteRequestsCounter.Add(-1)
 
 	_, err := h.handleRequest(ctx, uint64(r.Replica), r.Tenant, &prompb.WriteRequest{Timeseries: r.Timeseries})
 	if err != nil {

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -112,7 +112,7 @@ func NewLimiterWithOptions(
 	r ReceiverMode,
 	logger log.Logger,
 	configReloadTimer time.Duration,
-	config LimiterOptions) (*Limiter, error) {
+	opts LimiterOptions) (*Limiter, error) {
 	limiter := &Limiter{
 		writeGate:          gate.NewNoop(),
 		requestLimiter:     &noopRequestLimiter{},
@@ -120,7 +120,7 @@ func NewLimiterWithOptions(
 		logger:             logger,
 		receiverMode:       r,
 		configReloadTimer:  configReloadTimer,
-		maxPendingRequests: config.MaxPendingRequests,
+		maxPendingRequests: opts.MaxPendingRequests,
 	}
 
 	if reg != nil {

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -18,6 +18,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/gate"
+
+	"go.uber.org/atomic"
 )
 
 // Limiter is responsible for managing the configuration and initialization of
@@ -35,6 +37,19 @@ type Limiter struct {
 	configReloadFailedCounter prometheus.Counter
 	receiverMode              ReceiverMode
 	configReloadTimer         time.Duration
+
+	// Reject a request if this limit is reached.
+	// This filed is set at the instance creation and never changes afterwards.
+	// So it's safe to read it without a lock.
+	maxPendingRequests        int32
+	maxPendingRequestLimitHit prometheus.Counter
+	pendingRequests           atomic.Int32
+	pendingRequestsGauge      prometheus.Gauge
+}
+
+type LimiterOptions struct {
+	// Value 0 disables the max pending request limiting hehavior.
+	MaxPendingRequests int32
 }
 
 // headSeriesLimiter encompasses active/head series limiting logic.
@@ -62,16 +77,50 @@ func (l *Limiter) HeadSeriesLimiter() headSeriesLimiter {
 	return l.headSeriesLimiter
 }
 
+func (l *Limiter) ShouldRejectNewRequest() bool {
+	// maxPendingRequests doesn't change once set when a limiter instance is created.
+	// So, it's safe to read it without a lock.
+	if l.maxPendingRequests > 0 && l.pendingRequests.Load() >= l.maxPendingRequests {
+		if l.maxPendingRequestLimitHit != nil {
+			l.maxPendingRequestLimitHit.Inc()
+		}
+		return true
+	}
+	newValue := l.pendingRequests.Add(1)
+	if l.pendingRequestsGauge != nil {
+		l.pendingRequestsGauge.Set(float64(newValue))
+	}
+	return false
+}
+
+func (l *Limiter) DecrementPendingRequests() {
+	newValue := l.pendingRequests.Add(-1)
+	if l.pendingRequestsGauge != nil {
+		l.pendingRequestsGauge.Set(float64(newValue))
+	}
+}
+
 // NewLimiter creates a new *Limiter given a configuration and prometheus
 // registerer.
 func NewLimiter(configFile fileContent, reg prometheus.Registerer, r ReceiverMode, logger log.Logger, configReloadTimer time.Duration) (*Limiter, error) {
+	return NewLimiterWithOptions(configFile, reg, r, logger, configReloadTimer, LimiterOptions{})
+}
+
+func NewLimiterWithOptions(
+	configFile fileContent,
+	reg prometheus.Registerer,
+	r ReceiverMode,
+	logger log.Logger,
+	configReloadTimer time.Duration,
+	config LimiterOptions) (*Limiter, error) {
 	limiter := &Limiter{
-		writeGate:         gate.NewNoop(),
-		requestLimiter:    &noopRequestLimiter{},
-		headSeriesLimiter: NewNopSeriesLimit(),
-		logger:            logger,
-		receiverMode:      r,
-		configReloadTimer: configReloadTimer,
+		writeGate:          gate.NewNoop(),
+		requestLimiter:     &noopRequestLimiter{},
+		headSeriesLimiter:  NewNopSeriesLimit(),
+		logger:             logger,
+		receiverMode:       r,
+		configReloadTimer:  configReloadTimer,
+		maxPendingRequests: config.MaxPendingRequests,
 	}
 
 	if reg != nil {
@@ -90,6 +139,26 @@ func NewLimiter(configFile fileContent, reg prometheus.Registerer, r ReceiverMod
 				Subsystem: "receive",
 				Name:      "limits_config_reload_err_total",
 				Help:      "How many times the limit configuration failed to reload.",
+			},
+		)
+		limiter.configReloadFailedCounter = promauto.With(limiter.registerer).NewCounter(
+			prometheus.CounterOpts{
+				Namespace: "thanos",
+				Subsystem: "receive",
+				Name:      "limits_config_reload_err_total",
+				Help:      "How many times the limit configuration failed to reload.",
+			},
+		)
+		limiter.maxPendingRequestLimitHit = promauto.With(limiter.registerer).NewCounter(
+			prometheus.CounterOpts{
+				Name: "thanos_receive_max_pending_write_request_limit_hit_total",
+				Help: "Number of times the max pending write request limit was hit",
+			},
+		)
+		limiter.pendingRequestsGauge = promauto.With(limiter.registerer).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "thanos_receive_pending_write_requests",
+				Help: "Number of pending write requests",
 			},
 		)
 	}


### PR DESCRIPTION
This is to prevent Receive server from begin overloaded

### Tested in `dev-aws-eu-west-1`
```
[dev-aws-eu-west-1] [pantheon] [pantheon-db-rep0-0] > logs | rg pending
ts=2024-12-17T17:38:14.728273143Z caller=receive.go:272 level=info name=pantheon-db component=receive msg="set max pending gRPC write request in limiter" max_pending_requests=1000
```
<img width="1660" alt="image" src="https://github.com/user-attachments/assets/a22260ca-3158-4d7c-bec2-567679ca9c67" />
