### PR TITLE
Thanos Streamer supports dropping a replica label

### DIFF
--- a/cmd/thanos/streamer_test.go
+++ b/cmd/thanos/streamer_test.go
@@ -45,9 +45,15 @@ func TestConvertToSeriesReq(t *testing.T) {
 		MaxTime:    streamerReq.EndTimestampMs,
 		SkipChunks: streamerReq.SkipChunks,
 	}
+	config := &StreamerConfig{}
 
-	actualReq := convertToSeriesReq(streamerReq)
+	actualReq := convertToSeriesReq(config, streamerReq)
 	assert.Equal(t, expectedReq, actualReq, "Expected SeriesRequest to match")
+
+	config.replicaLabel = "replica"
+	expectedReq.WithoutReplicaLabels = []string{"replica"}
+	actualReq = convertToSeriesReq(config, streamerReq)
+	assert.Equal(t, expectedReq, actualReq, "Expected SeriesRequest to match with replica label removed")
 }
 
 type grpcServer struct {

--- a/cmd/thanos/tools_streamer.go
+++ b/cmd/thanos/tools_streamer.go
@@ -71,13 +71,6 @@ func runStreamerTool(conf *streamerToolConfig, logger log.Logger) error {
 		EndTimestampMs:   startMs + 4*3600*1000,
 		SkipChunks:       conf.skipChunks,
 		Metric:           conf.metric,
-		LabelMatchers: []streamer_pkg.LabelMatcher{
-			{
-				Name:  "__replica__",
-				Value: "",
-				Type:  streamer_pkg.LabelMatcher_EQ,
-			},
-		},
 	}
 
 	level.Info(logger).Log(


### PR DESCRIPTION
# Unit test
```
$ go test  github.com/thanos-io/thanos/cmd/thanos
```
# Run the Streamer and Streamer tool
```
$ make build
$ ~/go/bin/thanos streamer --stream.replica_label=__replica__
$ ~/go/bin/thanos tools streamer --hours_ago=3 --skip_chunks
```