### PR TITLE
Introduce Thanos Streamer

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -62,6 +62,7 @@ func main() {
 	registerTools(app)
 	registerReceive(app)
 	registerQueryFrontend(app)
+	registerStreamer(app)
 
 	cmd, setup := app.Parse()
 	logger := logging.NewLogger(*logLevel, *logFormat, *debugName)

--- a/cmd/thanos/streamer.go
+++ b/cmd/thanos/streamer.go
@@ -1,0 +1,461 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/run"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/thanos-io/thanos/pkg/component"
+	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"github.com/thanos-io/thanos/pkg/prober"
+	httpserver "github.com/thanos-io/thanos/pkg/server/http"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/thanos-io/thanos/pkg/streamer"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type StreamerConfig struct {
+	socketPath           string
+	storeAddrPort        string
+	streamTimeoutSeconds int
+}
+
+func registerStreamer(app *extkingpin.App) {
+	config := StreamerConfig{}
+	cmd := app.Command("streamer", "Run a streamer Unix socket server")
+	cmd.Flag("socket.path", "Path to the Unix socket").Default("/tmp/thanos-streamer.sock").StringVar(&config.socketPath)
+	cmd.Flag("store", "Thanos Store API gRPC endpoint").Default("localhost:10901").StringVar(&config.storeAddrPort)
+	cmd.Flag("stream.timeout_seconds", "One stream's overall timeout in seconds ").Default("36000").IntVar(&config.streamTimeoutSeconds)
+
+	hc := &httpConfig{}
+	hc = hc.registerFlag(cmd)
+
+	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ <-chan struct{}, debugLogging bool) error {
+
+		httpProbe := prober.NewHTTP()
+		statusProber := httpProbe
+
+		srv := httpserver.New(logger, reg, component.Replicate, httpProbe,
+			httpserver.WithListen(hc.bindAddress),
+			httpserver.WithGracePeriod(time.Duration(hc.gracePeriod)),
+			httpserver.WithTLSConfig(hc.tlsConfig),
+			httpserver.WithEnableH2C(true), // For groupcache.
+		)
+
+		g.Add(func() error {
+			statusProber.Healthy()
+
+			return srv.ListenAndServe()
+		}, func(err error) {
+			statusProber.NotReady(err)
+			defer statusProber.NotHealthy(err)
+
+			srv.Shutdown(err)
+		})
+		streamer, err := NewStreamer(config, logger)
+		if err != nil {
+			return err
+		}
+		g.Add(func() error {
+			statusProber.Ready()
+			return streamer.Run()
+		}, func(error) {
+			statusProber.NotReady(err)
+			streamer.Stop()
+		})
+		return nil
+	})
+}
+
+type Streamer struct {
+	config   StreamerConfig
+	logger   log.Logger
+	grpcConn *grpc.ClientConn
+	wg       sync.WaitGroup
+	ctx      context.Context
+	cancel   context.CancelFunc
+	listener net.Listener
+	shutdown atomic.Bool
+}
+
+func NewStreamer(
+	config StreamerConfig,
+	logger log.Logger) (*Streamer, error) {
+	conn, err := grpc.NewClient(
+		config.storeAddrPort,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	level.Info(logger).Log("msg", "connected to Store gRPC server", "addr", config.storeAddrPort)
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Streamer{
+		config:   config,
+		logger:   logger,
+		grpcConn: conn,
+		ctx:      ctx,
+		cancel:   cancel,
+	}, nil
+}
+
+type aggrChunkByTimestamp []storepb.AggrChunk
+
+func (c aggrChunkByTimestamp) Len() int      { return len(c) }
+func (c aggrChunkByTimestamp) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c aggrChunkByTimestamp) Less(i, j int) bool {
+	return c[i].MinTime < c[j].MinTime ||
+		// Sort the longer time range first.
+		(c[i].MinTime == c[j].MinTime && c[i].MaxTime > c[j].MaxTime)
+}
+
+func convertToSeriesReq(streamerReq *streamer.StreamerRequest) *storepb.SeriesRequest {
+	req := &storepb.SeriesRequest{
+		Aggregates: []storepb.Aggr{storepb.Aggr_RAW},
+		Matchers:   make([]storepb.LabelMatcher, 0),
+		MinTime:    streamerReq.StartTimestampMs,
+		MaxTime:    streamerReq.EndTimestampMs,
+		SkipChunks: streamerReq.SkipChunks,
+	}
+	for _, labelMatcher := range streamerReq.LabelMatchers {
+		req.Matchers = append(req.Matchers, storepb.LabelMatcher{
+			Type:  storepb.LabelMatcher_Type(labelMatcher.Type),
+			Name:  labelMatcher.Name,
+			Value: labelMatcher.Value,
+		})
+	}
+	if streamerReq.Metric != "" {
+		req.Matchers = append(req.Matchers, storepb.LabelMatcher{
+			Type:  storepb.LabelMatcher_EQ,
+			Name:  labels.MetricName,
+			Value: streamerReq.Metric,
+		})
+	}
+	return req
+}
+
+// NB: writeBytes() is not atomic and may end up with a part of the bytes.
+func writeBytes(writer io.Writer, bytes ...[]byte) error {
+	for _, b := range bytes {
+		if n, err := writer.Write(b); err != nil || n < len(b) {
+			if err == nil {
+				err = fmt.Errorf("unexpected number of bytes written: %d != %d", n, len(b))
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// streamOneRequest() returns an error if any write fails. Partial data may be written.
+// The expectation is the client will retry a failed stream.
+func (s *Streamer) streamOneRequest(request *streamer.StreamerRequest, writer io.Writer) error {
+	chunksTotal := 0
+	timeSeriesTotal := int64(0)
+	samplesTotal := int64(0)
+	outOfTimeRangeSampleTotal := 0
+	outOfOrderSampleTotal := 0
+	duplicateSampleTotal := 0
+	storeReq := convertToSeriesReq(request)
+	responseSeq := 0
+
+	// Write on a socket connection can be blocked until the overall stream timeout (config.streamTimeoutSeconds)
+	// if the reader is not reading and the buffer is full.
+	writeResponse := func(resp *streamer.StreamerResponse) error {
+		stringToWrite, err := streamer.Encode(resp)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(stringToWrite, streamer.Deliminator) {
+			return fmt.Errorf("response contains a delimiter")
+		}
+		bytesToWrite := []byte(stringToWrite)
+		// The encoded response shouldn't container streamer.Deliminator.
+		level.Debug(s.logger).Log(
+			"msg", "writing a response",
+			"seq", responseSeq,
+			"encoded_size", len(bytesToWrite),
+			// "encoded_response", string(bytesToWrite),
+		)
+		responseSeq++
+		return writeBytes(writer, bytesToWrite, []byte(streamer.Deliminator))
+	}
+
+	level.Info(s.logger).Log(
+		"msg", "sending one series request to Store",
+		"request_id", request.RequestId,
+		"req", storeReq.String(),
+		"num_matchers", len(storeReq.Matchers),
+		"matchers", fmt.Sprintf("%+v", storeReq.Matchers),
+	)
+	storeClient := storepb.NewStoreClient(s.grpcConn)
+	storeRes, err := storeClient.Series(s.ctx, storeReq)
+	if err != nil {
+		level.Error(s.logger).Log(
+			"err", err, "msg",
+			"error in starting a streaming request to Store",
+			"request_id", request.RequestId,
+			"connection state", s.grpcConn.GetState().String(),
+		)
+		return writeResponse(&streamer.StreamerResponse{Err: err.Error()})
+	}
+
+	defer func() {
+		if timeSeriesTotal > 0 {
+			level.Info(s.logger).Log(
+				"msg", "finished one streaming request",
+				"request_id", request.RequestId,
+				"time_series_total", timeSeriesTotal,
+				"num_chunks", chunksTotal,
+				"num_samples", samplesTotal,
+				"minTimeMs", storeReq.MinTime,
+				"unix_time", time.Unix(storeReq.MinTime/1000, 0).UTC(),
+				"maxTimeMs", storeReq.MaxTime,
+				"out_of_time_range_samples", outOfTimeRangeSampleTotal,
+				"out_of_order_samples", outOfOrderSampleTotal,
+				"duplicate_samples", duplicateSampleTotal,
+			)
+		}
+	}()
+	// The call site may cancel the context to stop the streaming.
+	for !s.shutdown.Load() {
+		response, err := storeRes.Recv()
+		if err == io.EOF {
+			level.Info(s.logger).Log(
+				"msg", "a streaming request reached EOF",
+				"request_id", request.RequestId,
+				// storeReq.MinTime and storeRq.MaxTime are in milliseconds.
+				"minTimeTsMs", storeReq.MinTime,
+				"unix_time", time.Unix(storeReq.MinTime/1000, 0).UTC(),
+			)
+			return writeResponse(&streamer.StreamerResponse{Eof: true})
+		}
+		if err != nil {
+			level.Error(s.logger).Log("err", err, "msg", "error in recv() from Store gRPC stream")
+			return writeResponse(&streamer.StreamerResponse{Err: err.Error()})
+		}
+		if warning := response.GetWarning(); warning != "" {
+			level.Error(s.logger).Log(
+				"warning", warning,
+				"msg", "warning response from Store gRPC stream",
+				"request_id", request.RequestId)
+			return writeResponse(&streamer.StreamerResponse{Err: fmt.Sprintf("warning response from Store gRPC stream: %s", warning)})
+		}
+		seriesResp := response.GetSeries()
+		if seriesResp == nil {
+			err := fmt.Errorf("unexpectedly missing series data")
+			level.Error(s.logger).Log("err", err, "request_id", request.RequestId)
+			return writeResponse(&streamer.StreamerResponse{Err: err.Error()})
+		}
+		timeSeries := &streamer.TimeSeries{}
+		metricName := ""
+		for _, label := range seriesResp.Labels {
+			timeSeries.Labels = append(timeSeries.Labels, streamer.Label{
+				Name:  label.Name,
+				Value: label.Value,
+			})
+		}
+		sort.Sort(aggrChunkByTimestamp(seriesResp.Chunks))
+		samples := 0
+		outOfTimeRangeSamples := 0
+		outOfOrderSamples := 0
+		duplicateSamples := 0
+		prevTs := int64(0)
+		prevChunkMinTime := int64(0)
+		for _, chunk := range seriesResp.Chunks {
+			if chunk.Raw == nil {
+				// We only ask for and handle RAW
+				err := fmt.Errorf("unexpectedly missing raw chunk data")
+				level.Error(s.logger).Log("err", err, "request_id", request.RequestId)
+				return writeResponse(&streamer.StreamerResponse{Err: err.Error()})
+			}
+			if chunk.Raw.Type != storepb.Chunk_XOR {
+				err := fmt.Errorf("unexpected encoding type: %v", chunk.Raw.Type)
+				level.Error(s.logger).Log("err", err, "request_id", request.RequestId)
+				return writeResponse(&streamer.StreamerResponse{Err: err.Error()})
+			}
+			level.Debug(s.logger).Log(
+				"msg", "received a chunk for a time series",
+				"request_id", request.RequestId,
+				"metric_name", metricName,
+				"chunk_min_time", chunk.MinTime,
+				"chunk_min_time_unix", time.Unix(chunk.MinTime/1000, 0).UTC(),
+				"duration_seconds", float64(chunk.MaxTime-chunk.MinTime)/1000,
+				"num_samples", len(chunk.Raw.Data),
+				// A duplicate chunk is common because offline store has replication factor > 1 to avoid data loss during release.
+				"is_duplicate_chunk", prevChunkMinTime == chunk.MinTime,
+			)
+			if prevChunkMinTime == chunk.MinTime {
+				continue
+			}
+			prevChunkMinTime = chunk.MinTime
+
+			raw, err := chunkenc.FromData(chunkenc.EncXOR, chunk.Raw.Data)
+			if err != nil {
+				level.Error(s.logger).Log("err", err, "msg", "error in decoding chunk", "request_id", request.RequestId)
+				return writeResponse(&streamer.StreamerResponse{Err: err.Error()})
+			}
+
+			for iter := raw.Iterator(nil); iter.Next() != chunkenc.ValNone; {
+				ts, value := iter.At()
+				if ts < request.StartTimestampMs || ts > request.EndTimestampMs {
+					outOfTimeRangeSamples++
+				} else if prevTs == ts {
+					duplicateSamples++
+				} else if prevTs > ts {
+					outOfOrderSamples++
+					level.Debug(s.logger).Log(
+						"msg", "out of order sample",
+						"request_id", request.RequestId,
+						"metric_name", metricName,
+						"prev_ts", prevTs,
+						"ts", ts,
+					)
+				} else {
+					timeSeries.Samples = append(timeSeries.Samples, streamer.DataSample{
+						// In milliseconds since epoch
+						Timestamp: ts,
+						Value:     value,
+					})
+					samples++
+					prevTs = ts
+				}
+			}
+		}
+		if outOfOrderSamples > 0 {
+			level.Debug(s.logger).Log(
+				"msg", "out of order samples",
+				"request_id", request.RequestId,
+				"metric_name", metricName,
+				"num_chunks", len(seriesResp.Chunks),
+				"num_samples", samples,
+				"num_out_of_order_samples", outOfOrderSamples,
+				"num_duplicate_samples", duplicateSamples,
+			)
+		}
+		level.Debug(s.logger).Log(
+			"msg", "received and processed chunks for a time series",
+			"request_id", request.RequestId,
+			"metric_name", metricName,
+			"num_chunks", len(seriesResp.Chunks),
+			"num_samples", samples,
+			"out_of_time_range_samples", outOfTimeRangeSamples,
+			"num_duplicate_samples", duplicateSamples,
+			"num_out_of_order_samples", outOfOrderSamples,
+		)
+		chunksTotal += len(seriesResp.Chunks)
+		timeSeriesTotal++
+		samplesTotal += int64(samples)
+		outOfOrderSampleTotal += outOfOrderSamples
+		duplicateSampleTotal += duplicateSamples
+		outOfTimeRangeSampleTotal += outOfTimeRangeSamples
+		if err := writeResponse(&streamer.StreamerResponse{Data: timeSeries}); err != nil {
+			level.Error(s.logger).Log("err", err, "msg", "error in writing a data response")
+			return err
+		}
+	}
+	return writeResponse(&streamer.StreamerResponse{Err: "unexpected interruption"})
+}
+
+// Run() is blocking and call Stop() to make it exit.
+func (s *Streamer) Run() error {
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	os.Remove(s.config.socketPath)
+
+	listenConfig := &net.ListenConfig{}
+	listener, err := listenConfig.Listen(s.ctx, "unix", s.config.socketPath)
+	if err != nil {
+		level.Error(s.logger).Log("err", err, "msg", "error in listening on a Unix socket")
+		return err
+	}
+	s.listener = listener
+
+	level.Info(s.logger).Log("msg", "server is listening on", "socket_path", s.config.socketPath)
+	for !s.shutdown.Load() {
+		level.Info(s.logger).Log("msg", "waiting for a connection")
+		conn, err := listener.Accept()
+		if err != nil {
+			level.Error(s.logger).Log("err", err, "msg", "error in accepting a connection")
+			continue
+		}
+		s.wg.Add(1)
+		go func(conn net.Conn) {
+			defer conn.Close()
+			defer s.wg.Done()
+
+			// All reads/writes will fail after the deadline.
+			deadline := time.Now().Add(time.Second * time.Duration(s.config.streamTimeoutSeconds))
+			_ = conn.SetDeadline(deadline)
+
+			level.Info(s.logger).Log("msg", "accepted a connection",
+				"overall_timeout", s.config.streamTimeoutSeconds,
+				"overall_deadline", deadline)
+			scanner := bufio.NewScanner(conn)
+			if !scanner.Scan() {
+				level.Error(s.logger).Log("err", err, "msg", "error in reading a request")
+				return
+			}
+			encodedRequest := scanner.Text()
+			request := &streamer.StreamerRequest{}
+			if err := request.Decode(encodedRequest); err != nil {
+				level.Error(s.logger).Log("err", err, "msg", "error in decoding a request")
+				return
+			}
+			level.Info(s.logger).Log(
+				"msg", "received a request and starting a stream",
+				"request_id", request.RequestId,
+				"start_timestamp_ms", request.StartTimestampMs,
+				"end_timestamp_ms", request.EndTimestampMs,
+				"request", fmt.Sprintf("%+v", request),
+			)
+			err = s.streamOneRequest(request, conn)
+			if err != nil {
+				level.Error(s.logger).Log(
+					"msg", "error in streaming a request",
+					"err", err,
+					"request_id", request.RequestId,
+					"start_timestamp_ms", request.StartTimestampMs,
+					"end_timestamp_ms", request.EndTimestampMs,
+				)
+			}
+			level.Info(s.logger).Log("msg", "finished a request", "request_id", request.RequestId)
+		}(conn)
+	}
+	return nil
+}
+
+// Don't use s again after calling Stop().
+func (s *Streamer) Stop() {
+	s.shutdown.Store(true)
+	level.Info(s.logger).Log("msg", "stopping the server")
+	if s.listener != nil {
+		level.Info(s.logger).Log("msg", "closing the listener")
+		s.listener.Close()
+	}
+	s.cancel()
+	level.Info(s.logger).Log("msg", "canceld the context", "context_err", s.ctx.Err())
+	s.wg.Wait()
+	level.Info(s.logger).Log("msg", "the server stopped")
+}

--- a/cmd/thanos/streamer_test.go
+++ b/cmd/thanos/streamer_test.go
@@ -1,0 +1,345 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/thanos-io/thanos/pkg/streamer"
+	streamer_pkg "github.com/thanos-io/thanos/pkg/streamer"
+	"google.golang.org/grpc"
+)
+
+func TestConvertToSeriesReq(t *testing.T) {
+	streamerReq := &streamer.StreamerRequest{
+		RequestId:        "test_request",
+		StartTimestampMs: 1672531200000,
+		EndTimestampMs:   1672534800000,
+		SkipChunks:       false,
+		LabelMatchers: []streamer.LabelMatcher{
+			{Name: "instance", Value: "localhost:9090", Type: streamer.LabelMatcher_EQ},
+		},
+		Metric: "cpu_usage",
+	}
+
+	expectedReq := &storepb.SeriesRequest{
+		Aggregates: []storepb.Aggr{storepb.Aggr_RAW},
+		Matchers: []storepb.LabelMatcher{
+			{Name: "instance", Value: "localhost:9090", Type: storepb.LabelMatcher_EQ},
+			{Name: "__name__", Value: "cpu_usage", Type: storepb.LabelMatcher_EQ},
+		},
+		MinTime:    streamerReq.StartTimestampMs,
+		MaxTime:    streamerReq.EndTimestampMs,
+		SkipChunks: streamerReq.SkipChunks,
+	}
+
+	actualReq := convertToSeriesReq(streamerReq)
+	assert.Equal(t, expectedReq, actualReq, "Expected SeriesRequest to match")
+}
+
+type grpcServer struct {
+	server   *grpc.Server
+	addr     string
+	exit     chan struct{}
+	listener net.Listener
+}
+
+func (g *grpcServer) Stop() {
+	g.server.Stop()
+	g.listener.Close()
+	// fmt.Print("Waiting for grpc server to exit")
+	<-g.exit
+	// fmt.Print("grpc server exit")
+}
+
+func startMockGRPCServer(t *testing.T) *grpcServer {
+	listener, err := net.Listen("tcp", ":0")
+	assert.Nil(t, err)
+
+	exitChan := make(chan struct{})
+	startChan := make(chan struct{})
+
+	server := grpc.NewServer()
+	go func() {
+		close(startChan)
+		err := server.Serve(listener)
+		require.NoError(t, err)
+		// fmt.Print("Closing exit chan")
+		close(exitChan)
+	}()
+	<-startChan
+	time.Sleep(time.Second)
+	return &grpcServer{
+		server:   server,
+		listener: listener,
+		addr:     listener.Addr().String(),
+		exit:     exitChan,
+	}
+}
+
+func TestNewStreamerWithMockServer(t *testing.T) {
+	mockServer := startMockGRPCServer(t)
+	defer mockServer.Stop()
+
+	config := StreamerConfig{
+		storeAddrPort:        mockServer.addr,
+		streamTimeoutSeconds: 3,
+	}
+	logger := log.NewLogfmtLogger(os.Stdout)
+
+	streamer, err := NewStreamer(config, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, streamer)
+	assert.NotNil(t, streamer.grpcConn)
+}
+
+func TestStreamOneRequest(t *testing.T) {
+	mockServer := startMockGRPCServer(t)
+	defer mockServer.Stop()
+
+	config := StreamerConfig{
+		storeAddrPort:        mockServer.addr,
+		streamTimeoutSeconds: 6,
+	}
+	logger := log.NewLogfmtLogger(os.Stdout)
+	streamer, err := NewStreamer(config, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, streamer)
+
+	request := &streamer_pkg.StreamerRequest{
+		RequestId:        "test_request",
+		StartTimestampMs: 1672531200000,
+		EndTimestampMs:   1672534800000,
+		SkipChunks:       false,
+		LabelMatchers:    nil,
+	}
+
+	buffer := &bytes.Buffer{}
+	err = streamer.streamOneRequest(request, buffer)
+	assert.NoError(t, err)
+	encodedData := buffer.String()
+	assert.True(t, len(encodedData) > 0)
+	errorResp := streamer_pkg.StreamerResponse{}
+	// Remove the Deliminator byte from the encoded data
+	err = errorResp.Decode(encodedData)
+	assert.NoError(t, err)
+	assert.Equal(t, "rpc error: code = Unimplemented desc = unknown service thanos.Store", errorResp.Err)
+}
+
+func TestStreamer_RunAndStop(t *testing.T) {
+	tmpFile, err := os.CreateTemp("/tmp", "streamer_test.sock")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	mockServer := startMockGRPCServer(t)
+	defer mockServer.Stop()
+
+	logger := log.NewLogfmtLogger(os.Stdout)
+	config := StreamerConfig{
+		socketPath:           tmpFile.Name(),
+		storeAddrPort:        mockServer.addr,
+		streamTimeoutSeconds: 10,
+	}
+	streamer, err := NewStreamer(config, logger)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := streamer.Run()
+		assert.NoError(t, err)
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(2 * time.Second) // Give time for server to start
+		conn, err := net.Dial("unix", config.socketPath)
+		require.NoError(t, err)
+		defer conn.Close()
+		request := &streamer_pkg.StreamerRequest{
+			RequestId:        "test_request",
+			StartTimestampMs: 1672531200000,
+			EndTimestampMs:   1672534800000,
+			SkipChunks:       false,
+			LabelMatchers: []streamer_pkg.LabelMatcher{
+				{
+					Name:  "__name__",
+					Value: "up",
+					Type:  streamer_pkg.LabelMatcher_EQ,
+				},
+			},
+		}
+		data, err := streamer_pkg.Encode(request)
+		assert.NoError(t, err)
+		err = writeBytes(conn, []byte(data), []byte(streamer_pkg.Deliminator))
+		assert.NoError(t, err)
+		_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		scanner := bufio.NewScanner(conn)
+		require.True(t, scanner.Scan())
+		encodedResp := scanner.Text()
+		require.NoError(t, err)
+		resp := &streamer_pkg.StreamerResponse{}
+		err = resp.Decode(encodedResp)
+		assert.NoError(t, err)
+		assert.Equal(t, "rpc error: code = Unimplemented desc = unknown service thanos.Store", resp.Err)
+	}()
+	time.Sleep(5 * time.Second)
+	streamer.Stop()
+	wg.Wait()
+}
+
+func TestStreamer_ClientCrashAfterSendingRequest(t *testing.T) {
+	tmpFile, err := os.CreateTemp("/tmp", "streamer_test.sock")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	mockServer := startMockGRPCServer(t)
+	defer mockServer.Stop()
+
+	logger := log.NewLogfmtLogger(os.Stdout)
+	config := StreamerConfig{
+		socketPath:           tmpFile.Name(),
+		storeAddrPort:        mockServer.addr,
+		streamTimeoutSeconds: 10,
+	}
+	streamer, err := NewStreamer(config, logger)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := streamer.Run()
+		assert.NoError(t, err)
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(2 * time.Second) // Give time for server to start
+		conn, err := net.Dial("unix", config.socketPath)
+		require.NoError(t, err)
+		defer conn.Close()
+		request := &streamer_pkg.StreamerRequest{}
+		data, err := streamer_pkg.Encode(request)
+		assert.NoError(t, err)
+		err = writeBytes(conn, []byte(data), []byte(streamer_pkg.Deliminator))
+		assert.NoError(t, err)
+		time.Sleep(2 * time.Second)
+	}()
+	time.Sleep(5 * time.Second)
+	streamer.Stop()
+	wg.Wait()
+}
+
+func TestStreamer_ClientCrashBeforeSendingRequest(t *testing.T) {
+	tmpFile, err := os.CreateTemp("/tmp", "streamer_test.sock")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	mockServer := startMockGRPCServer(t)
+	defer mockServer.Stop()
+
+	logger := log.NewLogfmtLogger(os.Stdout)
+	config := StreamerConfig{
+		socketPath:           tmpFile.Name(),
+		storeAddrPort:        mockServer.addr,
+		streamTimeoutSeconds: 100,
+	}
+	streamer, err := NewStreamer(config, logger)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := streamer.Run()
+		assert.NoError(t, err)
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(2 * time.Second) // Give time for server to start
+		conn, err := net.Dial("unix", config.socketPath)
+		require.NoError(t, err)
+		defer conn.Close()
+		time.Sleep(2 * time.Second)
+	}()
+	time.Sleep(5 * time.Second)
+	streamer.Stop()
+	wg.Wait()
+}
+
+func TestStreamer_Stop(t *testing.T) {
+	tmpFile, err := os.CreateTemp("/tmp", "streamer_test.sock")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	mockServer := startMockGRPCServer(t)
+	defer mockServer.Stop()
+
+	logger := log.NewLogfmtLogger(os.Stdout)
+	config := StreamerConfig{
+		socketPath:           tmpFile.Name(),
+		storeAddrPort:        mockServer.addr,
+		streamTimeoutSeconds: 3,
+	}
+	streamer, err := NewStreamer(config, logger)
+	require.NoError(t, err)
+
+	time.Sleep(time.Second)
+	streamer.Stop()
+	assert.NotNil(t, streamer.ctx.Err())
+}
+
+func TestSocket(t *testing.T) {
+	logger := log.NewLogfmtLogger(os.Stdout)
+
+	tmpFile, err := os.CreateTemp("/tmp", "streamer.sock.")
+	assert.NoError(t, err)
+	os.Remove(tmpFile.Name())
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	listenConfig := &net.ListenConfig{}
+	listener, err := listenConfig.Listen(ctx, "unix", tmpFile.Name())
+	require.NoError(t, err)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := listener.Accept()
+		require.NotNil(t, err)
+		_, err = listener.Accept()
+		require.NotNil(t, err)
+		level.Info(logger).Log("msg", "listener.Accept() returned")
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil {
+			time.Sleep(1 * time.Second)
+		}
+		assert.NotNil(t, ctx.Err())
+		level.Info(logger).Log("msg", "context canceled")
+	}()
+
+	listener.Close()
+	cancel()
+	assert.NotNil(t, ctx.Err())
+	wg.Wait()
+}

