### PR TITLE
Put rewriter change into release

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -245,7 +245,9 @@ func registerQuery(app *extkingpin.App) {
 	enforceTenancy := cmd.Flag("query.enforce-tenancy", "Enforce tenancy on Query APIs. Responses are returned only if the label value of the configured tenant-label-name and the value of the tenant header matches.").Default("false").Bool()
 	tenantLabel := cmd.Flag("query.tenant-label-name", "Label name to use when enforcing tenancy (if --query.enforce-tenancy is enabled).").Default(tenancy.DefaultTenantLabel).String()
 
-	rewriteAggregationLabelTo := cmd.Flag("query.aggregation-label-value-override", "The value override for __rollup__ label for aggregated metrics. If set to x, all queries on aggregated metrics will have a __rollup__=x matcher. Leave empty to disable this behavior. Default is empty.").Default("").String()
+	rewriteAggregationLabelName := cmd.Flag("query.aggregation-label-name", "The name for aggregation label. See query.aggregation-label-value-override for details. Default is empty.").Default("").String()
+	rewriteAggregationLabelTo := cmd.Flag("query.aggregation-label-value-override", "The value override for aggregation label. If set to x, all queries on aggregated metrics will have a `rewriteAggregationLabelName=x` matcher. Leave either flag empty to disable this behavior. Default is empty.").Default("").String()
+	rewriteAggregationInsertOnly := cmd.Flag("query.aggregation-label-insert-only", "If enabled, the above rewriter only insert missing rewriteAggregationLabelName=x and does not modify existing aggregation labels if any. Default is false.").Default("false").Bool()
 
 	var storeRateLimits store.SeriesSelectLimits
 	storeRateLimits.RegisterFlags(cmd)
@@ -386,7 +388,9 @@ func registerQuery(app *extkingpin.App) {
 			*enforceTenancy,
 			*tenantLabel,
 			*enableGroupReplicaPartialStrategy,
+			*rewriteAggregationLabelName,
 			*rewriteAggregationLabelTo,
+			*rewriteAggregationInsertOnly,
 		)
 	})
 }
