### PR TITLE
handle new compact error

### DIFF
--- a/pkg/compact/overlapping_test.go
+++ b/pkg/compact/overlapping_test.go
@@ -181,6 +181,26 @@ func TestHandleError(t *testing.T) {
 			handledErrs: 1,
 			errBlockIdx: 2,
 		},
+		{
+			testName: "length size exceeds error - only large blocks marked",
+			input: []*metadata.Meta{
+				createCustomBlockMeta(1, 1, 2, metadata.ReceiveSource, 1024),
+				createCustomBlockMeta(2, 1, 6, metadata.CompactorSource, 2*1024*1024),
+			},
+			err:         errors.New(lengthSizeExceedsError + " postings offset table"),
+			handledErrs: 1,
+			errBlockIdx: 1,
+		},
+		{
+			testName: "symbol table size exceeds with small blocks bypassed",
+			input: []*metadata.Meta{
+				createCustomBlockMeta(1, 1, 2, metadata.ReceiveSource, 1024),
+				createCustomBlockMeta(2, 1, 6, metadata.CompactorSource, 2*1024*1024),
+			},
+			err:         errors.New(symbolTableSizeExceedsError + " too large"),
+			handledErrs: 1,
+			errBlockIdx: 1,
+		},
 	} {
 		t.Run(tcase.testName, func(t *testing.T) {
 			ctx := context.Background()


### PR DESCRIPTION
length size exceeds 4 bytes is a new error we haven't seen previously, mark those blocks no compact.

```
/var/thanos/data/compact/0@5035119560150832788/01JYD5A2K45WY2WAS1T0JFCRA7 /var/thanos/data/compact/0@5035119560150832788/01JYJA3C76SN0EANGWN8SRK7Y7 /var/thanos/data/compact/0@5035119560150832788/01JYQG7VQDN9GHRWMKPWDSB4CY /var/thanos/data/compact/0@5035119560150832788/01JYWK93ZZAAZTEFE30B26ESYS /var/thanos/data/compact/0@5035119560150832788/01JZ1R3NN4CET1CXVF7CGKQZ7W /var/thanos/data/compact/0@5035119560150832788/01JZ6V67MTSH5TR8Z1XJBQADN5], handled 0 errors: postings offset table length/crc32 write error: length size exceeds 4 bytes: 4460206851"
ts=2025-07-30T04:40:51.362132623Z caller=http.go:93 level=info name=pantheon-compactor service=http/server component=compact msg="internal server is shutting down" err="critical error detected: whole compaction error: group 0@5035119560150832788: compact blocks [/var/thanos/data/compact/0@5035119560150832788/01JY7YPDA4DDHABQ73JCPMQT1J /var/thanos/data/compact/0@5035119560150832788/01JYD5A2K45WY2WAS1T0JFCRA7 /var/thanos/data/compact/0@5035119560150832788/01JYJA3C76SN0EANGWN8SRK7Y7 /var/thanos/data/compact/0@5035119560150832788/01JYQG7VQDN9GHRWMKPWDSB4CY /var/thanos/data/compact/0@5035119560150832788/01JYWK93ZZAAZTEFE30B26ESYS /var/thanos/data/compact/0@5035119560150832788/01JZ1R3NN4CET1CXVF7CGKQZ7W /var/thanos/data/compact/0@5035119560150832788/01JZ6V67MTSH5TR8Z1XJBQADN5], handled 0 errors: postings offset table length/crc32 write error: length size exceeds 4 bytes: 4460206851"
ts=2025-07-30T04:40:51.362346924Z caller=http.go:112 level=info name=pantheon-compactor service=http/server component=compact msg="internal server is shutdown gracefully" err="critical error detected: whole compaction error: group 0@5035119560150832788: compact blocks [/var/thanos/data/compact/0@5035119560150832788/01JY7YPDA4DDHABQ73JCPMQT1J /var/thanos/data/compact/0@5035119560150832788/01JYD5A2K45WY2WAS1T0JFCRA7 /var/thanos/data/compact/0@5035119560150832788/01JYJA3C76SN0EANGWN8SRK7Y7 /var/thanos/data/compact/0@5035119560150832788/01JYQG7VQDN9GHRWMKPWDSB4CY /var/thanos/data/compact/0@5035119560150832788/01JYWK93ZZAAZTEFE30B26ESYS /var/thanos/data/compact/0@5035119560150832788/01JZ1R3NN4CET1CXVF7CGKQZ7W /var/thanos/data/compact/0@5035119560150832788/01JZ6V67MTSH5TR8Z1XJBQADN5], handled 0 errors: postings offset table length/crc32 write error: length size exceeds 4 bytes: 4460206851"
ts=2025-07-30T04:40:51.362374924Z caller=intrumentation.go:81 level=info name=pantheon-compactor msg="changing probe status" status=not-healthy reason="critical error detected: whole compaction error: group 0@5035119560150832788: compact blocks [/var/thanos/data/compact/0@5035119560150832788/01JY7YPDA4DDHABQ73JCPMQT1J /var/thanos/data/compact/0@5035119560150832788/01JYD5A2K45WY2WAS1T0JFCRA7 /var/thanos/data/compact/0@5035119560150832788/01JYJA3C76SN0EANGWN8SRK7Y7 /var/thanos/data/compact/0@5035119560150832788/01JYQG7VQDN9GHRWMKPWDSB4CY /var/thanos/data/compact/0@5035119560150832788/01JYWK93ZZAAZTEFE30B26ESYS /var/thanos/data/compact/0@5035119560150832788/01JZ1R3NN4CET1CXVF7CGKQZ7W /var/thanos/data/compact/0@5035119560150832788/01JZ6V67MTSH5TR8Z1XJBQADN5], handled 0 errors: postings offset table length/crc32 write error: length size exceeds 4 bytes: 4460206851"
ts=2025-07-30T04:40:51.362520225Z caller=main.go:172 level=error name=pantheon-compactor err="group 0@5035119560150832788: compact blocks [/var/thanos/data/compact/0@5035119560150832788/01JY7YPDA4DDHABQ73JCPMQT1J /var/thanos/data/compact/0@5035119560150832788/01JYD5A2K45WY2WAS1T0JFCRA7 /var/thanos/data/compact/0@5035119560150832788/01JYJA3C76SN0EANGWN8SRK7Y7 /var/thanos/data/compact/0@5035119560150832788/01JYQG7VQDN9GHRWMKPWDSB4CY /var/thanos/data/compact/0@5035119560150832788/01JYWK93ZZAAZTEFE30B26ESYS /var/thanos/data/compact/0@5035119560150832788/01JZ1R3NN4CET1CXVF7CGKQZ7W /var/thanos/data/compact/0@5035119560150832788/01JZ6V67MTSH5TR8Z1XJBQADN5], handled 0 errors: postings offset table length/crc32 write error: length size exceeds 4 bytes: 4460206851\nwhole compaction error\nmain.runCompact.func7\n\t/thanos/thanos/cmd/thanos/compact.go:489\nmain.runCompact.func8.1\n\t/thanos/thanos/cmd/thanos/compact.go:586\ngithub.com/thanos-io/thanos/pkg/runutil.Repeat\n\t/thanos/thanos/pkg/runutil/runutil.go:91\nmain.runCompact.func8\n\t/thanos/thanos/cmd/thanos/compact.go:585\ngithub.com/oklog/run.(*Group).Run.func1\n\t/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700\ncritical error detected\nmain.runCompact.func8.1\n\t/thanos/thanos/cmd/thanos/compact.go:600\ngithub.com/thanos-io/thanos/pkg/runutil.Repeat\n\t/thanos/thanos/pkg/runutil/runutil.go:91\nmain.runCompact.func8\n\t/thanos/thanos/cmd/thanos/compact.go:585\ngithub.com/oklog/run.(*Group).Run.func1\n\t/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700\ncompact command failed\nmain.main\n\t/thanos/thanos/cmd/thanos/main.go:172\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:272\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700"
[prod-azure-uksouth-obs1] [pantheon] [pantheon-compactor-1] >
```

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
