### PR TITLE
Changing blocking patterns to avoid incorrect blocking: follow up to #207

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -103,7 +104,8 @@ type ProxyStore struct {
 	enableDedup                       bool
 	matcherConverter                  *storepb.MatcherConverter
 	lazyRetrievalMaxBufferedResponses int
-	blockedMetricPatterns             *radix.Tree
+	blockedMetricPrefixes             *radix.Tree
+	blockedMetricExacts               map[string]struct{}
 }
 
 type proxyStoreMetrics struct {
@@ -186,12 +188,30 @@ func WithProxyStoreMatcherConverter(mc *storepb.MatcherConverter) ProxyStoreOpti
 }
 
 // WithBlockedMetricPatterns returns a ProxyStoreOption that sets the blocked metric patterns.
+// It parses input patterns to extract prefixes (like "kube_", "envoy_") using regex
+// and stores them in a radix tree for efficient prefix matching. Exact patterns
+// (like "up") are stored in a set for whole match checking.
 func WithBlockedMetricPatterns(patterns []string) ProxyStoreOption {
 	return func(s *ProxyStore) {
-		s.blockedMetricPatterns = radix.New()
+		s.blockedMetricPrefixes = radix.New()
+		s.blockedMetricExacts = make(map[string]struct{})
+
+		// Regex to match clear prefix patterns: "kube_*", "envoy_", "prometheus_*" (end with _ or _*)
+		clearPrefixPattern := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*_)\*?$`)
+
 		for _, pattern := range patterns {
-			if pattern != "" {
-				s.blockedMetricPatterns.Insert(pattern, pattern)
+			if pattern == "" {
+				continue
+			}
+
+			// Always store as exact match
+			s.blockedMetricExacts[pattern] = struct{}{}
+
+			// Only add to prefix tree if pattern already ends with underscore
+			if matches := clearPrefixPattern.FindStringSubmatch(pattern); len(matches) > 1 {
+				// Extract the prefix (everything up to and including the last _)
+				prefix := matches[1]
+				s.blockedMetricPrefixes.Insert(prefix, pattern)
 			}
 		}
 	}
@@ -958,7 +978,7 @@ func (s *ProxyStore) countAllFilters(matchers []*labels.Matcher) int {
 // shouldBlockQuery determines if a query should be blocked based on metric patterns and label filters.
 // Returns (shouldBlock, metricName, matchedPattern).
 func (s *ProxyStore) shouldBlockQuery(matchers []*labels.Matcher) (bool, string, string) {
-	if s.blockedMetricPatterns == nil {
+	if s.blockedMetricPrefixes == nil && s.blockedMetricExacts == nil {
 		return false, "", ""
 	}
 
@@ -987,19 +1007,25 @@ func (s *ProxyStore) shouldBlockQuery(matchers []*labels.Matcher) (bool, string,
 }
 
 // getMatchedBlockedPattern returns the first pattern that matches the metric name, or empty string if none match.
+// It first checks for exact matches, then checks for prefix matches in the radix tree.
 func (s *ProxyStore) getMatchedBlockedPattern(metricName string) string {
-	if s.blockedMetricPatterns == nil {
-		return ""
+	// First check for exact matches
+	if s.blockedMetricExacts != nil {
+		if _, found := s.blockedMetricExacts[metricName]; found {
+			return metricName
+		}
 	}
 
-	_, value, found := s.blockedMetricPatterns.LongestPrefix(metricName)
-	if !found {
-		return ""
+	// Then check for prefix matches
+	if s.blockedMetricPrefixes != nil {
+		_, value, found := s.blockedMetricPrefixes.LongestPrefix(metricName)
+		if found {
+			if originalPattern, ok := value.(string); ok {
+				// The radix tree key is the prefix, but we return the original pattern
+				return originalPattern
+			}
+		}
 	}
 
-	// The value stored is the original pattern
-	if pattern, ok := value.(string); ok {
-		return pattern
-	}
 	return ""
 }

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -188,7 +187,7 @@ func WithProxyStoreMatcherConverter(mc *storepb.MatcherConverter) ProxyStoreOpti
 }
 
 // WithBlockedMetricPatterns returns a ProxyStoreOption that sets the blocked metric patterns.
-// It parses input patterns to extract prefixes (like "kube_", "envoy_") using regex
+// It parses input patterns to extract prefixes (like "kube_", "envoy_") by checking suffix characters
 // and stores them in a radix tree for efficient prefix matching. Exact patterns
 // (like "up") are stored in a set for whole match checking.
 func WithBlockedMetricPatterns(patterns []string) ProxyStoreOption {
@@ -196,27 +195,25 @@ func WithBlockedMetricPatterns(patterns []string) ProxyStoreOption {
 		s.blockedMetricPrefixes = radix.New()
 		s.blockedMetricExacts = make(map[string]struct{})
 
-		// Regex to match patterns ending with * (wildcard patterns)
-		starPattern := regexp.MustCompile(`^(.+)\*$`)
-		// Regex to match patterns ending with _ (underscore prefix patterns)
-		underscorePattern := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*_)$`)
-
 		for _, pattern := range patterns {
 			if pattern == "" {
 				continue
 			}
 
-			// Check if pattern ends with * (wildcard behavior)
-			if starPattern.MatchString(pattern) {
-				// Extract prefix (everything before the *)
-				prefix := pattern[:len(pattern)-1] // Remove the trailing *
-				s.blockedMetricPrefixes.Insert(prefix, pattern)
-			} else if underscorePattern.MatchString(pattern) {
-				// Pattern ends with _ (like "kube_"), treat as prefix
-				s.blockedMetricPrefixes.Insert(pattern, pattern)
-			} else {
-				// No * or _ at the end, store as exact match only
-				s.blockedMetricExacts[pattern] = struct{}{}
+			// Check if pattern ends with * or _ for prefix matching
+			if len(pattern) > 0 {
+				lastChar := pattern[len(pattern)-1]
+				if lastChar == '*' {
+					// Extract prefix (everything before the *)
+					prefix := pattern[:len(pattern)-1]
+					s.blockedMetricPrefixes.Insert(prefix, pattern)
+				} else if lastChar == '_' {
+					// Pattern ends with _ (like "kube_"), treat as prefix
+					s.blockedMetricPrefixes.Insert(pattern, pattern)
+				} else {
+					// No * or _ at the end, store as exact match only
+					s.blockedMetricExacts[pattern] = struct{}{}
+				}
 			}
 		}
 	}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -196,22 +196,27 @@ func WithBlockedMetricPatterns(patterns []string) ProxyStoreOption {
 		s.blockedMetricPrefixes = radix.New()
 		s.blockedMetricExacts = make(map[string]struct{})
 
-		// Regex to match clear prefix patterns: "kube_*", "envoy_", "prometheus_*" (end with _ or _*)
-		clearPrefixPattern := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*_)\*?$`)
+		// Regex to match patterns ending with * (wildcard patterns)
+		starPattern := regexp.MustCompile(`^(.+)\*$`)
+		// Regex to match patterns ending with _ (underscore prefix patterns)
+		underscorePattern := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*_)$`)
 
 		for _, pattern := range patterns {
 			if pattern == "" {
 				continue
 			}
 
-			// Always store as exact match
-			s.blockedMetricExacts[pattern] = struct{}{}
-
-			// Only add to prefix tree if pattern already ends with underscore
-			if matches := clearPrefixPattern.FindStringSubmatch(pattern); len(matches) > 1 {
-				// Extract the prefix (everything up to and including the last _)
-				prefix := matches[1]
+			// Check if pattern ends with * (wildcard behavior)
+			if starPattern.MatchString(pattern) {
+				// Extract prefix (everything before the *)
+				prefix := pattern[:len(pattern)-1] // Remove the trailing *
 				s.blockedMetricPrefixes.Insert(prefix, pattern)
+			} else if underscorePattern.MatchString(pattern) {
+				// Pattern ends with _ (like "kube_"), treat as prefix
+				s.blockedMetricPrefixes.Insert(pattern, pattern)
+			} else {
+				// No * or _ at the end, store as exact match only
+				s.blockedMetricExacts[pattern] = struct{}{}
 			}
 		}
 	}

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1213,52 +1213,6 @@ func TestProxyStore_Series(t *testing.T) {
 			},
 		},
 		{
-			title: "blocked query: multiple blocked patterns - first pattern matches",
-			storeAPIs: []Client{
-				&storetestutil.TestClient{
-					StoreClient: &mockedStoreAPI{
-						RespSeries: []*storepb.SeriesResponse{
-							storeSeriesResponse(t, labels.FromStrings("__name__", "high_cardinality_metric"), []sample{{0, 0}, {2, 1}}),
-						},
-					},
-					MinTime: 1,
-					MaxTime: 300,
-				},
-			},
-			req: &storepb.SeriesRequest{
-				MinTime: 1,
-				MaxTime: 300,
-				Matchers: []storepb.LabelMatcher{
-					{Name: "__name__", Value: "high_cardinality_metric", Type: storepb.LabelMatcher_EQ},
-				},
-			},
-			blockedPatterns: []string{"high_cardinality_", "another_pattern_"},
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality_', please add proper filters to reduce the amount of data to fetch"),
-		},
-		{
-			title: "blocked query: multiple blocked patterns - second pattern matches",
-			storeAPIs: []Client{
-				&storetestutil.TestClient{
-					StoreClient: &mockedStoreAPI{
-						RespSeries: []*storepb.SeriesResponse{
-							storeSeriesResponse(t, labels.FromStrings("__name__", "another_pattern_metric"), []sample{{0, 0}, {2, 1}}),
-						},
-					},
-					MinTime: 1,
-					MaxTime: 300,
-				},
-			},
-			req: &storepb.SeriesRequest{
-				MinTime: 1,
-				MaxTime: 300,
-				Matchers: []storepb.LabelMatcher{
-					{Name: "__name__", Value: "another_pattern_metric", Type: storepb.LabelMatcher_EQ},
-				},
-			},
-			blockedPatterns: []string{"high_cardinality_", "another_pattern_"},
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'another_pattern_metric' matches blocked pattern 'another_pattern_', please add proper filters to reduce the amount of data to fetch"),
-		},
-		{
 			title: "not blocked query: multiple exact filters should be allowed",
 			storeAPIs: []Client{
 				&storetestutil.TestClient{
@@ -1375,12 +1329,12 @@ func TestProxyStore_Series(t *testing.T) {
 			},
 		},
 		{
-			title: "blocked query: prefix matching - longest prefix should match",
+			title: "blocked query: wildcard * pattern matches any prefix",
 			storeAPIs: []Client{
 				&storetestutil.TestClient{
 					StoreClient: &mockedStoreAPI{
 						RespSeries: []*storepb.SeriesResponse{
-							storeSeriesResponse(t, labels.FromStrings("__name__", "high_cardinality_detailed_metric"), []sample{{0, 0}, {2, 1}}),
+							storeSeriesResponse(t, labels.FromStrings("__name__", "upstream_connections"), []sample{{0, 0}, {2, 1}}),
 						},
 					},
 					MinTime: 1,
@@ -1391,11 +1345,11 @@ func TestProxyStore_Series(t *testing.T) {
 				MinTime: 1,
 				MaxTime: 300,
 				Matchers: []storepb.LabelMatcher{
-					{Name: "__name__", Value: "high_cardinality_detailed_metric", Type: storepb.LabelMatcher_EQ},
+					{Name: "__name__", Value: "upstream_connections", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-			blockedPatterns: []string{"high_", "high_cardinality_", "high_cardinality_detailed_"},
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_detailed_metric' matches blocked pattern 'high_cardinality_detailed_', please add proper filters to reduce the amount of data to fetch"),
+			blockedPatterns: []string{"up*"},
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'upstream_connections' matches blocked pattern 'up*', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{
 			title: "not blocked query: no prefix match",
@@ -1424,6 +1378,80 @@ func TestProxyStore_Series(t *testing.T) {
 					chunks: [][]sample{{{0, 0}, {2, 1}}},
 				},
 			},
+		},
+		{
+			title: "exact match pattern: metric must match exactly (not as prefix)",
+			storeAPIs: []Client{
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespSeries: []*storepb.SeriesResponse{
+							storeSeriesResponse(t, labels.FromStrings("__name__", "uptime_seconds"), []sample{{0, 0}, {2, 1}}),
+						},
+					},
+					MinTime: 1,
+					MaxTime: 300,
+				},
+			},
+			req: &storepb.SeriesRequest{
+				MinTime: 1,
+				MaxTime: 300,
+				Matchers: []storepb.LabelMatcher{
+					{Name: "__name__", Value: "uptime_seconds", Type: storepb.LabelMatcher_EQ},
+				},
+			},
+			blockedPatterns: []string{"up"}, // exact match pattern (no * or _)
+			expectedSeries: []rawSeries{
+				{
+					lset:   labels.FromStrings("__name__", "uptime_seconds"),
+					chunks: [][]sample{{{0, 0}, {2, 1}}},
+				},
+			},
+		},
+		{
+			title: "exact match pattern: blocks only exact matches",
+			storeAPIs: []Client{
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespSeries: []*storepb.SeriesResponse{
+							storeSeriesResponse(t, labels.FromStrings("__name__", "up"), []sample{{0, 0}, {2, 1}}),
+						},
+					},
+					MinTime: 1,
+					MaxTime: 300,
+				},
+			},
+			req: &storepb.SeriesRequest{
+				MinTime: 1,
+				MaxTime: 300,
+				Matchers: []storepb.LabelMatcher{
+					{Name: "__name__", Value: "up", Type: storepb.LabelMatcher_EQ},
+				},
+			},
+			blockedPatterns: []string{"up"}, // exact match pattern (no * or _)
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'up' matches blocked pattern 'up', please add proper filters to reduce the amount of data to fetch"),
+		},
+		{
+			title: "wildcard pattern: blocks metric with exact match too (up* blocks both up and upstream_*)",
+			storeAPIs: []Client{
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespSeries: []*storepb.SeriesResponse{
+							storeSeriesResponse(t, labels.FromStrings("__name__", "up"), []sample{{0, 0}, {2, 1}}),
+						},
+					},
+					MinTime: 1,
+					MaxTime: 300,
+				},
+			},
+			req: &storepb.SeriesRequest{
+				MinTime: 1,
+				MaxTime: 300,
+				Matchers: []storepb.LabelMatcher{
+					{Name: "__name__", Value: "up", Type: storepb.LabelMatcher_EQ},
+				},
+			},
+			blockedPatterns: []string{"up*"}, // wildcard pattern - broader than exact match
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'up' matches blocked pattern 'up*', please add proper filters to reduce the amount of data to fetch"),
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1067,8 +1067,8 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "__name__", Value: "high_cardinality_metric", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality"},
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality', please add proper filters to reduce the amount of data to fetch"),
+			blockedPatterns: []string{"high_cardinality_"},
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality_', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{
 			title: "blocked query: metric matches pattern but has sufficient filters - should succeed",
@@ -1091,7 +1091,7 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "job", Value: "my_job", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality"},
+			blockedPatterns: []string{"high_cardinality_"},
 			expectedSeries: []rawSeries{
 				{
 					lset:   labels.FromStrings("__name__", "high_cardinality_metric", "job", "my_job"),
@@ -1120,7 +1120,7 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "job", Value: ".*", Type: storepb.LabelMatcher_RE},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality"},
+			blockedPatterns: []string{"high_cardinality_"},
 			expectedSeries: []rawSeries{
 				{
 					lset:   labels.FromStrings("__name__", "high_cardinality_metric", "job", "my_job"),
@@ -1148,7 +1148,7 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "__name__", Value: "low_cardinality_metric", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality"},
+			blockedPatterns: []string{"high_cardinality_"},
 			expectedSeries: []rawSeries{
 				{
 					lset:   labels.FromStrings("__name__", "low_cardinality_metric"),
@@ -1176,7 +1176,7 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "job", Value: "my_job", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality"},
+			blockedPatterns: []string{"high_cardinality_"},
 			expectedSeries: []rawSeries{
 				{
 					lset:   labels.FromStrings("job", "my_job"),
@@ -1204,7 +1204,7 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "__name__", Value: "high_.*", Type: storepb.LabelMatcher_RE},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality"},
+			blockedPatterns: []string{"high_cardinality_"},
 			expectedSeries: []rawSeries{
 				{
 					lset:   labels.FromStrings("__name__", "high_cardinality_metric"),
@@ -1232,8 +1232,8 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "__name__", Value: "high_cardinality_metric", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality", "another_pattern"},
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality', please add proper filters to reduce the amount of data to fetch"),
+			blockedPatterns: []string{"high_cardinality_", "another_pattern_"},
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality_', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{
 			title: "blocked query: multiple blocked patterns - second pattern matches",
@@ -1255,8 +1255,8 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "__name__", Value: "another_pattern_metric", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality", "another_pattern"},
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'another_pattern_metric' matches blocked pattern 'another_pattern', please add proper filters to reduce the amount of data to fetch"),
+			blockedPatterns: []string{"high_cardinality_", "another_pattern_"},
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'another_pattern_metric' matches blocked pattern 'another_pattern_', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{
 			title: "not blocked query: multiple exact filters should be allowed",
@@ -1280,7 +1280,7 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "instance", Value: "localhost", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality"},
+			blockedPatterns: []string{"high_cardinality_"},
 			expectedSeries: []rawSeries{
 				{
 					lset:   labels.FromStrings("__name__", "high_cardinality_metric", "job", "my_job", "instance", "localhost"),
@@ -1309,7 +1309,7 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "job", Value: "unwanted_job", Type: storepb.LabelMatcher_NEQ},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality"},
+			blockedPatterns: []string{"high_cardinality_"},
 			expectedSeries: []rawSeries{
 				{
 					lset:   labels.FromStrings("__name__", "high_cardinality_metric", "job", "my_job"),
@@ -1338,7 +1338,7 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "job", Value: "unwanted.*", Type: storepb.LabelMatcher_NRE},
 				},
 			},
-			blockedPatterns: []string{"high_cardinality"},
+			blockedPatterns: []string{"high_cardinality_"},
 			expectedSeries: []rawSeries{
 				{
 					lset:   labels.FromStrings("__name__", "high_cardinality_metric", "job", "my_job"),
@@ -1394,8 +1394,8 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "__name__", Value: "high_cardinality_detailed_metric", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-			blockedPatterns: []string{"high", "high_cardinality", "high_cardinality_detailed"},
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_detailed_metric' matches blocked pattern 'high_cardinality_detailed', please add proper filters to reduce the amount of data to fetch"),
+			blockedPatterns: []string{"high_", "high_cardinality_", "high_cardinality_detailed_"},
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_detailed_metric' matches blocked pattern 'high_cardinality_detailed_', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{
 			title: "not blocked query: no prefix match",


### PR DESCRIPTION
Follow up to #207 , changing patterns to ensure we do not incorrectly block queries with certain metrics (e.g. up should only block up not upstream)

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Changed what we are blocking, either exact words (e.g. up or any full metric name) or prefix (ending with _).

## Verification
Unit tests in proxy_test and testing via SOP in [Pantheon Knowledge Base](https://databricks.atlassian.net/wiki/pages/viewpage.action?pageId=3754591684&pageVersion=12)