@@ -471,7 +475,9 @@ func runQuery(
 	enforceTenancy bool,
 	tenantLabel string,
 	groupReplicaPartialResponseStrategy bool,
+	rewriteAggregationLabelName string,
 	rewriteAggregationLabelTo string,
+	rewriteAggregationInsertOnly bool,
 ) error {
 	comp := component.Query
 	if alertQueryURL == "" {
@@ -601,6 +607,8 @@ func runQuery(
 	opts := query.Options{
 		GroupReplicaPartialResponseStrategy: groupReplicaPartialResponseStrategy,
 		DeduplicationFunc:                   queryDeduplicationFunc,
+		RewriteAggregationInsertOnly:        rewriteAggregationInsertOnly,
+		RewriteAggregationLabelName:         rewriteAggregationLabelName,
 		RewriteAggregationLabelTo:           rewriteAggregationLabelTo,
 	}
 	level.Info(logger).Log("msg", "databricks querier features", "opts", fmt.Sprintf("%+v", opts))

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -245,9 +245,8 @@ func registerQuery(app *extkingpin.App) {
 	enforceTenancy := cmd.Flag("query.enforce-tenancy", "Enforce tenancy on Query APIs. Responses are returned only if the label value of the configured tenant-label-name and the value of the tenant header matches.").Default("false").Bool()
 	tenantLabel := cmd.Flag("query.tenant-label-name", "Label name to use when enforcing tenancy (if --query.enforce-tenancy is enabled).").Default(tenancy.DefaultTenantLabel).String()
 
-	rewriteAggregationLabelName := cmd.Flag("query.aggregation-label-name", "The name for aggregation label. See query.aggregation-label-value-override for details. Default is empty.").Default("").String()
-	rewriteAggregationLabelTo := cmd.Flag("query.aggregation-label-value-override", "The value override for aggregation label. If set to x, all queries on aggregated metrics will have a `rewriteAggregationLabelName=x` matcher. Leave either flag empty to disable this behavior. Default is empty.").Default("").String()
-	rewriteAggregationInsertOnly := cmd.Flag("query.aggregation-label-insert-only", "If enabled, the above rewriter only insert missing rewriteAggregationLabelName=x and does not modify existing aggregation labels if any. Default is false.").Default("false").Bool()
+	rewriteAggregationLabelStrategy := cmd.Flag("query.aggregation-label-strategy", "The strategy to use when rewriting aggregation labels. Used during aggregator migration only.").Default(string(query.NoopLabelRewriter)).Hidden().Enum(string(query.NoopLabelRewriter), string(query.UpsertLabelRewriter), string(query.InsertOnlyLabelRewriter))
+	rewriteAggregationLabelTo := cmd.Flag("query.aggregation-label-value-override", "The value override for aggregation label. If set to x, all queries on aggregated metrics will have a `__agg_rule_type__=x` matcher. If empty, this behavior is disabled. Default is empty.").Hidden().Default("").String()
 
 	var storeRateLimits store.SeriesSelectLimits
 	storeRateLimits.RegisterFlags(cmd)
@@ -388,9 +387,8 @@ func registerQuery(app *extkingpin.App) {
 			*enforceTenancy,
 			*tenantLabel,
 			*enableGroupReplicaPartialStrategy,
-			*rewriteAggregationLabelName,
+			*rewriteAggregationLabelStrategy,
 			*rewriteAggregationLabelTo,
-			*rewriteAggregationInsertOnly,
 		)
 	})
 }
@@ -475,9 +473,8 @@ func runQuery(
 	enforceTenancy bool,
 	tenantLabel string,
 	groupReplicaPartialResponseStrategy bool,
-	rewriteAggregationLabelName string,
+	rewriteAggregationLabelStrategy string,
 	rewriteAggregationLabelTo string,
-	rewriteAggregationInsertOnly bool,
 ) error {
 	comp := component.Query
 	if alertQueryURL == "" {
@@ -607,8 +604,7 @@ func runQuery(
 	opts := query.Options{
 		GroupReplicaPartialResponseStrategy: groupReplicaPartialResponseStrategy,
 		DeduplicationFunc:                   queryDeduplicationFunc,
-		RewriteAggregationInsertOnly:        rewriteAggregationInsertOnly,
-		RewriteAggregationLabelName:         rewriteAggregationLabelName,
+		RewriteAggregationLabelStrategy:     rewriteAggregationLabelStrategy,
 		RewriteAggregationLabelTo:           rewriteAggregationLabelTo,
 	}
 	level.Info(logger).Log("msg", "databricks querier features", "opts", fmt.Sprintf("%+v", opts))

--- a/pkg/query/aggregation_label_rewriter.go
+++ b/pkg/query/aggregation_label_rewriter.go
@@ -77,7 +77,7 @@ func NewAggregationLabelRewriter(logger log.Logger, reg prometheus.Registerer, l
 		logger = log.NewNopLogger()
 	}
 	return &AggregationLabelRewriter{
-		enabled:           desiredLabelValue != "" || labelKey != "",
+		enabled:           desiredLabelValue != "" && labelKey != "",
 		logger:            logger,
 		metrics:           newAggregationLabelRewriterMetrics(reg, desiredLabelValue),
 		insertOnly:        insertOnly,

--- a/pkg/query/aggregation_label_rewriter.go
+++ b/pkg/query/aggregation_label_rewriter.go
@@ -14,13 +14,26 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-type AggregationLabelRewriter struct {
-	logger  log.Logger
-	metrics *aggregationLabelRewriterMetrics
+// RewriterStrategy defines the strategy used by the AggregationLabelRewriter.
+type RewriterStrategy string
 
-	enabled           bool
-	insertOnly        bool
-	labelKey          string
+const (
+	// NoopLabelRewriter is a no-op strategy that basically disables the rewriter.
+	NoopLabelRewriter RewriterStrategy = "noop"
+	// UpsertLabelRewriter is a strategy that upserts the aggregation label.
+	UpsertLabelRewriter RewriterStrategy = "upsert"
+	// InsertOnlyLabelRewriter is a strategy that only inserts the aggregation label if it does not exist.
+	InsertOnlyLabelRewriter RewriterStrategy = "insert-only"
+)
+
+const (
+	aggregationLabelName = "__agg_rule_type__"
+)
+
+type AggregationLabelRewriter struct {
+	logger            log.Logger
+	metrics           *aggregationLabelRewriterMetrics
+	strategy          RewriterStrategy
 	desiredLabelValue string
 }
 
@@ -68,26 +81,27 @@ func newAggregationLabelRewriterMetrics(reg prometheus.Registerer, desiredLabelV
 
 func NewNopAggregationLabelRewriter() *AggregationLabelRewriter {
 	return &AggregationLabelRewriter{
-		enabled: false,
+		strategy: NoopLabelRewriter,
 	}
 }
 
-func NewAggregationLabelRewriter(logger log.Logger, reg prometheus.Registerer, labelKey string, desiredLabelValue string, insertOnly bool) *AggregationLabelRewriter {
+func NewAggregationLabelRewriter(logger log.Logger, reg prometheus.Registerer, strategy RewriterStrategy, desiredLabelValue string) *AggregationLabelRewriter {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
+	if desiredLabelValue == "" {
+		strategy = NoopLabelRewriter
+	}
 	return &AggregationLabelRewriter{
-		enabled:           desiredLabelValue != "" && labelKey != "",
+		strategy:          strategy,
 		logger:            logger,
 		metrics:           newAggregationLabelRewriterMetrics(reg, desiredLabelValue),
-		insertOnly:        insertOnly,
-		labelKey:          labelKey,
 		desiredLabelValue: desiredLabelValue,
 	}
 }
 
 func (a *AggregationLabelRewriter) Rewrite(ms []*labels.Matcher) []*labels.Matcher {
-	if !a.enabled {
+	if a.strategy == NoopLabelRewriter {
 		return ms
 	}
 
@@ -118,13 +132,13 @@ func (a *AggregationLabelRewriter) Rewrite(ms []*labels.Matcher) []*labels.Match
 				break
 			}
 			// In any case, if we see an aggregation label, we store that for later use
-		} else if m.Name == a.labelKey {
+		} else if m.Name == aggregationLabelName {
 			aggregationLabelMatcher = m
 			aggregationLabelIndex = i
 		}
 	}
 
-	if aggregationLabelMatcher != nil && a.insertOnly {
+	if aggregationLabelMatcher != nil && a.strategy == InsertOnlyLabelRewriter {
 		needsRewrite = false
 		skipReason = "insert-only"
 	}
@@ -133,7 +147,7 @@ func (a *AggregationLabelRewriter) Rewrite(ms []*labels.Matcher) []*labels.Match
 	// but if it is true, we either append or modify an aggregation label
 	if needsRewrite {
 		newMatcher := &labels.Matcher{
-			Name:  a.labelKey,
+			Name:  aggregationLabelName,
 			Type:  labels.MatchRegexp,
 			Value: a.desiredLabelValue,
 		}

--- a/pkg/query/aggregation_label_rewriter.go
+++ b/pkg/query/aggregation_label_rewriter.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	aggregationLabelName = "__rollup__"
+	aggregationLabelName = "__agg_rule_type__"
 )
 
 type AggregationLabelRewriter struct {
@@ -128,7 +128,7 @@ func (a *AggregationLabelRewriter) Rewrite(ms []*labels.Matcher) []*labels.Match
 	if needsRewrite {
 		newMatcher := &labels.Matcher{
 			Name:  aggregationLabelName,
-			Type:  labels.MatchEqual,
+			Type:  labels.MatchRegexp,
 			Value: a.desiredLabelValue,
 		}
 		if aggregationLabelMatcher != nil {

--- a/pkg/query/aggregation_label_rewriter.go
+++ b/pkg/query/aggregation_label_rewriter.go
@@ -77,7 +77,7 @@ func NewAggregationLabelRewriter(logger log.Logger, reg prometheus.Registerer, l
 		logger = log.NewNopLogger()
 	}
 	return &AggregationLabelRewriter{
-		enabled:           desiredLabelValue != "",
+		enabled:           desiredLabelValue != "" || labelKey != "",
 		logger:            logger,
 		metrics:           newAggregationLabelRewriterMetrics(reg, desiredLabelValue),
 		insertOnly:        insertOnly,

--- a/pkg/query/aggregation_label_rewriter.go
+++ b/pkg/query/aggregation_label_rewriter.go
@@ -14,15 +14,13 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-const (
-	aggregationLabelName = "__agg_rule_type__"
-)
-
 type AggregationLabelRewriter struct {
 	logger  log.Logger
 	metrics *aggregationLabelRewriterMetrics
 
 	enabled           bool
+	insertOnly        bool
+	labelKey          string
 	desiredLabelValue string
 }
 
@@ -74,7 +72,7 @@ func NewNopAggregationLabelRewriter() *AggregationLabelRewriter {
 	}
 }
 
-func NewAggregationLabelRewriter(logger log.Logger, reg prometheus.Registerer, desiredLabelValue string) *AggregationLabelRewriter {
+func NewAggregationLabelRewriter(logger log.Logger, reg prometheus.Registerer, labelKey string, desiredLabelValue string, insertOnly bool) *AggregationLabelRewriter {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -82,6 +80,8 @@ func NewAggregationLabelRewriter(logger log.Logger, reg prometheus.Registerer, d
 		enabled:           desiredLabelValue != "",
 		logger:            logger,
 		metrics:           newAggregationLabelRewriterMetrics(reg, desiredLabelValue),
+		insertOnly:        insertOnly,
+		labelKey:          labelKey,
 		desiredLabelValue: desiredLabelValue,
 	}
 }
@@ -118,16 +118,22 @@ func (a *AggregationLabelRewriter) Rewrite(ms []*labels.Matcher) []*labels.Match
 				break
 			}
 			// In any case, if we see an aggregation label, we store that for later use
-		} else if m.Name == aggregationLabelName {
+		} else if m.Name == a.labelKey {
 			aggregationLabelMatcher = m
 			aggregationLabelIndex = i
 		}
 	}
+
+	if aggregationLabelMatcher != nil && a.insertOnly {
+		needsRewrite = false
+		skipReason = "insert-only"
+	}
+
 	// After the for loop, if needsRewrite is false, no need to do anything
 	// but if it is true, we either append or modify an aggregation label
 	if needsRewrite {
 		newMatcher := &labels.Matcher{
-			Name:  aggregationLabelName,
+			Name:  a.labelKey,
 			Type:  labels.MatchRegexp,
 			Value: a.desiredLabelValue,
 		}

--- a/pkg/query/aggregation_label_rewriter_test.go
+++ b/pkg/query/aggregation_label_rewriter_test.go
@@ -41,20 +41,33 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 			},
 			expectedMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
-				labels.MustNewMatcher(labels.MatchEqual, "__rollup__", "5m"),
+				labels.MustNewMatcher(labels.MatchRegexp, aggregationLabelName, "5m"),
 			},
 			expectedAddCount: 1,
 		},
 		{
-			name:              "should rewrite existing aggregation label for aggregated metric",
+			name:              "should rewrite existing equal aggregation label for aggregated metric",
 			desiredLabelValue: "5m",
 			inputMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
-				labels.MustNewMatcher(labels.MatchEqual, "__rollup__", "1h"),
+				labels.MustNewMatcher(labels.MatchEqual, aggregationLabelName, "1h"),
 			},
 			expectedMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
-				labels.MustNewMatcher(labels.MatchEqual, "__rollup__", "5m"),
+				labels.MustNewMatcher(labels.MatchRegexp, aggregationLabelName, "5m"),
+			},
+			expectedRewriteMap: map[string]float64{"1h": 1},
+		},
+		{
+			name:              "should rewrite existing regex aggregation label for aggregated metric",
+			desiredLabelValue: "5m",
+			inputMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
+				labels.MustNewMatcher(labels.MatchRegexp, aggregationLabelName, "1h"),
+			},
+			expectedMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
+				labels.MustNewMatcher(labels.MatchRegexp, aggregationLabelName, "5m"),
 			},
 			expectedRewriteMap: map[string]float64{"1h": 1},
 		},

--- a/pkg/query/aggregation_label_rewriter_test.go
+++ b/pkg/query/aggregation_label_rewriter_test.go
@@ -11,12 +11,17 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
+const (
+	aggregationLabelName = "__agg_rule_type__"
+)
+
 func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
 		name               string
 		desiredLabelValue  string // Empty means disabled
+		insertOnly         bool
 		inputMatchers      []*labels.Matcher
 		expectedMatchers   []*labels.Matcher
 		expectedSkipCount  float64
@@ -104,13 +109,29 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 			},
 			expectedSkipCount: 1,
 		},
+		{
+			name:              "if insert only, should NOT rewrite existing aggregation label for aggregated metric",
+			desiredLabelValue: "5m",
+			insertOnly:        true,
+			inputMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
+				labels.MustNewMatcher(labels.MatchEqual, aggregationLabelName, "1h"),
+			},
+			expectedMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
+				labels.MustNewMatcher(labels.MatchEqual, aggregationLabelName, "1h"),
+			},
+			expectedSkipCount: 1,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := prometheus.NewRegistry()
 			rewriter := NewAggregationLabelRewriter(
 				nil,
 				reg,
+				aggregationLabelName,
 				tc.desiredLabelValue,
+				tc.insertOnly,
 			)
 
 			result := rewriter.Rewrite(tc.inputMatchers)

