### PR TITLE
add n tenants metrics after tsdb pruning

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -503,6 +503,10 @@ func runReceive(
 
 	level.Debug(logger).Log("msg", "setting up periodic tenant pruning")
 	{
+		nTenantsMetric := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "thanos_receive_n_tenants",
+			Help: "Number of tenants in multi TSDB.",
+		})
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
 			pruneInterval := 2 * time.Duration(tsdbOpts.MaxBlockDuration) * time.Millisecond
@@ -515,6 +519,7 @@ func runReceive(
 				if err := dbs.Prune(ctx); err != nil {
 					level.Error(logger).Log("err", err)
 				}
+				nTenantsMetric.Set(float64(dbs.GetNTenants()))
 				return nil
 			})
 		}, func(err error) {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -137,6 +137,12 @@ func (t *MultiTSDB) GetTenants() []string {
 	return tenants
 }
 
+func (t *MultiTSDB) GetNTenants() int {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	return len(t.tenants)
+}
+
 // testGetTenant returns the tenant with the given tenantID for testing purposes.
 func (t *MultiTSDB) testGetTenant(tenantID string) *tenant {
 	t.mtx.RLock()


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