--- a/cmd/thanos/tools.go
+++ b/cmd/thanos/tools.go
@@ -29,6 +29,7 @@ func registerTools(app *extkingpin.App) {
 	registerBucket(cmd)
 	registerCheckRules(cmd)
 	registerStreamMetric(cmd)
+	registerStreamerTool(cmd)
 }
 
 func (tc *checkRulesConfig) registerFlag(cmd extkingpin.FlagClause) *checkRulesConfig {

--- a/cmd/thanos/tools_streamer.go
+++ b/cmd/thanos/tools_streamer.go
@@ -1,0 +1,159 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/run"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"github.com/thanos-io/thanos/pkg/streamer"
+
+	streamer_pkg "github.com/thanos-io/thanos/pkg/streamer"
+)
+
+type streamerToolConfig struct {
+	socketPath string
+	metric     string
+	hoursAgo   int
+	skipChunks bool
+}
+
+func registerStreamerTool(app extkingpin.AppClause) {
+	cmd := app.Command("streamer", "Stream time series for a metric")
+
+	conf := &streamerToolConfig{}
+	cmd.Flag("socket.path", "Path to the Unix socket").Default("/tmp/thanos-streamer.sock").StringVar(&conf.socketPath)
+	cmd.Flag("metric", "The metric name to stream time series for this metric").Default("node_cpu_seconds_total").StringVar(&conf.metric)
+	cmd.Flag("hours_ago", "Stream the metric from this number of hours ago").Default("16").IntVar(&conf.hoursAgo)
+	cmd.Flag("skip_chunks", "Skip chunks in the response").Default("false").BoolVar(&conf.skipChunks)
+
+	cmd.Setup(func(
+		g *run.Group,
+		logger log.Logger,
+		_ *prometheus.Registry,
+		_ opentracing.Tracer,
+		_ <-chan struct{},
+		_ bool) error {
+		// Dummy actor to immediately kill the group after the run function returns.
+		g.Add(func() error { return nil }, func(error) {})
+		err := runStreamerTool(conf, logger)
+		if err != nil {
+			level.Error(logger).Log("msg", "Failed to run streamer tool", "err", err)
+		}
+		return err
+	})
+}
+
+func runStreamerTool(conf *streamerToolConfig, logger log.Logger) error {
+	conn, err := net.Dial("unix", conf.socketPath)
+	if err != nil {
+		level.Error(logger).Log("msg", "Failed to connect to the Unix socket", "err", err, "socket", conf.socketPath)
+		return err
+	}
+	defer conn.Close()
+
+	nowMs := time.Now().Unix() * 1000
+	startMs := nowMs - int64(conf.hoursAgo)*3600*1000
+	request := &streamer.StreamerRequest{
+		RequestId:        conf.metric,
+		StartTimestampMs: startMs,
+		EndTimestampMs:   startMs + 4*3600*1000,
+		SkipChunks:       conf.skipChunks,
+		Metric:           conf.metric,
+		LabelMatchers: []streamer_pkg.LabelMatcher{
+			{
+				Name:  "__replica__",
+				Value: "",
+				Type:  streamer_pkg.LabelMatcher_EQ,
+			},
+		},
+	}
+
+	level.Info(logger).Log(
+		"msg", "sending a socket request to Thanos streamer",
+		"req", fmt.Sprintf("%+v", request),
+	)
+
+	data, err := streamer_pkg.Encode(request)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to encode a request", "err", err)
+		return err
+	}
+	err = writeBytes(conn, []byte(data), []byte(streamer_pkg.Deliminator))
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to write a request to the Unix socket", "err", err)
+		return err
+	}
+	seq := 0
+	scanner := bufio.NewScanner(conn)
+	for ; scanner.Scan(); seq++ {
+		encodedResp, err := scanner.Text(), scanner.Err()
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to read a response from the Unix socket", "err", err)
+			return err
+		}
+		resp := &streamer_pkg.StreamerResponse{}
+		level.Info(logger).Log(
+			"msg", "received a response from the Unix socket",
+			"seq", seq,
+			"encoded_size", len(encodedResp),
+			// "encoded_response", encodedResp,
+		)
+		err = resp.Decode(encodedResp)
+		if err != nil {
+			level.Error(logger).Log(
+				"msg", "failed to decode a response from the Unix socket", "err", err,
+				"encoded_size", len(encodedResp),
+				"seq", seq,
+				"encoded_response", fmt.Sprintf("%+v", encodedResp))
+			return err
+		}
+		if resp.Eof {
+			level.Info(logger).Log("msg", "successfully streamed all time series for the metric", "metric", conf.metric, "num_series", seq)
+			return nil
+		}
+		if resp.Err != "" {
+			level.Error(logger).Log("msg", "error in response", "err", resp.Err)
+			return nil
+		}
+		if 0 == (seq % 1000) {
+			level.Info(logger).Log("msg", "streaming time series", "seq", seq)
+		}
+		series := resp.Data
+		metric := ""
+		fmt.Printf("{")
+		for _, label := range series.Labels {
+			name := strings.Clone(label.Name)
+			value := strings.Clone(label.Value)
+			fmt.Printf("%s=%s,", label.Name, label.Value)
+			if name == labels.MetricName {
+				metric = value
+			}
+		}
+		fmt.Printf("}")
+		if metric != conf.metric {
+			return fmt.Errorf("%d-th time series from the response has a different metric name:\n   Actual: %+v\n   Expected: %+v",
+				seq, []byte(metric), []byte(conf.metric))
+		}
+		order := 0
+		for _, sample := range series.Samples {
+			if order < 5 {
+				fmt.Printf(" %f @%d,", sample.Value, sample.Timestamp)
+			}
+			order++
+		}
+		fmt.Printf("\n")
+	}
+	return fmt.Errorf("unexpected interruption: %w", scanner.Err())
+}