--- a/pkg/query/aggregation_label_rewriter_test.go
+++ b/pkg/query/aggregation_label_rewriter_test.go
@@ -11,17 +11,13 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-const (
-	aggregationLabelName = "__agg_rule_type__"
-)
-
 func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
 		name               string
 		desiredLabelValue  string // Empty means disabled
-		insertOnly         bool
+		strategy           RewriterStrategy
 		inputMatchers      []*labels.Matcher
 		expectedMatchers   []*labels.Matcher
 		expectedSkipCount  float64
@@ -30,7 +26,19 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 	}{
 		{
 			name:              "disabled rewriter should not modify label matchers",
+			desiredLabelValue: "v1",
+			strategy:          NoopLabelRewriter,
+			inputMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
+			},
+			expectedMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
+			},
+		},
+		{
+			name:              "no desired label value makes a disabled rewriter and should not modify label matchers",
 			desiredLabelValue: "",
+			strategy:          UpsertLabelRewriter,
 			inputMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
 			},
@@ -41,6 +49,7 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 		{
 			name:              "should add label for aggregated metric if no existing aggregation label",
 			desiredLabelValue: "5m",
+			strategy:          UpsertLabelRewriter,
 			inputMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
 			},
@@ -53,6 +62,7 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 		{
 			name:              "should rewrite existing equal aggregation label for aggregated metric",
 			desiredLabelValue: "5m",
+			strategy:          UpsertLabelRewriter,
 			inputMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
 				labels.MustNewMatcher(labels.MatchEqual, aggregationLabelName, "1h"),
@@ -66,6 +76,7 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 		{
 			name:              "should rewrite existing regex aggregation label for aggregated metric",
 			desiredLabelValue: "5m",
+			strategy:          UpsertLabelRewriter,
 			inputMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
 				labels.MustNewMatcher(labels.MatchRegexp, aggregationLabelName, "1h"),
@@ -79,6 +90,7 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 		{
 			name:              "should skip non-aggregated metric",
 			desiredLabelValue: "5m",
+			strategy:          UpsertLabelRewriter,
 			inputMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test_metric"),
 			},
@@ -90,6 +102,7 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 		{
 			name:              "should skip non-equal name matcher",
 			desiredLabelValue: "5m",
+			strategy:          UpsertLabelRewriter,
 			inputMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchRegexp, "__name__", "test:sum"),
 			},
@@ -101,6 +114,7 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 		{
 			name:              "should skip when no name matcher",
 			desiredLabelValue: "5m",
+			strategy:          UpsertLabelRewriter,
 			inputMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
 			},
@@ -112,7 +126,7 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 		{
 			name:              "if insert only, should NOT rewrite existing aggregation label for aggregated metric",
 			desiredLabelValue: "5m",
-			insertOnly:        true,
+			strategy:          InsertOnlyLabelRewriter,
 			inputMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "__name__", "test:sum"),
 				labels.MustNewMatcher(labels.MatchEqual, aggregationLabelName, "1h"),
@@ -129,9 +143,8 @@ func TestAggregationLabelRewriter_Rewrite(t *testing.T) {
 			rewriter := NewAggregationLabelRewriter(
 				nil,
 				reg,
-				aggregationLabelName,
+				tc.strategy,
 				tc.desiredLabelValue,
-				tc.insertOnly,
 			)
 
 			result := rewriter.Rewrite(tc.inputMatchers)

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -61,9 +61,8 @@ type QueryableCreator func(
 type Options struct {
 	GroupReplicaPartialResponseStrategy bool
 	DeduplicationFunc                   string
-	RewriteAggregationLabelName         string
+	RewriteAggregationLabelStrategy     string
 	RewriteAggregationLabelTo           string
-	RewriteAggregationInsertOnly        bool
 }
 
 // NewQueryableCreator creates QueryableCreator.
@@ -96,9 +95,8 @@ func NewQueryableCreatorWithOptions(
 	aggregationLabelRewriter := NewAggregationLabelRewriter(
 		logger,
 		extprom.WrapRegistererWithPrefix("aggregation_label_rewriter_", reg),
-		opts.RewriteAggregationLabelName,
+		RewriterStrategy(opts.RewriteAggregationLabelStrategy),
 		opts.RewriteAggregationLabelTo,
-		opts.RewriteAggregationInsertOnly,
 	)
 	return func(
 		deduplicate bool,

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -61,7 +61,9 @@ type QueryableCreator func(
 type Options struct {
 	GroupReplicaPartialResponseStrategy bool
 	DeduplicationFunc                   string
+	RewriteAggregationLabelName         string
 	RewriteAggregationLabelTo           string
+	RewriteAggregationInsertOnly        bool
 }
 
 // NewQueryableCreator creates QueryableCreator.
@@ -94,7 +96,9 @@ func NewQueryableCreatorWithOptions(
 	aggregationLabelRewriter := NewAggregationLabelRewriter(
 		logger,
 		extprom.WrapRegistererWithPrefix("aggregation_label_rewriter_", reg),
+		opts.RewriteAggregationLabelName,
 		opts.RewriteAggregationLabelTo,
+		opts.RewriteAggregationInsertOnly,
 	)
 	return func(
 		deduplicate bool,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

As part of aggregator migration we implement relevant label rewriting logic on thanos querier side to modify aggregator labels on query at query time. This PR cuts those changes into release branch.

This is an ancestor commit of db_main branch to include changes in https://github.com/databricks/thanos/pull/154 (merged to db_main 2 weeks ago)

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

The changes included in this pr exists in db_main branch and has been running in staging for a week, and no significant change in query kpi dash, [no relevant alert found](https://databricks.pagerduty.com/search/?endDate=2025-05-12&searchString=staging-aws-us-east-1-obs1&sortBy=relevance&startDate=2025-05-05&team[]=P9CJO10)

<img width="828" alt="image" src="https://github.com/user-attachments/assets/b986067e-ea87-49f8-b7c4-a36a3e5ace51" />


