### PR TITLE
Add unit tests for group replica response strategy

### DIFF
--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -223,7 +223,9 @@ type RecursiveLister struct {
 }
 
 func NewRecursiveLister(logger log.Logger, bkt objstore.InstrumentedBucketReader) *RecursiveLister {
-	level.Info(logger).Log("msg", "Using recursive block lister")
+	if logger != nil {
+		level.Info(logger).Log("msg", "Using recursive block lister")
+	}
 	return &RecursiveLister{
 		logger: logger,
 		bkt:    bkt,
@@ -231,8 +233,13 @@ func NewRecursiveLister(logger log.Logger, bkt objstore.InstrumentedBucketReader
 }
 
 func (f *RecursiveLister) GetActiveAndPartialBlockIDs(ctx context.Context, ch chan<- ulid.ULID) (partialBlocks map[ulid.ULID]bool, err error) {
-	level.Info(f.logger).Log("msg", "recursive block lister started")
-	start := time.Now()
+	if f.logger != nil {
+		level.Info(f.logger).Log("msg", "recursive block lister started")
+		start := time.Now()
+		defer func() {
+			level.Info(f.logger).Log("msg", "recursive block lister ended", "duration", time.Since(start))
+		}()
+	}
 	partialBlocks = make(map[ulid.ULID]bool)
 	err = f.bkt.Iter(ctx, "", func(name string) error {
 		parts := strings.Split(name, "/")
@@ -256,7 +263,6 @@ func (f *RecursiveLister) GetActiveAndPartialBlockIDs(ctx context.Context, ch ch
 		}
 		return nil
 	}, objstore.WithRecursiveIter())
-	level.Info(f.logger).Log("msg", "recursive block lister ended", "duration", time.Since(start))
 	return partialBlocks, err
 }
 
@@ -268,6 +274,9 @@ type ConcurrentLister struct {
 }
 
 func NewConcurrentLister(logger log.Logger, bkt objstore.InstrumentedBucketReader) *ConcurrentLister {
+	if logger != nil {
+		level.Info(logger).Log("msg", "Using concurrent block lister")
+	}
 	return &ConcurrentLister{
 		logger: logger,
 		bkt:    bkt,
@@ -275,11 +284,13 @@ func NewConcurrentLister(logger log.Logger, bkt objstore.InstrumentedBucketReade
 }
 
 func (f *ConcurrentLister) GetActiveAndPartialBlockIDs(ctx context.Context, ch chan<- ulid.ULID) (partialBlocks map[ulid.ULID]bool, err error) {
-	level.Info(f.logger).Log("msg", "concurrent block lister started")
-	start := time.Now()
-	defer func() {
-		level.Info(f.logger).Log("msg", "concurrent block lister end", "duration", time.Since(start))
-	}()
+	if f.logger != nil {
+		level.Info(f.logger).Log("msg", "concurrent block lister started")
+		start := time.Now()
+		defer func() {
+			level.Info(f.logger).Log("msg", "concurrent block lister end", "duration", time.Since(start))
+		}()
+	}
 	const concurrency = 64
 
 	partialBlocks = make(map[ulid.ULID]bool)

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -268,7 +268,6 @@ type ConcurrentLister struct {
 }
 
 func NewConcurrentLister(logger log.Logger, bkt objstore.InstrumentedBucketReader) *ConcurrentLister {
-	level.Info(logger).Log("msg", "Using concurrent block lister")
 	return &ConcurrentLister{
 		logger: logger,
 		bkt:    bkt,

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -72,12 +72,13 @@ type Client interface {
 	// represents a local client (server-as-client) and has no remote address.
 	Addr() (addr string, isLocalClient bool)
 
-	// A replica key defines a set of endpoints belong to the same replica.
-	// E.g, "pantheon-db-rep0", "pantheon-db-rep1", "long-range-store".
+	// ReplicaKey returns replica name of the store client. A replica consists of a set of endpoints belong to the
+	// same replica. E.g, "pantheon-db-rep0", "pantheon-db-rep1", "long-range-store".
 	ReplicaKey() string
-	// A group key defines a group of replicas that belong to the same group.
-	// E.g. "pantheon-db" has replicas "pantheon-db-rep0", "pantheon-db-rep1".
-	//		"long-range-store" has only one replica, "long-range-store".
+
+	// GroupKey returns group name of the store client. A group defines a group of replicas that belong to the
+	// same group. E.g. "pantheon-db" has replicas "pantheon-db-rep0", "pantheon-db-rep1".
+	// "long-range-store" has only one replica, "long-range-store".
 	GroupKey() string
 
 	// Matches returns true if provided label matchers are allowed in the store.


### PR DESCRIPTION
1. Add unit tests for group replica response strategy introduced in https://github.com/databricks/thanos/pull/33
2. Fix some unit tests bugs from OSS (those bugs only appear if environment variable THANOS_ENABLE_STORE_READ_TIMEOUT_TESTS is set)