--- a/pkg/streamer/types.go
+++ b/pkg/streamer/types.go
@@ -1,0 +1,104 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package streamer
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/gob"
+)
+
+type LabelMatcher_Type int32
+
+const (
+	// Must be the same with the values in github.com/thanos-io/thanos@v0.30.0/pkg/store/storepb/types.pb.go .
+	LabelMatcher_EQ  LabelMatcher_Type = 0
+	LabelMatcher_NEQ LabelMatcher_Type = 1
+	LabelMatcher_RE  LabelMatcher_Type = 2
+	LabelMatcher_NRE LabelMatcher_Type = 3
+)
+
+var (
+	// NB: don't change. The socket reader uses a scanner to read a line ended by a newline.
+	Deliminator = "\n"
+)
+
+type LabelMatcher struct {
+	// The label name to match.
+	Name string
+	// The regular expression to match against the label value.
+	Value string
+	Type  LabelMatcher_Type
+}
+
+type StreamerRequest struct {
+	// Can be empty to get all metrics.
+	Metric        string
+	LabelMatchers []LabelMatcher
+	// In milliseconds since epoch
+	StartTimestampMs int64
+	// In milliseconds since epoch
+	EndTimestampMs int64
+	SkipChunks     bool
+	RequestId      string
+}
+
+type Label struct {
+	Name  string
+	Value string
+}
+
+type Labels []Label
+
+type DataSample struct {
+	// In milliseconds since epoch
+	Timestamp int64
+	Value     float64
+}
+
+type TimeSeries struct {
+	// Labels are sorted by their names.
+	Labels  Labels
+	Samples []DataSample
+}
+
+type StreamerResponse struct {
+	// If the response is an error, this field will be non-empty.
+	Err string
+	// True if no more data will be sent and this response has no data either.
+	Eof  bool
+	Data *TimeSeries
+}
+
+func Encode(e any) (string, error) {
+	var buf bytes.Buffer
+	encoder := gob.NewEncoder(&buf)
+	err := encoder.Encode(e)
+	if err != nil {
+		return "", err
+	}
+
+	binaryData := buf.Bytes()
+	base64Encoded := base64.StdEncoding.EncodeToString(binaryData)
+	return base64Encoded, nil
+}
+
+func decode(e any, base64Encoded string) error {
+	base64Decoded, err := base64.StdEncoding.DecodeString(base64Encoded)
+	if err != nil {
+		return err
+	}
+	buf := bytes.NewBuffer(base64Decoded)
+	decoder := gob.NewDecoder(buf)
+	err = decoder.Decode(e)
+	return err
+}
+
+func (s *StreamerRequest) Decode(base64Encoded string) error {
+	return decode(s, base64Encoded)
+}
+
+func (s *StreamerResponse) Decode(base64Encoded string) error {
+	return decode(s, base64Encoded)
+}

