### PR TITLE
Add a tool to stream a metric

### DIFF
--- a/cmd/thanos/tools.go
+++ b/cmd/thanos/tools.go
@@ -28,6 +28,7 @@ func registerTools(app *extkingpin.App) {
 
 	registerBucket(cmd)
 	registerCheckRules(cmd)
+	registerStreamMetric(cmd)
 }
 
 func (tc *checkRulesConfig) registerFlag(cmd extkingpin.FlagClause) *checkRulesConfig {

--- a/cmd/thanos/tools_metric.go
+++ b/cmd/thanos/tools_metric.go
@@ -1,0 +1,147 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/run"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type rawMetricConfig struct {
+	storeAddr  string
+	metric     string
+	hoursAgo   int
+	skipChunks bool
+}
+
+func registerFlags(cmd extkingpin.FlagClause) *rawMetricConfig {
+	conf := &rawMetricConfig{}
+	cmd.Flag("store", "Thanos Store API gRPC endpoint").Default("localhost:10901").StringVar(&conf.storeAddr)
+	cmd.Flag("metric", "The metric name to stream time series for this metric").Default("node_cpu_seconds_total").StringVar(&conf.metric)
+	cmd.Flag("hours_ago", "Stream the metric from this number of hours ago").Default("16").IntVar(&conf.hoursAgo)
+	cmd.Flag("skip_chunks", "Skip chunks in the response").Default("false").BoolVar(&conf.skipChunks)
+	return conf
+}
+
+func registerStreamMetric(app extkingpin.AppClause) {
+	cmd := app.Command("metric", "Stream time series for a metric")
+
+	conf := registerFlags(cmd)
+	cmd.Setup(func(
+		g *run.Group,
+		logger log.Logger,
+		_ *prometheus.Registry,
+		_ opentracing.Tracer,
+		_ <-chan struct{},
+		_ bool) error {
+		// Dummy actor to immediately kill the group after the run function returns.
+		g.Add(func() error { return nil }, func(error) {})
+		return streamMetric(conf, logger)
+	})
+}
+
+func streamMetric(conf *rawMetricConfig, logger log.Logger) error {
+	nowMs := time.Now().Unix() * 1000
+	startMs := nowMs - int64(conf.hoursAgo)*3600*1000
+	conn, err := grpc.Dial(
+		conf.storeAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		level.Error(logger).Log("msg", "Failed to create gRPC client", "err", err, "store", conf.storeAddr)
+		return err
+	}
+	storeClient := storepb.NewStoreClient(conn)
+	labelMatchers := []storepb.LabelMatcher{
+		{Type: storepb.LabelMatcher_EQ, Name: "__name__", Value: conf.metric},
+	}
+	storeReq := &storepb.SeriesRequest{
+		Aggregates: []storepb.Aggr{storepb.Aggr_RAW},
+		Matchers:   labelMatchers,
+		MinTime:    startMs,
+		MaxTime:    4*3600*1000 + startMs,
+		SkipChunks: conf.skipChunks,
+	}
+
+	level.Info(logger).Log(
+		"msg", "sending a gRPC call to store",
+		"num_label_matchers", len(storeReq.Matchers),
+		"label_matchers", fmt.Sprintf("%+v", storeReq.Matchers),
+		"req", storeReq.String(),
+	)
+
+	storeRes, err := storeClient.Series(context.Background(), storeReq)
+	if err != nil {
+		return err
+	}
+	seq := 0
+	for ; true; seq++ {
+		resPtr, err := storeRes.Recv()
+		if err == io.EOF {
+			level.Info(logger).Log("msg", "Got EOF from store")
+			break
+		}
+		if err != nil {
+			return err
+		}
+		series := resPtr.GetSeries()
+		if series == nil {
+			return fmt.Errorf("Got a nil series")
+		}
+		if 0 == (seq % 1000) {
+			level.Info(logger).Log("msg", "streaming time series", "seq", seq)
+		}
+		metric := ""
+		fmt.Printf("{")
+		for _, label := range series.Labels {
+			name := strings.Clone(label.Name)
+			value := strings.Clone(label.Value)
+			fmt.Printf("%s=%s,", label.Name, label.Value)
+			if name == labels.MetricName {
+				metric = value
+			}
+		}
+		fmt.Printf("}")
+		if metric != conf.metric {
+			return fmt.Errorf("%d-th time series from the response has a different metric name:\n   Actual: %+v\n   Expected: %+v",
+				seq, []byte(metric), []byte(conf.metric))
+		}
+		order := 0
+		for _, chunk := range series.Chunks {
+			raw, err := chunkenc.FromData(chunkenc.EncXOR, chunk.Raw.Data)
+			if err != nil {
+				level.Error(logger).Log("err", err, "msg", "error in decoding chunk")
+				continue
+			}
+
+			iter := raw.Iterator(nil)
+			for iter.Next() != chunkenc.ValNone {
+				ts, value := iter.At()
+				if order < 5 {
+					fmt.Printf(" %f @%d,", value, ts)
+				}
+				order++
+			}
+		}
+		fmt.Printf("\n")
+	}
+	level.Info(logger).Log("msg", "successfully streamed all time series for the metric", "metric", conf.metric, "num_series", seq)
+	return nil
+}


