### PR TITLE
Make relabel config file optional

### DIFF
--- a/pkg/receive/relabeller.go
+++ b/pkg/receive/relabeller.go
@@ -6,6 +6,7 @@ package receive
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/go-kit/log"
@@ -97,6 +98,14 @@ func (r *Relabeller) setRelabelConfig(configs RelabelConfig) {
 }
 
 func (r *Relabeller) loadConfig() error {
+	path := r.configPathOrContent.Path()
+	if len(path) != 0 {
+		_, err := os.ReadFile(path)
+		if err != nil {
+			level.Warn(r.logger).Log("msg", "failed to load relabel config", "path", path, "err", err)
+			return nil
+		}
+	}
 	relabelContentYaml, err := r.configPathOrContent.Content()
 	if err != nil {
 		return errors.Wrap(err, "getting content of relabel config")

--- a/pkg/receive/relabeller.go
+++ b/pkg/receive/relabeller.go
@@ -98,16 +98,14 @@ func (r *Relabeller) setRelabelConfig(configs RelabelConfig) {
 }
 
 func (r *Relabeller) loadConfig() error {
-	path := r.configPathOrContent.Path()
-	if len(path) != 0 {
-		_, err := os.ReadFile(path)
-		if err != nil {
-			level.Warn(r.logger).Log("msg", "failed to load relabel config", "path", path, "err", err)
-			return nil
-		}
-	}
 	relabelContentYaml, err := r.configPathOrContent.Content()
 	if err != nil {
+		// If file does not exist, we just set an empty config.
+		if errors.Is(err, os.ErrNotExist) {
+			level.Debug(r.logger).Log("msg", "relabel config file does not exist")
+			r.setRelabelConfig(RelabelConfig{})
+			return nil
+		}
 		return errors.Wrap(err, "getting content of relabel config")
 	}
 	var relabelConfig RelabelConfig


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

Allow thanos to start even if specified relabel config file path doesn't exist. The path is still polled and when the file gets created, its configuration will be loaded in.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
