### PR TITLE
[ES-1393569] azure compactor crash loop due to symbol table size limits

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -404,7 +404,7 @@ func runCompact(
 		planner,
 		comp,
 		compact.DefaultBlockDeletableChecker{},
-		compact.NewOverlappingCompactionLifecycleCallback(reg, conf.enableOverlappingRemoval),
+		compact.NewOverlappingCompactionLifecycleCallback(reg, logger, conf.enableOverlappingRemoval),
 		compactDir,
 		insBkt,
 		conf.compactionConcurrency,

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -345,7 +345,7 @@ func (f *ConcurrentLister) GetActiveAndPartialBlockIDs(ctx context.Context, ch c
 		case metaChan <- id:
 		}
 		return nil
-	}); err != nil {
+	}, objstore.WithUpdatedAt()); err != nil {
 		return nil, err
 	}
 	close(metaChan)

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -842,6 +842,7 @@ type CompactionLifecycleCallback interface {
 	PreCompactionCallback(ctx context.Context, logger log.Logger, group *Group, toCompactBlocks []*metadata.Meta) error
 	PostCompactionCallback(ctx context.Context, logger log.Logger, group *Group, blockID ulid.ULID) error
 	GetBlockPopulator(ctx context.Context, logger log.Logger, group *Group) (tsdb.BlockPopulator, error)
+	HandleError(ctx context.Context, logger log.Logger, group *Group, toCompactBlocks []*metadata.Meta, err error)
 }
 
 type DefaultCompactionLifecycleCallback struct {
@@ -871,6 +872,9 @@ func (c DefaultCompactionLifecycleCallback) PostCompactionCallback(_ context.Con
 
 func (c DefaultCompactionLifecycleCallback) GetBlockPopulator(_ context.Context, _ log.Logger, _ *Group) (tsdb.BlockPopulator, error) {
 	return tsdb.DefaultBlockPopulator{}, nil
+}
+
+func (c DefaultCompactionLifecycleCallback) HandleError(_ context.Context, _ log.Logger, _ *Group, _ []*metadata.Meta, err error) {
 }
 
 // Compactor provides compaction against an underlying storage of time series data.
@@ -1253,6 +1257,7 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 		compIDs, e = comp.CompactWithBlockPopulator(dir, toCompactDirs, nil, populateBlockFunc)
 		return e
 	}); err != nil {
+		compactionLifecycleCallback.HandleError(ctx, cg.logger, cg, toCompact, err)
 		return false, nil, halt(errors.Wrapf(err, "compact blocks %v", toCompactDirs))
 	}
 	if len(compIDs) == 0 {

--- a/pkg/compact/overlapping_test.go
+++ b/pkg/compact/overlapping_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
@@ -150,19 +151,48 @@ func TestHandleError(t *testing.T) {
 	logger := log.NewNopLogger()
 	callback := NewOverlappingCompactionLifecycleCallback(reg, logger, true)
 	for _, tcase := range []struct {
-		testName string
-		input    []*metadata.Meta
-		err      error
+		testName    string
+		input       []*metadata.Meta
+		err         error
+		handledErrs int
+		errBlockIdx int
 	}{
 		{
 			testName: "empty error",
+			input:    []*metadata.Meta{},
+		},
+		{
+			testName: "non empty error but not handled",
+			input: []*metadata.Meta{
+				createCustomBlockMeta(1, 1, 2, metadata.ReceiveSource, 1),
+				createCustomBlockMeta(2, 1, 6, metadata.CompactorSource, 1),
+			},
+			err:         errors.New("some error"),
+			handledErrs: 0,
+		},
+		{
+			testName: "non empty error symbol table size exceeds",
+			input: []*metadata.Meta{
+				createCustomBlockMeta(1, 1, 2, metadata.ReceiveSource, 1),
+				createCustomBlockMeta(2, 1, 6, metadata.CompactorSource, 1),
+				createCustomBlockMeta(3, 1, 6, metadata.ReceiveSource, 1024*1024),
+			},
+			err:         errors.New(symbolTableSizeExceedsError + " 1024*1024"),
+			handledErrs: 1,
+			errBlockIdx: 2,
 		},
 	} {
 		t.Run(tcase.testName, func(t *testing.T) {
 			ctx := context.Background()
 			bkt := objstore.NewInMemBucket()
 			group := &Group{logger: log.NewNopLogger(), bkt: bkt}
-			callback.HandleError(ctx, logger, group, tcase.input, tcase.err)
+			require.Equal(t, tcase.handledErrs, callback.HandleError(ctx, logger, group, tcase.input, tcase.err))
+			if tcase.handledErrs > 0 {
+				for i := 0; i < len(tcase.input); i++ {
+					ok, _ := bkt.Exists(ctx, path.Join(tcase.input[i].ULID.String(), metadata.NoCompactMarkFilename))
+					require.Equal(t, i == tcase.errBlockIdx, ok)
+				}
+			}
 		})
 	}
 }

--- a/pkg/compact/overlapping_test.go
+++ b/pkg/compact/overlapping_test.go
@@ -21,7 +21,7 @@ import (
 func TestPreCompactionCallback(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	logger := log.NewNopLogger()
-	callback := NewOverlappingCompactionLifecycleCallback(reg, true)
+	callback := NewOverlappingCompactionLifecycleCallback(reg, logger, true)
 	for _, tcase := range []struct {
 		testName      string
 		input         []*metadata.Meta
@@ -142,6 +142,28 @@ func TestPreCompactionCallback(t *testing.T) {
 		}); !ok {
 			return
 		}
+	}
+}
+
+func TestHandleError(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	logger := log.NewNopLogger()
+	callback := NewOverlappingCompactionLifecycleCallback(reg, logger, true)
+	for _, tcase := range []struct {
+		testName string
+		input    []*metadata.Meta
+		err      error
+	}{
+		{
+			testName: "empty error",
+		},
+	} {
+		t.Run(tcase.testName, func(t *testing.T) {
+			ctx := context.Background()
+			bkt := objstore.NewInMemBucket()
+			group := &Group{logger: log.NewNopLogger(), bkt: bkt}
+			callback.HandleError(ctx, logger, group, tcase.input, tcase.err)
+		})
 	}
 }
 


### PR DESCRIPTION
handle this error automatically by marking them as no compact

```
2 errors: add series: symbol table size exceeds 4294967295 bytes: 4904754086; symbol table size exceeds 4294967295 bytes: 4904754086\nwhole compaction error\nmain.runCompact.func7\n\t/thanos/thanos/cmd/thanos/compact.go:485\nmain.runCompact.func8.
```

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