### PR DESCRIPTION
This is a new sub-command in Thanos binary's command tool.
```
$ make build
$ ~/go/bin/thanos tools metric --metric is_leader

ts=2025-02-06T05:50:08.75096Z caller=tools_metric.go:83 level=info msg="sending a gRPC call to store" num_label_matchers=1 label_matchers="[{Type:EQ Name:__name__ Value:is_leader}]" req="min_time:1738763408000 max_time:1738777808000 matchers:<name:\"__name__\" value:\"is_leader\" > aggregates:RAW "
ts=2025-02-06T05:50:09.191885Z caller=tools_metric.go:109 level=info msg="streaming time series" seq=0
{__name__=is_leader,__tenant__=eng-monitoring-platform,app=rulemanager,cloud=aws,cloud_provider=AWS,cloud_provider_region=AWS_US_WEST_2,component=rulemanager,db_environment=DEV,db_regulatory_domain=PUBLIC,env=dev,instance=10.6.127.63:7777,job=kubernetes-pods,kubernetes_cluster_type=GENERAL_CLASSIC,kubernetes_cluster_uri=kubernetes-cluster:dev/aws/public/us-west-2/gc/01,kubernetes_namespace=m3,kubernetes_pod_name=rulemanager-597bf4d4cd-w7vnr,kubernetes_pod_node_name=ip-10-20-9-147.us-west-2.compute.internal,project=rulemanager,region=us-west-2,region_uri=region:dev/aws/public/us-west-2,shardName=oregon-dev,system=rulemanager,} 0.000000 @1738760426428, 0.000000 @1738760456428, 0.000000 @1738760486428, 0.000000 @1738760516437, 0.000000 @1738760546428,
{__name__=is_leader,__tenant__=eng-monitoring-platform,app=rulemanager,cloud=aws,cloud_provider=AWS,cloud_provider_region=AWS_US_WEST_2,component=rulemanager,db_environment=DEV,db_regulatory_domain=PUBLIC,env=dev,instance=10.6.28.145:7777,job=kubernetes-pods,kubernetes_cluster_type=GENERAL_CLASSIC,kubernetes_cluster_uri=kubernetes-cluster:dev/aws/public/us-west-2/gc/01,kubernetes_namespace=m3,kubernetes_pod_name=rulemanager-597bf4d4cd-8fhd7,kubernetes_pod_node_name=ip-10-20-11-18.us-west-2.compute.internal,project=rulemanager,region=us-west-2,region_uri=region:dev/aws/public/us-west-2,shardName=oregon-dev,system=rulemanager,} 1.000000 @1738760420177, 1.000000 @1738760450177, 1.000000 @1738760480177, 1.000000 @1738760510177, 1.000000 @1738760540177,
{__name__=is_leader,__tenant__=eng-monitoring-platform,app=rulemanager,cloud=aws,cloud_provider=AWS,cloud_provider_region=AWS_US_WEST_2,component=rulemanager,db_environment=DEV,db_regulatory_domain=PUBLIC,env=dev,instance=10.6.54.46:7777,job=kubernetes-pods,kubernetes_cluster_type=GENERAL_CLASSIC,kubernetes_cluster_uri=kubernetes-cluster:dev/aws/public/us-west-2/gc/01,kubernetes_namespace=m3,kubernetes_pod_name=rulemanager-5995b448d8-wghw9,kubernetes_pod_node_name=ip-10-20-11-23.us-west-2.compute.internal,project=rulemanager,region=us-west-2,region_uri=region:dev/aws/public/us-west-2,shardName=oregon-dev,system=rulemanager,} 0.000000 @1738767840022, 0.000000 @1738767870022, 0.000000 @1738767900022, 0.000000 @1738767930022, 0.000000 @1738767960022,
{__name__=is_leader,__tenant__=eng-monitoring-platform,app=rulemanager,cloud=aws,cloud_provider=AWS,cloud_provider_region=AWS_US_WEST_2,component=rulemanager,db_environment=DEV,db_regulatory_domain=PUBLIC,env=dev,instance=10.6.97.96:7777,job=kubernetes-pods,kubernetes_cluster_type=GENERAL_CLASSIC,kubernetes_cluster_uri=kubernetes-cluster:dev/aws/public/us-west-2/gc/01,kubernetes_namespace=m3,kubernetes_pod_name=rulemanager-5995b448d8-4fjcz,kubernetes_pod_node_name=ip-10-20-10-73.us-west-2.compute.internal,project=rulemanager,region=us-west-2,region_uri=region:dev/aws/public/us-west-2,shardName=oregon-dev,system=rulemanager,} 0.000000 @1738767514537, 0.000000 @1738767544475, 0.000000 @1738767574475, 0.000000 @1738767604475, 0.000000 @1738767634475,
ts=2025-02-06T05:50:09.196323Z caller=tools_metric.go:98 level=info msg="Got EOF from store"
ts=2025-02-06T05:50:09.196343Z caller=tools_metric.go:145 level=info msg="successfully streamed all time series for the metric" metric=is_leader num_series=4
ts=2025-02-06T05:50:09.196836Z caller=main.go:174 level=info msg=exiting

```
