### PR TITLE
Fix a Query fan out corner case

### DIFF
--- a/pkg/query/endpointset_test.go
+++ b/pkg/query/endpointset_test.go
@@ -1652,3 +1652,50 @@ func TestDeadlockLocking(t *testing.T) {
 
 	testutil.Ok(t, g.Wait())
 }
+
+func TestDefaultTimeRange(t *testing.T) {
+	t.Parallel()
+
+	{
+		endpointRef := &endpointRef{
+			groupKey: "store-grpc-group-svc-pantheon-long-range-store",
+		}
+		minTime, maxTime := endpointRef.timeRange()
+
+		testutil.Assert(t, minTime != math.MinInt64, "minTime should not be math.MinInt64")
+		testutil.Assert(t, maxTime != math.MaxInt64, "maxTime should not be math.MaxInt64")
+
+		now := time.Now()
+		testutil.Equals(t, now.Add(-9600*time.Hour).Unix()/60, minTime/(1000*60))
+		testutil.Equals(t, now.Add(-11490*time.Minute).Unix()/60, maxTime/(1000*60))
+	}
+	{
+		endpointRef := &endpointRef{
+			groupKey: "store-grpc-group-svc-pantheon-store",
+		}
+		minTime, maxTime := endpointRef.timeRange()
+
+		testutil.Assert(t, minTime != math.MinInt64, "minTime should not be math.MinInt64")
+		testutil.Assert(t, maxTime != math.MaxInt64, "maxTime should not be math.MaxInt64")
+
+		now := time.Now()
+		testutil.Equals(t, now.Add(-192*time.Hour).Unix()/60, minTime/(1000*60))
+		testutil.Equals(t, now.Add(-1410*time.Minute).Unix()/60, maxTime/(1000*60))
+	}
+	{
+		endpointRef := &endpointRef{
+			groupKey: "store-grpc-group-svc-pantheon-db",
+		}
+		minTime, maxTime := endpointRef.timeRange()
+
+		testutil.Equals(t, int64(math.MinInt64), minTime)
+		testutil.Equals(t, int64(math.MaxInt64), maxTime)
+	}
+	{
+		endpointRef := &endpointRef{}
+		minTime, maxTime := endpointRef.timeRange()
+
+		testutil.Equals(t, int64(math.MinInt64), minTime)
+		testutil.Equals(t, int64(math.MaxInt64), maxTime)
+	}
+}


### PR DESCRIPTION
This is to fix a corner case manifested as the following event sequence:
			1. A long range store pod becomes ready and visible to the range querier.
			2. The range querier creates an endpoint for the long range store pod.
			3. The long range store pod quickly starts to OOM.
			4. The range querier tries to get the long range store pod’s meta info through info() gRPC call to get it’s time range.
			   The gRPC calls keep failing.
			5. The range querier uses the default time range [min-int64, max-int64] for the long range store pod to match any in-coming query.
			   This way, the long range store pod is incorrectly included in the fan-out endpoints.