### PR TITLE
receiver: Add hot reload for relabel configs

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -1087,7 +1087,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	rc.relabelConfigPath = extflag.RegisterPathOrContent(cmd, "receive.relabel-config", "YAML file that contains relabeling configuration.", extflag.WithEnvSubstitution())
 	cmd.Flag("receive.relabel-config-reload-timer", "Minimum amount of time to pass for the relabel configuration to be reloaded. Helps to avoid excessive reloads.").
-		Default("1s").Hidden().DurationVar(&rc.relabelConfigReloadTimer)
+		Default("0s").Hidden().DurationVar(&rc.relabelConfigReloadTimer)
 
 	rc.tsdbMinBlockDuration = extkingpin.ModelDuration(cmd.Flag("tsdb.min-block-duration", "Min duration for local TSDB blocks").Default("2h").Hidden())
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1733,7 +1733,7 @@ func TestRelabel(t *testing.T) {
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
 			h := NewHandler(nil, &Options{
-				RelabelConfigs: tcase.relabel,
+				Relabeller: newRelabelerWithConstantConfig(tcase.relabel, nil),
 			})
 
 			h.relabel(&tcase.writeRequest)

--- a/pkg/receive/interfaces.go
+++ b/pkg/receive/interfaces.go
@@ -1,0 +1,10 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+// fileContent is an interface to avoid a direct dependency on kingpin or extkingpin.
+type fileContent interface {
+	Content() ([]byte, error)
+	Path() string
+}

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -64,12 +64,6 @@ type requestLimiter interface {
 	AllowSamples(tenant string, amount int64) bool
 }
 
-// fileContent is an interface to avoid a direct dependency on kingpin or extkingpin.
-type fileContent interface {
-	Content() ([]byte, error)
-	Path() string
-}
-
 func (l *Limiter) HeadSeriesLimiter() headSeriesLimiter {
 	l.headSeriesLimiterMtx.Lock()
 	defer l.headSeriesLimiterMtx.Unlock()
@@ -133,14 +127,6 @@ func NewLimiterWithOptions(
 				Subsystem: "receive",
 				Name:      "limits_config_reload_total",
 				Help:      "How many times the limit configuration was reloaded",
-			},
-		)
-		limiter.configReloadFailedCounter = promauto.With(limiter.registerer).NewCounter(
-			prometheus.CounterOpts{
-				Namespace: "thanos",
-				Subsystem: "receive",
-				Name:      "limits_config_reload_err_total",
-				Help:      "How many times the limit configuration failed to reload.",
 			},
 		)
 		limiter.configReloadFailedCounter = promauto.With(limiter.registerer).NewCounter(

--- a/pkg/receive/relabeller.go
+++ b/pkg/receive/relabeller.go
@@ -1,0 +1,144 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"go.uber.org/atomic"
+	"gopkg.in/yaml.v2"
+)
+
+// Relabeller is responsible for managing the configuration and initialization of
+// different types that apply relabel configurations to the Receive instance.
+// The new config is atomically swapped in, so we don't need to use locks.
+type Relabeller struct {
+	configPathOrContent       fileContent
+	relabelConfigs            *atomic.Pointer[RelabelConfig]
+	logger                    log.Logger
+	configReloadCounter       prometheus.Counter
+	configReloadFailedCounter prometheus.Counter
+	configReloadTimer         time.Duration
+}
+
+// RelabelConfig is a collection of relabel configurations.
+type RelabelConfig []*relabel.Config
+
+// NewRelabeller creates a new relabeller and loads the configuration to make sure loading is possible.
+func NewRelabeller(configFile fileContent, reg prometheus.Registerer, logger log.Logger, configReloadTimer time.Duration) (*Relabeller, error) {
+	var relabelConfigs atomic.Pointer[RelabelConfig]
+	relabelConfigs.Store(&RelabelConfig{})
+	relabeller := &Relabeller{
+		configPathOrContent: configFile,
+		relabelConfigs:      &relabelConfigs,
+		logger:              logger,
+		configReloadTimer:   configReloadTimer,
+	}
+
+	if reg != nil {
+		relabeller.configReloadCounter = promauto.With(reg).NewCounter(
+			prometheus.CounterOpts{
+				Namespace: "thanos",
+				Subsystem: "receive",
+				Name:      "relabel_config_reload_total",
+				Help:      "How many times the relabel configuration was reloaded",
+			},
+		)
+		relabeller.configReloadFailedCounter = promauto.With(reg).NewCounter(
+			prometheus.CounterOpts{
+				Namespace: "thanos",
+				Subsystem: "receive",
+				Name:      "relabel_config_reload_err_total",
+				Help:      "How many times the relabel configuration failed to reload.",
+			},
+		)
+	}
+	if configFile == nil {
+		return relabeller, nil
+	}
+	relabeller.configPathOrContent = configFile
+	if err := relabeller.loadConfig(); err != nil {
+		return nil, errors.Wrap(err, "load relabel config")
+	}
+	return relabeller, nil
+}
+
+// simply returns the provided config. This is useful for testing.
+func newRelabelerWithConstantConfig(config RelabelConfig, logger log.Logger) *Relabeller {
+	var relabelConfigs atomic.Pointer[RelabelConfig]
+	relabelConfigs.Store(&config)
+	return &Relabeller{nil, &relabelConfigs, logger, nil, nil, 0}
+}
+
+// RelabelConfig returns the current relabel config.
+// This is concurrent safe.
+func (r *Relabeller) RelabelConfig() RelabelConfig {
+	if r == nil {
+		var relabelConfig RelabelConfig
+		return relabelConfig
+	}
+	return *r.relabelConfigs.Load()
+}
+
+// setRelabelConfig sets the relabel config to the provided array.
+// This is concurrent safe.
+func (r *Relabeller) setRelabelConfig(configs RelabelConfig) {
+	r.relabelConfigs.Store(&configs)
+}
+
+func (r *Relabeller) loadConfig() error {
+	relabelContentYaml, err := r.configPathOrContent.Content()
+	if err != nil {
+		return errors.Wrap(err, "getting content of relabel config")
+	}
+	var relabelConfig RelabelConfig
+	if err := yaml.Unmarshal(relabelContentYaml, &relabelConfig); err != nil {
+		return errors.Wrap(err, "parsing relabel config")
+	}
+	r.setRelabelConfig(relabelConfig)
+	return nil
+}
+
+// StartConfigReloader starts the automatic configuration reloader based off of
+// the file indicated by pathOrContent.
+func (r *Relabeller) StartConfigReloader(ctx context.Context) error {
+	if !r.CanReload() {
+		return nil
+	}
+
+	return extkingpin.PathContentReloader(ctx, r.configPathOrContent, r.logger, func() {
+		level.Info(r.logger).Log("msg", "reloading relabel config.")
+
+		if err := r.loadConfig(); err != nil {
+			if failedReload := r.configReloadFailedCounter; failedReload != nil {
+				failedReload.Inc()
+			}
+			errMsg := fmt.Sprintf("error reloading relabel config from %s", r.configPathOrContent.Path())
+			level.Error(r.logger).Log("msg", errMsg, "err", err)
+		}
+		if reloadCounter := r.configReloadCounter; reloadCounter != nil {
+			reloadCounter.Inc()
+		}
+
+	}, r.configReloadTimer)
+}
+
+func (r *Relabeller) CanReload() bool {
+	if r.configPathOrContent == nil {
+		return false
+	}
+	if r.configPathOrContent.Path() == "" {
+		return false
+	}
+	return true
+}

--- a/pkg/receive/relabeller.go
+++ b/pkg/receive/relabeller.go
@@ -134,6 +134,9 @@ func (r *Relabeller) StartConfigReloader(ctx context.Context) error {
 }
 
 func (r *Relabeller) CanReload() bool {
+	if r.configReloadTimer == 0 {
+		return false
+	}
 	if r.configPathOrContent == nil {
 		return false
 	}

--- a/pkg/receive/relabeller_test.go
+++ b/pkg/receive/relabeller_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/thanos-io/thanos/pkg/extkingpin"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+)
+
+func TestRelabeller_ConfigReload(t *testing.T) {
+	t.Parallel()
+
+	// Load the test data
+	origRelabels, err := os.ReadFile("./testdata/relabel_config/good_relabels.yaml")
+	testutil.Ok(t, err)
+	invalidRelabels, err := os.ReadFile("./testdata/relabel_config/invalid_relabels.yaml")
+	testutil.Ok(t, err)
+	newRelabels, err := os.ReadFile("./testdata/relabel_config/good_relabels2.yaml")
+	testutil.Ok(t, err)
+
+	// Copy the original relabels file to a temporary directory.
+	tempFilePath := path.Join(t.TempDir(), "relabels.yaml")
+	testutil.Ok(t, os.WriteFile(tempFilePath, origRelabels, 0666))
+
+	// Create a relabeller with the relabels file in the temporary directory.
+	relabelFile, err := extkingpin.NewStaticPathContent(tempFilePath)
+	testutil.Ok(t, err)
+	relabeller, err := NewRelabeller(relabelFile, nil, log.NewLogfmtLogger(os.Stdout), 1*time.Second)
+	testutil.Ok(t, err)
+
+	config := relabeller.RelabelConfig()
+	origRelabelsConfig, err := parseRelabel("./testdata/relabel_config/good_relabels.yaml")
+	testutil.Ok(t, err)
+	testutil.Equals(t, origRelabelsConfig, config)
+
+	// Start the config reloader.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err = relabeller.StartConfigReloader(ctx)
+	testutil.Ok(t, err)
+
+	// Rewrite the relabels file in temp with an invalid file, should not update the config.
+	testutil.Ok(t, relabelFile.Rewrite(invalidRelabels))
+	time.Sleep(1 * time.Second)
+	testutil.Equals(t, origRelabelsConfig, relabeller.RelabelConfig())
+
+	// Rewrite the relabels file in temp with a different valid file.
+	testutil.Ok(t, relabelFile.Rewrite(newRelabels))
+	newRelabelsConfig, err := parseRelabel("./testdata/relabel_config/good_relabels2.yaml")
+	testutil.Ok(t, err)
+	time.Sleep(1 * time.Second)
+	testutil.Equals(t, newRelabelsConfig, relabeller.RelabelConfig())
+}
+
+func parseRelabel(path string) (RelabelConfig, error) {
+	var relabelConfig RelabelConfig
+	file, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	err = yaml.UnmarshalStrict(file, &relabelConfig)
+	if err != nil {
+		return nil, err
+	}
+	return relabelConfig, nil
+}
+
+func TestRelabeller_CanReload(t *testing.T) {
+	t.Parallel()
+
+	validRelabelsPath, err := extkingpin.NewStaticPathContent("./testdata/relabel_config/good_relabels.yaml")
+	testutil.Ok(t, err)
+	emptyRelabelsPath := emptyPathFile{}
+
+	type args struct {
+		configFilePath fileContent
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantReload bool
+	}{
+		{
+			name:       "Nil config file path cannot be reloaded",
+			args:       args{configFilePath: nil},
+			wantReload: false,
+		},
+		{
+			name:       "Empty config file path cannot be reloaded",
+			args:       args{configFilePath: emptyRelabelsPath},
+			wantReload: false,
+		},
+		{
+			name:       "Valid config file path can be reloaded",
+			args:       args{configFilePath: validRelabelsPath},
+			wantReload: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configFile := tt.args.configFilePath
+			relabeller, err := NewRelabeller(configFile, nil, log.NewLogfmtLogger(os.Stdout), 1*time.Second)
+			testutil.Ok(t, err)
+			if tt.wantReload {
+				testutil.Assert(t, relabeller.CanReload())
+			} else {
+				testutil.Assert(t, !relabeller.CanReload())
+			}
+		})
+	}
+}

--- a/pkg/receive/testdata/relabel_config/good_relabels.yaml
+++ b/pkg/receive/testdata/relabel_config/good_relabels.yaml
@@ -1,0 +1,5 @@
+- action: keep
+  source_labels: [__name__]
+  regex: "http_requests_total|cpu_usage"
+- action: labelmap
+  regex: "__meta_kubernetes_pod_label_(.+)"  # Map Kubernetes labels

--- a/pkg/receive/testdata/relabel_config/good_relabels2.yaml
+++ b/pkg/receive/testdata/relabel_config/good_relabels2.yaml
@@ -1,0 +1,8 @@
+- action: keep
+  source_labels: [__name__]
+  regex: "http_requests_total|cpu_usage"
+- action: labelmap
+  regex: "__meta_kubernetes_pod_label_(.+)"  # Map Kubernetes labels
+- action: drop
+  source_labels: [__name__]
+  regex: "^zippy_data_apply_latency_millis_bucket$"

--- a/pkg/receive/testdata/relabel_config/invalid_relabels.yaml
+++ b/pkg/receive/testdata/relabel_config/invalid_relabels.yaml
@@ -1,0 +1,5 @@
+- action: unknown # This is invalid
+  source_labels: [__name__]
+  regex: "http_requests_total|cpu_usage"  # Only keep specific metrics
+- action: labelmap
+  regex: "__meta_kubernetes_pod_label_(.+)"  # Map Kubernetes labels


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Receiver to hot reload the relabel configs file. Implementation is similar to the receiever limits config file which already supports hot reload.

## Verification
- [x] Unit tests
- [x] Deployed to dev-aws-us-east-1-obs-integrationtest 
	- [x] no Crash Loop
- [x] Deployed to dev-azure-westus
	- [x] No crash loop, alerts firing 
