### PR TITLE
compacted block can encounter this issue too

### DIFF
--- a/pkg/compact/overlapping.go
+++ b/pkg/compact/overlapping.go
@@ -138,10 +138,6 @@ func (o OverlappingCompactionLifecycleCallback) HandleError(ctx context.Context,
 	level.Error(logger).Log("msg", "failed to compact blocks", "err", compactErr)
 	if strings.Contains(compactErr.Error(), symbolTableSizeExceedsError) {
 		for _, m := range toCompact {
-			if m.Thanos.Source != metadata.ReceiveSource {
-				level.Debug(logger).Log("msg", "bypass blocks that are already compacted", "block", m.String())
-				continue
-			}
 			if m.Stats.NumSeries < symbolTableSizeLimit {
 				level.Warn(logger).Log("msg", "bypass small blocks", "block", m.String(), "series", m.Stats.NumSeries)
 				continue


### PR DESCRIPTION
```
ts=2025-04-08T21:09:58.766161658Z caller=main.go:172 level=error name=pantheon-compactor err="group 0@5967091127469975657: compact blocks [/var/thanos/data/compact/0@5967091127469975657/01JR7WXGZS5G7CCCJK2KZJG2SJ /var/thanos/data/compact/0@5967091127469975657/01JR7XJ6A71ADYWWHVXVCN1EAF /var/thanos/data/compact/0@5967091127469975657/01JR7Y6Q96YSXK5E4A7BERPRM1 /var/thanos/data/compact/0@5967091127469975657/01JR7YW5K7FQG4T0GEFRZADNYB /var/thanos/data/compact/0@5967091127469975657/01JR9XMBA3A00EGTWPKJ4JMDX3 /var/thanos/data/compact/0@5967091127469975657/01JRB800X6B02SE8RETCMPQNVM], handled 0 errors: 2 errors: add series: symbol table size exceeds 4294967295 bytes: 6334283905; symbol table size exceeds 4294967295 bytes: 6334283905\nwhole compaction error\nmain.runCompact.func7\n\t/thanos/thanos/cmd/thanos/compact.go:485\nmain.runCompact.func8.1\n\t/thanos/thanos/cmd/thanos/compact.go:582\ngithub.com/thanos-io/thanos/pkg/runutil.Repeat\n\t/thanos/thanos/pkg/runutil/runutil.go:91\nmain.runCompact.func8\n\t/thanos/thanos/cmd/thanos/compact.go:581\ngithub.com/oklog/run.(*Group).Run.func1\n\t/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700\ncritical error detected\nmain.runCompact.func8.1\n\t/thanos/thanos/cmd/thanos/compact.go:596\ngithub.com/thanos-io/thanos/pkg/runutil.Repeat\n\t/thanos/thanos/pkg/runutil/runutil.go:91\nmain.runCompact.func8\n\t/thanos/thanos/cmd/thanos/compact.go:581\ngithub.com/oklog/run.(*Group).Run.func1\n\t/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700\ncompact command failed\nmain.main\n\t/thanos/thanos/cmd/thanos/main.go:172\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:272\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700"
```
<img width="1698" alt="Screenshot 2025-04-08 at 3 10 33 PM" src="https://github.com/user-attachments/assets/b69d8250-3eec-459a-bf67-e5bc70f42272" />

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