--- a/pkg/streamer/types_test.go
+++ b/pkg/streamer/types_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package streamer
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncodeDecode tests the Encode and Decode functions for StreamerRequest.
+func TestEncodeDecodeStreamerRequest(t *testing.T) {
+	original := StreamerRequest{
+		Metric: "cpu_usage",
+		LabelMatchers: []LabelMatcher{
+			{Name: "instance", Value: "localhost", Type: LabelMatcher_EQ},
+		},
+		StartTimestampMs: 1610000000000,
+		EndTimestampMs:   1610003600000,
+		SkipChunks:       false,
+		RequestId:        "req-123",
+	}
+
+	// Encode
+	encoded, err := Encode(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	// Decode
+	var decoded StreamerRequest
+	err = decoded.Decode(encoded)
+	require.NoError(t, err)
+
+	// Verify that decoded struct matches the original
+	assert.Equal(t, original, decoded)
+}
+
+// TestEncodeDecodeStreamerResponse tests the encoding and decoding of StreamerResponse.
+func TestEncodeDecodeStreamerResponse(t *testing.T) {
+	original := StreamerResponse{
+		Err: "test error",
+		Eof: false,
+		Data: &TimeSeries{
+			Labels: Labels{
+				{Name: "instance", Value: "localhost"},
+			},
+			Samples: []DataSample{
+				{Timestamp: 1610000000000, Value: 3.14},
+			},
+		},
+	}
+
+	// Encode
+	encoded, err := Encode(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	// Decode
+	var decoded StreamerResponse
+	err = decoded.Decode(encoded)
+	require.NoError(t, err)
+
+	// Verify that decoded struct matches the original
+	assert.Equal(t, original, decoded)
+}
+
+// TestDecodeInvalidBase64 tests decoding with invalid base64 input.
+func TestDecodeInvalidBase64(t *testing.T) {
+	invalidBase64 := "invalid_base64_string"
+
+	var decoded StreamerRequest
+	err := decoded.Decode(invalidBase64)
+
+	assert.Error(t, err, "Expected decoding error for invalid base64 input")
+}
+
+// TestEmptyEncoding tests encoding and decoding an empty StreamerRequest.
+func TestEmptyEncoding(t *testing.T) {
+	original := StreamerRequest{}
+
+	encoded, err := Encode(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	var decoded StreamerRequest
+	err = decoded.Decode(encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, original, decoded)
+}
+
+// TestEncodeDecodeWithSpecialCharacters ensures that special characters in fields do not cause errors.
+func TestEncodeDecodeWithSpecialCharacters(t *testing.T) {
+	original := StreamerRequest{
+		Metric: "cpu$usage@!%",
+		LabelMatchers: []LabelMatcher{
+			{Name: "inst@#$", Value: "local\nhost", Type: LabelMatcher_RE},
+		},
+		StartTimestampMs: 1610000000000,
+		EndTimestampMs:   1610003600000,
+		SkipChunks:       false,
+		RequestId:        "req-456",
+	}
+
+	encoded, err := Encode(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	var decoded StreamerRequest
+	err = decoded.Decode(encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, original, decoded)
+}
+
+// TestBase64DecodingFailure verifies that decoding fails gracefully when provided with an invalid Base64 input.
+func TestBase64DecodingFailure(t *testing.T) {
+	invalidBase64 := base64.StdEncoding.EncodeToString([]byte("corrupt_data"))
+
+	var decoded StreamerResponse
+	err := decoded.Decode(invalidBase64)
+
+	assert.Error(t, err, "Expected an error while decoding corrupt data")
+}
+
+// TestDecodeWithModifiedData ensures decoding fails if base64 is tampered with.
+func TestDecodeWithModifiedData(t *testing.T) {
+	original := StreamerRequest{
+		Metric: "memory_usage",
+	}
+
+	encoded, err := Encode(original)
+	require.NoError(t, err)
+
+	// Modify the encoded data to introduce corruption
+	modifiedEncoded := encoded + "X"
+
+	var decoded StreamerRequest
+	err = decoded.Decode(modifiedEncoded)
+
+	assert.Error(t, err, "Expected an error when decoding modified base64 data")
+}
+
+func TestDecodeWithEmptyData(t *testing.T) {
+	// Empty data should return an error.
+	var decoded StreamerRequest
+	err := decoded.Decode("")
+	assert.Error(t, err, "Expected an error when decoding empty data")
+}
+
+func TestDeliminator(t *testing.T) {
+	base64Chars := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+	assert.NotContains(t, base64Chars, Deliminator)
+	assert.Contains(t, base64Chars, "+")
+	assert.Contains(t, base64Chars, "=")
+}


### PR DESCRIPTION
`thanos streamer` is a Unix domain socket server which accept a request and streams data for a metric. 
`thanos tools streamer` is a socket client to stream a metric and print out its time series.

Will be tested in https://github.com/databricks-eng/universe/pull/908720 besides the tests below.

# Tests

```
$ go test -timeout 20s  github.com/thanos-io/thanos/cmd/thanos

$ go test github.com/thanos-io/thanos/pkg/streamer

$ ~/go/bin/thanos streamer --log.level=info
                                                                                                                                                                                               ts=2025-02-08T21:53:15.496339Z caller=streamer.go:79 level=info msg="connected to Store gRPC server" addr=localhost:10901
ts=2025-02-08T21:53:15.496818Z caller=streamer.go:363 level=info msg="server is listening on" socket_path=/tmp/thanos-streamer.sock
ts=2025-02-08T21:53:55.239835Z caller=streamer.go:365 level=info msg="waiting for a connection"
ts=2025-02-08T21:53:55.239865Z caller=streamer.go:380 level=info msg="accepted a connection" overall_timeout=3600 overall_deadline=2025-02-08T14:53:55.239853-08:00
ts=2025-02-08T21:53:55.239982Z caller=streamer.go:394 level=info msg="received a request and starting a stream" request_id=node_cpu_seconds_total start_timestamp_ms=1738994035000 end_timestamp_ms=1739008435000 request="&{Metric:node_cpu_seconds_total LabelMatchers:[] StartTimestampMs:1738994035000 EndTimestampMs:1739008435000 SkipChunks:false RequestId:node_cpu_seconds_total}"
ts=2025-02-08T21:53:55.240002Z caller=streamer.go:172 level=info msg="sending one series request to Store" request_id=node_cpu_seconds_total req="min_time:1738994035000 max_time:1739008435000 matchers:<name:\"__name__\" value:\"node_cpu_seconds_total\" > aggregates:RAW " num_matchers=1 matchers="[{Type:EQ Name:__name__ Value:node_cpu_seconds_total}]"
...
ts=2025-02-08T21:55:04.875173Z caller=streamer.go:212 level=info msg="a streaming request reached EOF" request_id=node_cpu_seconds_total minTimeTsMs=1738994035000 unix_time=2025-02-08T05:53:55Z
ts=2025-02-08T21:55:04.875229Z caller=streamer.go:193 level=info msg="finished one streaming request" request_id=node_cpu_seconds_total time_series_total=61248 num_chunks=578544 num_samples=27108703 minTimeMs=1738994035000 unix_time=2025-02-08T05:53:55Z maxTimeMs=1739008435000 out_of_time_range_samples=7080296 out_of_order_samples=0 duplicate_samples=0
ts=2025-02-08T21:55:04.87524Z caller=streamer.go:411 level=info msg="finished a request" request_id=node_cpu_seconds_total

$ ~/go/bin/thanos tools streamer

ts=2025-02-08T21:53:55.239823Z caller=tools_streamer.go:76 level=info msg="sending a socket request to Thanos streamer" req="&{Metric:node_cpu_seconds_total LabelMatchers:[] StartTimestampMs:1738994035000 EndTimestampMs:1739008435000 SkipChunks:false RequestId:node_cpu_seconds_total}"
ts=2025-02-08T21:53:58.338969Z caller=tools_streamer.go:100 level=info msg="received a response from the Unix socket" seq=0 encoded_size=13412
ts=2025-02-08T21:53:58.34098Z caller=tools_streamer.go:124 level=info msg="streaming time series" seq=0
{__name__=node_cpu_seconds_total,__tenant__=eng-kubernetes-runtime-team,app=node-exporter,cloud=aws,cloud_provider=AWS,cloud_provider_region=AWS_US_WEST_2,cpu=0,db_environment=DEV,db_regulatory_domain=PUBLIC,env=dev,instance=10.20.10.100:9100,job=kubernetes-pods,kubernetes_cluster_type=GENERAL_CLASSIC,kubernetes_cluster_uri=kubernetes-cluster:dev/aws/public/us-west-2/gc/01,kubernetes_namespace=node-exporter,kubernetes_pod_name=node-exporter-75h46,kubernetes_pod_node_name=ip-10-20-10-100.us-west-2.compute.internal,mode=idle,region=us-west-2,region_uri=region:dev/aws/public/us-west-2,shardName=oregon-dev,system=node-exporter,vector_dev_exclude=true,} 466646.490000 @1738994046784, 466663.490000 @1738994076784, 466679.390000 @1738994106784, 466697.050000 @1738994136784, 466713.050000 @1738994166784,
ts=2025-02-08T21:53:58.341544Z caller=tools_streamer.go:100 level=info msg="received a response from the Unix socket" seq=1 encoded_size=13324

...

ts=2025-02-08T21:55:04.875176Z caller=tools_streamer.go:100 level=info msg="received a response from the Unix socket" seq=61247 encoded_size=13392
{__name__=node_cpu_seconds_total,__tenant__=eng-kubernetes-runtime-team,app=node-exporter,cloud=aws,cloud_provider=AWS,cloud_provider_region=AWS_US_WEST_2,cpu=9,db_environment=DEV,db_regulatory_domain=PUBLIC,env=dev,instance=10.20.9.9:9100,job=kubernetes-pods,kubernetes_cluster_type=GENERAL_CLASSIC,kubernetes_cluster_uri=kubernetes-cluster:dev/aws/public/us-west-2/gc/01,kubernetes_namespace=node-exporter,kubernetes_pod_name=node-exporter-92fvw,kubernetes_pod_node_name=ip-10-20-9-9.us-west-2.compute.internal,mode=user,region=us-west-2,region_uri=region:dev/aws/public/us-west-2,shardName=oregon-dev,system=node-exporter,vector_dev_exclude=true,} 117567.440000 @1738994056413, 117569.490000 @1738994086413, 117571.360000 @1738994116413, 117573.160000 @1738994146413, 117575.110000 @1738994176413,
ts=2025-02-08T21:55:04.875287Z caller=tools_streamer.go:100 level=info msg="received a response from the Unix socket" seq=61248 encoded_size=348
ts=2025-02-08T21:55:04.875318Z caller=tools_streamer.go:116 level=info msg="successfully streamed all time series for the metric" metric=node_cpu_seconds_total num_series=61248
ts=2025-02-08T21:55:04.875564Z caller=main.go:175 level=info msg=exiting


```