### PR TITLE
fix Pull iterator data race

### DIFF
--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -558,13 +558,13 @@ func newAsyncRespSet(
 func (l *lazyRespSet) Close() {
 	l.bufferedResponsesMtx.Lock()
 	defer l.bufferedResponsesMtx.Unlock()
+	_ = l.cl.CloseSend()
 
 	l.closeSeries()
 	l.noMoreData = true
 	l.dataOrFinishEvent.Signal()
 
 	l.shardMatcher.Close()
-	_ = l.cl.CloseSend()
 }
 
 // eagerRespSet is a SeriesSet that blocks until all data is retrieved from
@@ -750,11 +750,11 @@ func sortWithoutLabels(set []*storepb.SeriesResponse, labelsToRemove map[string]
 }
 
 func (l *eagerRespSet) Close() {
+	_ = l.cl.CloseSend()
 	if l.closeSeries != nil {
 		l.closeSeries()
 	}
 	l.shardMatcher.Close()
-	_ = l.cl.CloseSend()
 }
 
 func (l *eagerRespSet) At() *storepb.SeriesResponse {

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -558,13 +558,13 @@ func newAsyncRespSet(
 func (l *lazyRespSet) Close() {
 	l.bufferedResponsesMtx.Lock()
 	defer l.bufferedResponsesMtx.Unlock()
-	_ = l.cl.CloseSend()
 
 	l.closeSeries()
 	l.noMoreData = true
 	l.dataOrFinishEvent.Signal()
 
 	l.shardMatcher.Close()
+	_ = l.cl.CloseSend()
 }
 
 // eagerRespSet is a SeriesSet that blocks until all data is retrieved from
@@ -750,11 +750,11 @@ func sortWithoutLabels(set []*storepb.SeriesResponse, labelsToRemove map[string]
 }
 
 func (l *eagerRespSet) Close() {
-	_ = l.cl.CloseSend()
 	if l.closeSeries != nil {
 		l.closeSeries()
 	}
 	l.shardMatcher.Close()
+	_ = l.cl.CloseSend()
 }
 
 func (l *eagerRespSet) At() *storepb.SeriesResponse {

--- a/pkg/store/storepb/inprocess.go
+++ b/pkg/store/storepb/inprocess.go
@@ -53,8 +53,8 @@ func newInProcessClient(ctx context.Context, next func() (*SeriesResponse, error
 
 func (c *inProcessClient) Recv() (*SeriesResponse, error) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	resp, err, ok := c.next()
-	c.mu.Unlock()
 	if err != nil {
 		c.stop()
 		return nil, err
@@ -74,8 +74,8 @@ func (c *inProcessClient) Context() context.Context {
 
 func (c *inProcessClient) CloseSend() error {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.stop()
-	c.mu.Unlock()
 	return nil
 }
 

--- a/pkg/store/storepb/inprocess.go
+++ b/pkg/store/storepb/inprocess.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"iter"
+	"sync"
 
 	"google.golang.org/grpc"
 )
@@ -38,6 +39,7 @@ type inProcessClient struct {
 	ctx  context.Context
 	next func() (*SeriesResponse, error, bool)
 	stop func()
+	mu   sync.Mutex
 }
 
 func newInProcessClient(ctx context.Context, next func() (*SeriesResponse, error, bool), stop func()) *inProcessClient {
@@ -45,11 +47,14 @@ func newInProcessClient(ctx context.Context, next func() (*SeriesResponse, error
 		ctx:  ctx,
 		next: next,
 		stop: stop,
+		mu:   sync.Mutex{},
 	}
 }
 
 func (c *inProcessClient) Recv() (*SeriesResponse, error) {
+	c.mu.Lock()
 	resp, err, ok := c.next()
+	c.mu.Unlock()
 	if err != nil {
 		c.stop()
 		return nil, err
@@ -68,7 +73,9 @@ func (c *inProcessClient) Context() context.Context {
 }
 
 func (c *inProcessClient) CloseSend() error {
+	c.mu.Lock()
 	c.stop()
+	c.mu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Go's Pull iterator prohibits calling `next()` and `stop()` simultaneously ([code pointer](https://github.com/golang/go/blob/a204ed53d907c3b325e3c2bdd6f847a8f97e90d9/src/iter/iter.go#L254)). Use a mutex to protect Recv() and CloseSend() which essentially calls `next()` and `stop()`.
The race is introduced in https://github.com/thanos-io/thanos/pull/7821 and happens rarely during a query timeout