### PR TITLE
[ES-1458485] lower no compaction limit

### DIFF
--- a/pkg/compact/overlapping.go
+++ b/pkg/compact/overlapping.go
@@ -23,7 +23,7 @@ const (
 	overlappingReason = "blocks-overlapping"
 
 	symbolTableSizeExceedsError = "symbol table size exceeds"
-	symbolTableSizeLimit        = 1024 * 1024
+	symbolTableSizeLimit        = 512 * 1024 // lower this limits
 )
 
 type OverlappingCompactionLifecycleCallback struct {


### PR DESCRIPTION
to fix this warnings, the idea is we only want to mark large blocks no compaction but still try to compact smaller blocks

```
ts=2025-05-12T23:23:59.235565728Z caller=overlapping.go:138 level=error name=pantheon-compactor group="0@{__tenant__=\"eng-host-networking\"}" groupKey=0@18182447385824296036 msg="failed to compact blocks" err="2 errors: add series: symbol table size exceeds 4294967295 bytes: 4598600787; symbol table size exceeds 4294967295 bytes: 4598600787"
ts=2025-05-12T23:23:59.235649862Z caller=overlapping.go:142 level=warn name=pantheon-compactor group="0@{__tenant__=\"eng-host-networking\"}" groupKey=0@18182447385824296036 msg="bypass small blocks" block="01JSR16JR14NPPQ60X9XHMCV8M (min time: 1745452800000, max time: 1745625600000)" series=711562
ts=2025-05-12T23:23:59.235665029Z caller=overlapping.go:142 level=warn name=pantheon-compactor group="0@{__tenant__=\"eng-host-networking\"}" groupKey=0@18182447385824296036 msg="bypass small blocks" block="01JSX60817W997YA9BEEFB004Y (min time: 1745625600000, max time: 1745798400000)" series=515684
ts=2025-05-12T23:23:59.235672167Z caller=overlapping.go:142 level=warn name=pantheon-compactor group="0@{__tenant__=\"eng-host-networking\"}" groupKey=0@18182447385824296036 msg="bypass small blocks" block="01JT2AT3AFT8NMVCS5H9ZM9DTA (min time: 1745798400000, max time: 1745971200000)" series=760770
ts=2025-05-12T23:23:59.23568043Z caller=overlapping.go:142 level=warn name=pantheon-compactor group="0@{__tenant__=\"eng-host-networking\"}" groupKey=0@18182447385824296036 msg="bypass small blocks" block="01JT7FPH3V5Y1DWP37NTQVKVKG (min time: 1745971200000, max time: 1746144000000)" series=823049
ts=2025-05-12T23:23:59.235686425Z caller=overlapping.go:142 level=warn name=pantheon-compactor group="0@{__tenant__=\"eng-host-networking\"}" groupKey=0@18182447385824296036 msg="bypass small blocks" block="01JTCMFW3BESTBB1PBZF0X7T9P (min time: 1746144000000, max time: 1746316800000)" series=613975
ts=2025-05-12T23:23:59.235692501Z caller=overlapping.go:142 level=warn name=pantheon-compactor group="0@{__tenant__=\"eng-host-networking\"}" groupKey=0@18182447385824296036 msg="bypass small blocks" block="01JTHS9K00RKH62NDRN900MQDD (min time: 1746316800000, max time: 1746489600000)" series=565526
ts=2025-05-12T23:23:59.235699894Z caller=overlapping.go:142 level=warn name=pantheon-compactor group="0@{__tenant__=\"eng-host-networking\"}" groupKey=0@18182447385824296036 msg="bypass small blocks" block="01JTPQHQ2MKPWR4R971QW62JBB (min time: 1746489600000, max time: 1746662400000)" series=792913
```

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
