### PR TITLE
Correct email field name in logs

### DIFF
--- a/pkg/queryfrontend/queryinstant_logger.go
+++ b/pkg/queryfrontend/queryinstant_logger.go
@@ -36,7 +36,7 @@ type MetricsInstantQueryLogging struct {
 	Tenant              string `json:"tenant"`
 	ForwardedFor        string `json:"forwardedFor"`
 	UserAgent           string `json:"userAgent"`
-	EmailId             string `json:"emailID"`
+	EmailId             string `json:"emailId"`
 	// Query-related fields (instant query specific)
 	QueryTimestampMs      int64    `json:"queryTimestampMs"` // Query timestamp for instant queries
 	Path                  string   `json:"path"`

--- a/pkg/queryfrontend/queryrange_logger.go
+++ b/pkg/queryfrontend/queryrange_logger.go
@@ -36,7 +36,7 @@ type MetricsRangeQueryLogging struct {
 	Tenant              string `json:"tenant"`
 	ForwardedFor        string `json:"forwardedFor"`
 	UserAgent           string `json:"userAgent"`
-	EmailId             string `json:"emailID"`
+	EmailId             string `json:"emailId"`
 	// Query-related fields
 	StartTimestampMs      int64    `json:"startTimestampMs"`
 	EndTimestampMs        int64    `json:"endTimestampMs"`


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

Change the email field name in json logs from "emailID" to "emailId".
Needed since later in the pipeline camelCase is converted to snake_case

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
