### PR TITLE
Update segregation way to avoid logging queries from rule manager

### DIFF
--- a/pkg/queryfrontend/queryinstant_logger.go
+++ b/pkg/queryfrontend/queryinstant_logger.go
@@ -137,9 +137,8 @@ func (m *instantQueryLoggingMiddleware) logInstantQuery(req *ThanosQueryInstantR
 	// Extract email from response headers
 	email := ExtractEmailFromResponse(resp)
 
-	// If email is empty, don't log the query.
 	// This is to avoid logging queries that come from rule manager.
-	if email == "" {
+	if userInfo.UserAgent == "Databricks-RuleManager/1.0" {
 		return
 	}
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

Update segregation way to avoid logging queries from rule manager
Used the newly added user-agent header from rule manager - "Databricks-RuleManager/1.0"

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
