### PR TITLE
[ES-1413137] parallel cleanup

### DIFF
--- a/pkg/compact/progress.go
+++ b/pkg/compact/progress.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const ParallelLimit = 1024
+
 type CompactorState int64
 
 // Use a gauge to track the state of a compactor pod.


### PR DESCRIPTION
Azure took very long time to apply retention or cleanup, parallelize these operations (bounded):

<img width="835" alt="Screenshot 2025-04-04 at 9 20 37 PM" src="https://github.com/user-attachments/assets/3a05cc15-96d4-4aa4-af4d-5c7a8126de4f" />

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
