### PR TITLE
log unaggregated samples that have high e2e latency

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	stdlog "log"
 	"math"
+	"math/rand"
 	"net"
 	"net/http"
 	"sort"
@@ -672,6 +673,22 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, ts := range wreq.Timeseries {
 		if lat := secondsSinceFirstSample(nowMS, ts); lat > 0 {
 			h.writeE2eLatency.WithLabelValues(strconv.Itoa(responseStatusCode), tenantHTTP, strconv.FormatBool(isPreAgged(ts))).Observe(lat)
+
+			// Log high latency requests (>3 minutes) with sampling (1 in 10000)
+			if lat > 180 && !isPreAgged(ts) && rand.Intn(10000) == 0 {
+
+				// Convert labels to string for logging
+				var labelPairs []string
+				for _, label := range ts.Labels {
+					labelPairs = append(labelPairs, fmt.Sprintf("%s=%s", label.Name, label.Value))
+				}
+
+				level.Warn(h.logger).Log(
+					"msg", "high e2e latency detected for non-rollup timeseries",
+					"latency_seconds", lat,
+					"labels", fmt.Sprintf("{%s}", strings.Join(labelPairs, ", ")),
+				)
+			}
 		}
 	}
 }

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -672,10 +672,11 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	nowMS := time.Now().UnixNano() / int64(time.Millisecond)
 	for _, ts := range wreq.Timeseries {
 		if lat := secondsSinceFirstSample(nowMS, ts); lat > 0 {
-			h.writeE2eLatency.WithLabelValues(strconv.Itoa(responseStatusCode), tenantHTTP, strconv.FormatBool(isPreAgged(ts))).Observe(lat)
+			isPreAgged := isPreAgged(ts)
+			h.writeE2eLatency.WithLabelValues(strconv.Itoa(responseStatusCode), tenantHTTP, strconv.FormatBool(isPreAgged)).Observe(lat)
 
 			// Log high latency requests (>3 minutes) with sampling (1 in 10000)
-			if lat > 180 && !isPreAgged(ts) && rand.Intn(10000) == 0 {
+			if lat > 180 && !isPreAgged && rand.Intn(10000) == 0 {
 
 				// Convert labels to string for logging
 				var labelPairs []string

--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -314,308 +314,309 @@ faulty_config:
 	g.Wait()
 }
 
-//func TestReloader_ConfigDirApply(t *testing.T) {
-//	t.Parallel()
-//
-//	l, err := net.Listen("tcp", "localhost:0")
-//	testutil.Ok(t, err)
-//
-//	i := 0
-//	reloads := 0
-//	reloadsMtx := sync.Mutex{}
-//
-//	srv := &http.Server{}
-//	srv.Handler = http.HandlerFunc(func(resp http.ResponseWriter, r *http.Request) {
-//		reloadsMtx.Lock()
-//		defer reloadsMtx.Unlock()
-//
-//		i++
-//		if i%2 == 0 {
-//			// Fail every second request to ensure that retry works.
-//			resp.WriteHeader(http.StatusServiceUnavailable)
-//			return
-//		}
-//
-//		reloads++
-//		resp.WriteHeader(http.StatusOK)
-//	})
-//	go func() {
-//		_ = srv.Serve(l)
-//	}()
-//	defer func() { testutil.Ok(t, srv.Close()) }()
-//
-//	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
-//	testutil.Ok(t, err)
-//
-//	ruleDir := t.TempDir()
-//	tempRule1File := path.Join(ruleDir, "rule1.yaml")
-//	tempRule3File := path.Join(ruleDir, "rule3.yaml")
-//	tempRule4File := path.Join(ruleDir, "rule4.yaml")
-//
-//	testutil.Ok(t, os.WriteFile(tempRule1File, []byte("rule1-changed"), os.ModePerm))
-//	testutil.Ok(t, os.WriteFile(tempRule3File, []byte("rule3-changed"), os.ModePerm))
-//	testutil.Ok(t, os.WriteFile(tempRule4File, []byte("rule4-changed"), os.ModePerm))
-//
-//	dir := t.TempDir()
-//	dir2 := t.TempDir()
-//
-//	outDir := t.TempDir()
-//	outDir2 := t.TempDir()
-//
-//	// dir
-//	// └─ rule-dir -> dir2/rule-dir
-//	// dir2
-//	// └─ rule-dir
-//	testutil.Ok(t, os.Mkdir(path.Join(dir2, "rule-dir"), os.ModePerm))
-//	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule-dir"), path.Join(dir, "rule-dir")))
-//
-//	logger := log.NewNopLogger()
-//	r := prometheus.NewRegistry()
-//	reloader := New(
-//		logger,
-//		r,
-//		&Options{
-//			ReloadURL:     reloadURL,
-//			CfgFile:       "",
-//			CfgOutputFile: "",
-//			CfgDirs: []CfgDirOption{
-//				{
-//					Dir:       dir,
-//					OutputDir: outDir,
-//				},
-//				{
-//					Dir:       dir2,
-//					OutputDir: outDir2,
-//				},
-//			},
-//			WatchedDirs:   nil,
-//			WatchInterval: 9999 * time.Hour, // Disable interval to test watch logic only.
-//			RetryInterval: 100 * time.Millisecond,
-//		})
-//
-//	// dir
-//	// ├─ rule-dir -> dir2/rule-dir
-//	// └─ rule1.yaml
-//	// dir2
-//	// ├─ rule-dir
-//	// │  └─ rule4.yaml
-//	// ├─ rule3-001.yaml -> rule3-source.yaml
-//	// └─ rule3-source.yaml
-//	// The reloader watches 2 directories: dir and dir/rule-dir.
-//	testutil.Ok(t, os.WriteFile(path.Join(dir, "rule1.yaml"), []byte("rule"), os.ModePerm))
-//	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3"), os.ModePerm))
-//	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-001.yaml")))
-//	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule-dir", "rule4.yaml"), []byte("rule4"), os.ModePerm))
-//
-//	stepFunc := func(rel int) {
-//		t.Log("Performing step number", rel)
-//		switch rel {
-//		case 0:
-//			// Create rule2.yaml.
-//			//
-//			// dir
-//			// ├─ rule-dir -> dir2/rule-dir
-//			// ├─ rule1.yaml
-//			// └─ rule2.yaml (*)
-//			// dir2
-//			// ├─ rule-dir
-//			// │  └─ rule4.yaml
-//			// ├─ rule3-001.yaml -> rule3-source.yaml
-//			// └─ rule3-source.yaml
-//			testutil.Ok(t, os.WriteFile(path.Join(dir, "rule2.yaml"), []byte("rule2"), os.ModePerm))
-//			// out1
-//			// ├─ rule1.yaml
-//			// └─ rule2.yaml
-//			// out2
-//			// ├─ rule3-001.yaml
-//			// └─ rule3-source.yaml
-//		case 1:
-//			// Update rule1.yaml.
-//			//
-//			// dir
-//			// ├─ rule-dir -> dir2/rule-dir
-//			// ├─ rule1.yaml (*)
-//			// └─ rule2.yaml
-//			// dir2
-//			// ├─ rule-dir
-//			// │  └─ rule4.yaml
-//			// ├─ rule3-001.yaml -> rule3-source.yaml
-//			// └─ rule3-source.yaml
-//			testutil.Ok(t, os.Rename(tempRule1File, path.Join(dir, "rule1.yaml")))
-//			// out1
-//			// ├─ rule1.yaml
-//			// └─ rule2.yaml
-//			// out2
-//			// ├─ rule3-001.yaml
-//			// └─ rule3-source.yaml
-//		case 2:
-//			// Create dir/rule3.yaml (symlink to rule3-001.yaml).
-//			//
-//			// dir
-//			// ├─ rule-dir -> dir2/rule-dir
-//			// ├─ rule1.yaml
-//			// ├─ rule2.yaml
-//			// └─ rule3.yaml -> dir2/rule3-001.yaml (*)
-//			// dir2
-//			// ├─ rule-dir
-//			// │  └─ rule4.yaml
-//			// ├─ rule3-001.yaml -> rule3-source.yaml
-//			// └─ rule3-source.yaml
-//			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-001.yaml"), path.Join(dir2, "rule3.yaml")))
-//			testutil.Ok(t, os.Rename(path.Join(dir2, "rule3.yaml"), path.Join(dir, "rule3.yaml")))
-//			// out1
-//			// ├─ rule1.yaml
-//			// ├─ rule2.yaml
-//			// └─ rule3.yaml
-//			// out2
-//			// ├─ rule3-001.yaml
-//			// └─ rule3-source.yaml
-//		case 3:
-//			// Update the symlinked file and replace the symlink file to trigger fsnotify.
-//			//
-//			// dir
-//			// ├─ rule-dir -> dir2/rule-dir
-//			// ├─ rule1.yaml
-//			// ├─ rule2.yaml
-//			// └─ rule3.yaml -> dir2/rule3-002.yaml (*)
-//			// dir2
-//			// ├─ rule-dir
-//			// │  └─ rule4.yaml
-//			// ├─ rule3-002.yaml -> rule3-source.yaml (*)
-//			// └─ rule3-source.yaml (*)
-//			testutil.Ok(t, os.Rename(tempRule3File, path.Join(dir2, "rule3-source.yaml")))
-//			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-002.yaml")))
-//			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-002.yaml"), path.Join(dir2, "rule3.yaml")))
-//			testutil.Ok(t, os.Rename(path.Join(dir2, "rule3.yaml"), path.Join(dir, "rule3.yaml")))
-//			testutil.Ok(t, os.Remove(path.Join(dir2, "rule3-001.yaml")))
-//			// out1
-//			// ├─ rule1.yaml
-//			// ├─ rule2.yaml
-//			// └─ rule3.yaml
-//			// out2
-//			// ├─ rule3-002.yaml
-//			// └─ rule3-source.yaml
-//		case 4:
-//			// Update rule4.yaml in the symlinked directory.
-//			//
-//			// dir
-//			// ├─ rule-dir -> dir2/rule-dir
-//			// ├─ rule1.yaml
-//			// ├─ rule2.yaml
-//			// └─ rule3.yaml -> rule3-source.yaml
-//			// dir2
-//			// ├─ rule-dir
-//			// │  └─ rule4.yaml (*)
-//			// └─ rule3-source.yaml
-//			testutil.Ok(t, os.Rename(tempRule4File, path.Join(dir2, "rule-dir", "rule4.yaml")))
-//			// out1
-//			// ├─ rule1.yaml
-//			// ├─ rule2.yaml
-//			// └─ rule3.yaml
-//			// out2
-//			// ├─ rule3-002.yaml
-//			// └─ rule3-source.yaml
-//		}
-//	}
-//
-//	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-//	g := sync.WaitGroup{}
-//	g.Add(1)
-//	go func() {
-//		defer g.Done()
-//		defer cancel()
-//
-//		reloadsSeen := 0
-//		init := false
-//		for {
-//			runtime.Gosched() // Ensure during testing on small machine, other go routines have chance to continue.
-//
-//			select {
-//			case <-ctx.Done():
-//				return
-//			case <-time.After(500 * time.Millisecond):
-//			}
-//
-//			reloadsMtx.Lock()
-//			rel := reloads
-//			reloadsMtx.Unlock()
-//			if init && rel <= reloadsSeen {
-//				continue
-//			}
-//
-//			// Catch up if reloader is step(s) ahead.
-//			for skipped := rel - reloadsSeen - 1; skipped > 0; skipped-- {
-//				stepFunc(rel - skipped)
-//			}
-//
-//			stepFunc(rel)
-//
-//			init = true
-//			reloadsSeen = rel
-//
-//			if rel > 4 {
-//				// All good.
-//				return
-//			}
-//		}
-//	}()
-//	err = reloader.Watch(ctx)
-//	cancel()
-//	g.Wait()
-//
-//	testutil.Ok(t, err)
-//	testutil.Equals(t, 12.0, promtest.ToFloat64(reloader.watcher.watchEvents))
-//	testutil.Equals(t, 0.0, promtest.ToFloat64(reloader.watcher.watchErrors))
-//	testutil.Equals(t, 3.0, promtest.ToFloat64(reloader.reloadErrors))
-//	testutil.Equals(t, 7.0, promtest.ToFloat64(reloader.reloads))
-//	testutil.Equals(t, 4, reloads)
-//
-//	outEntries, err := os.ReadDir(outDir)
-//	testutil.Ok(t, err)
-//	outFiles := []string{}
-//	for _, entry := range outEntries {
-//		outFiles = append(outFiles, entry.Name())
-//	}
-//	slices.Sort(outFiles)
-//	expectedOutFiles := []string{
-//		"rule1.yaml",
-//		"rule2.yaml",
-//		"rule3.yaml",
-//	}
-//	slices.Sort(expectedOutFiles)
-//	testutil.Equals(t, expectedOutFiles, outFiles)
-//
-//	data, err := os.ReadFile(filepath.Join(outDir, "rule1.yaml"))
-//	testutil.Ok(t, err)
-//	testutil.Equals(t, "rule1-changed", string(data))
-//	data, err = os.ReadFile(filepath.Join(outDir, "rule2.yaml"))
-//	testutil.Ok(t, err)
-//	testutil.Equals(t, "rule2", string(data))
-//	data, err = os.ReadFile(filepath.Join(outDir, "rule3.yaml"))
-//	testutil.Ok(t, err)
-//	testutil.Equals(t, "rule3-changed", string(data))
-//
-//	outEntries2, err := os.ReadDir(outDir2)
-//	testutil.Ok(t, err)
-//	outFiles2 := []string{}
-//	for _, entry := range outEntries2 {
-//		outFiles2 = append(outFiles2, entry.Name())
-//	}
-//	slices.Sort(outFiles2)
-//	expectedOutFiles2 := []string{
-//		"rule3-002.yaml",
-//		"rule3-source.yaml",
-//	}
-//	slices.Sort(expectedOutFiles2)
-//	testutil.Equals(t, expectedOutFiles2, outFiles2)
-//
-//	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-002.yaml"))
-//	testutil.Ok(t, err)
-//	testutil.Equals(t, "rule3-changed", string(data))
-//	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-source.yaml"))
-//	testutil.Ok(t, err)
-//	testutil.Equals(t, "rule3-changed", string(data))
-//}
+func TestReloader_ConfigDirApply(t *testing.T) {
+	t.Skip("flaky test")
+	t.Parallel()
+
+	l, err := net.Listen("tcp", "localhost:0")
+	testutil.Ok(t, err)
+
+	i := 0
+	reloads := 0
+	reloadsMtx := sync.Mutex{}
+
+	srv := &http.Server{}
+	srv.Handler = http.HandlerFunc(func(resp http.ResponseWriter, r *http.Request) {
+		reloadsMtx.Lock()
+		defer reloadsMtx.Unlock()
+
+		i++
+		if i%2 == 0 {
+			// Fail every second request to ensure that retry works.
+			resp.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+
+		reloads++
+		resp.WriteHeader(http.StatusOK)
+	})
+	go func() {
+		_ = srv.Serve(l)
+	}()
+	defer func() { testutil.Ok(t, srv.Close()) }()
+
+	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
+	testutil.Ok(t, err)
+
+	ruleDir := t.TempDir()
+	tempRule1File := path.Join(ruleDir, "rule1.yaml")
+	tempRule3File := path.Join(ruleDir, "rule3.yaml")
+	tempRule4File := path.Join(ruleDir, "rule4.yaml")
+
+	testutil.Ok(t, os.WriteFile(tempRule1File, []byte("rule1-changed"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(tempRule3File, []byte("rule3-changed"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(tempRule4File, []byte("rule4-changed"), os.ModePerm))
+
+	dir := t.TempDir()
+	dir2 := t.TempDir()
+
+	outDir := t.TempDir()
+	outDir2 := t.TempDir()
+
+	// dir
+	// └─ rule-dir -> dir2/rule-dir
+	// dir2
+	// └─ rule-dir
+	testutil.Ok(t, os.Mkdir(path.Join(dir2, "rule-dir"), os.ModePerm))
+	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule-dir"), path.Join(dir, "rule-dir")))
+
+	logger := log.NewNopLogger()
+	r := prometheus.NewRegistry()
+	reloader := New(
+		logger,
+		r,
+		&Options{
+			ReloadURL:     reloadURL,
+			CfgFile:       "",
+			CfgOutputFile: "",
+			CfgDirs: []CfgDirOption{
+				{
+					Dir:       dir,
+					OutputDir: outDir,
+				},
+				{
+					Dir:       dir2,
+					OutputDir: outDir2,
+				},
+			},
+			WatchedDirs:   nil,
+			WatchInterval: 9999 * time.Hour, // Disable interval to test watch logic only.
+			RetryInterval: 100 * time.Millisecond,
+		})
+
+	// dir
+	// ├─ rule-dir -> dir2/rule-dir
+	// └─ rule1.yaml
+	// dir2
+	// ├─ rule-dir
+	// │  └─ rule4.yaml
+	// ├─ rule3-001.yaml -> rule3-source.yaml
+	// └─ rule3-source.yaml
+	// The reloader watches 2 directories: dir and dir/rule-dir.
+	testutil.Ok(t, os.WriteFile(path.Join(dir, "rule1.yaml"), []byte("rule"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3"), os.ModePerm))
+	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-001.yaml")))
+	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule-dir", "rule4.yaml"), []byte("rule4"), os.ModePerm))
+
+	stepFunc := func(rel int) {
+		t.Log("Performing step number", rel)
+		switch rel {
+		case 0:
+			// Create rule2.yaml.
+			//
+			// dir
+			// ├─ rule-dir -> dir2/rule-dir
+			// ├─ rule1.yaml
+			// └─ rule2.yaml (*)
+			// dir2
+			// ├─ rule-dir
+			// │  └─ rule4.yaml
+			// ├─ rule3-001.yaml -> rule3-source.yaml
+			// └─ rule3-source.yaml
+			testutil.Ok(t, os.WriteFile(path.Join(dir, "rule2.yaml"), []byte("rule2"), os.ModePerm))
+			// out1
+			// ├─ rule1.yaml
+			// └─ rule2.yaml
+			// out2
+			// ├─ rule3-001.yaml
+			// └─ rule3-source.yaml
+		case 1:
+			// Update rule1.yaml.
+			//
+			// dir
+			// ├─ rule-dir -> dir2/rule-dir
+			// ├─ rule1.yaml (*)
+			// └─ rule2.yaml
+			// dir2
+			// ├─ rule-dir
+			// │  └─ rule4.yaml
+			// ├─ rule3-001.yaml -> rule3-source.yaml
+			// └─ rule3-source.yaml
+			testutil.Ok(t, os.Rename(tempRule1File, path.Join(dir, "rule1.yaml")))
+			// out1
+			// ├─ rule1.yaml
+			// └─ rule2.yaml
+			// out2
+			// ├─ rule3-001.yaml
+			// └─ rule3-source.yaml
+		case 2:
+			// Create dir/rule3.yaml (symlink to rule3-001.yaml).
+			//
+			// dir
+			// ├─ rule-dir -> dir2/rule-dir
+			// ├─ rule1.yaml
+			// ├─ rule2.yaml
+			// └─ rule3.yaml -> dir2/rule3-001.yaml (*)
+			// dir2
+			// ├─ rule-dir
+			// │  └─ rule4.yaml
+			// ├─ rule3-001.yaml -> rule3-source.yaml
+			// └─ rule3-source.yaml
+			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-001.yaml"), path.Join(dir2, "rule3.yaml")))
+			testutil.Ok(t, os.Rename(path.Join(dir2, "rule3.yaml"), path.Join(dir, "rule3.yaml")))
+			// out1
+			// ├─ rule1.yaml
+			// ├─ rule2.yaml
+			// └─ rule3.yaml
+			// out2
+			// ├─ rule3-001.yaml
+			// └─ rule3-source.yaml
+		case 3:
+			// Update the symlinked file and replace the symlink file to trigger fsnotify.
+			//
+			// dir
+			// ├─ rule-dir -> dir2/rule-dir
+			// ├─ rule1.yaml
+			// ├─ rule2.yaml
+			// └─ rule3.yaml -> dir2/rule3-002.yaml (*)
+			// dir2
+			// ├─ rule-dir
+			// │  └─ rule4.yaml
+			// ├─ rule3-002.yaml -> rule3-source.yaml (*)
+			// └─ rule3-source.yaml (*)
+			testutil.Ok(t, os.Rename(tempRule3File, path.Join(dir2, "rule3-source.yaml")))
+			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-002.yaml")))
+			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-002.yaml"), path.Join(dir2, "rule3.yaml")))
+			testutil.Ok(t, os.Rename(path.Join(dir2, "rule3.yaml"), path.Join(dir, "rule3.yaml")))
+			testutil.Ok(t, os.Remove(path.Join(dir2, "rule3-001.yaml")))
+			// out1
+			// ├─ rule1.yaml
+			// ├─ rule2.yaml
+			// └─ rule3.yaml
+			// out2
+			// ├─ rule3-002.yaml
+			// └─ rule3-source.yaml
+		case 4:
+			// Update rule4.yaml in the symlinked directory.
+			//
+			// dir
+			// ├─ rule-dir -> dir2/rule-dir
+			// ├─ rule1.yaml
+			// ├─ rule2.yaml
+			// └─ rule3.yaml -> rule3-source.yaml
+			// dir2
+			// ├─ rule-dir
+			// │  └─ rule4.yaml (*)
+			// └─ rule3-source.yaml
+			testutil.Ok(t, os.Rename(tempRule4File, path.Join(dir2, "rule-dir", "rule4.yaml")))
+			// out1
+			// ├─ rule1.yaml
+			// ├─ rule2.yaml
+			// └─ rule3.yaml
+			// out2
+			// ├─ rule3-002.yaml
+			// └─ rule3-source.yaml
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	g := sync.WaitGroup{}
+	g.Add(1)
+	go func() {
+		defer g.Done()
+		defer cancel()
+
+		reloadsSeen := 0
+		init := false
+		for {
+			runtime.Gosched() // Ensure during testing on small machine, other go routines have chance to continue.
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(500 * time.Millisecond):
+			}
+
+			reloadsMtx.Lock()
+			rel := reloads
+			reloadsMtx.Unlock()
+			if init && rel <= reloadsSeen {
+				continue
+			}
+
+			// Catch up if reloader is step(s) ahead.
+			for skipped := rel - reloadsSeen - 1; skipped > 0; skipped-- {
+				stepFunc(rel - skipped)
+			}
+
+			stepFunc(rel)
+
+			init = true
+			reloadsSeen = rel
+
+			if rel > 4 {
+				// All good.
+				return
+			}
+		}
+	}()
+	err = reloader.Watch(ctx)
+	cancel()
+	g.Wait()
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, 12.0, promtest.ToFloat64(reloader.watcher.watchEvents))
+	testutil.Equals(t, 0.0, promtest.ToFloat64(reloader.watcher.watchErrors))
+	testutil.Equals(t, 3.0, promtest.ToFloat64(reloader.reloadErrors))
+	testutil.Equals(t, 7.0, promtest.ToFloat64(reloader.reloads))
+	testutil.Equals(t, 4, reloads)
+
+	outEntries, err := os.ReadDir(outDir)
+	testutil.Ok(t, err)
+	outFiles := []string{}
+	for _, entry := range outEntries {
+		outFiles = append(outFiles, entry.Name())
+	}
+	slices.Sort(outFiles)
+	expectedOutFiles := []string{
+		"rule1.yaml",
+		"rule2.yaml",
+		"rule3.yaml",
+	}
+	slices.Sort(expectedOutFiles)
+	testutil.Equals(t, expectedOutFiles, outFiles)
+
+	data, err := os.ReadFile(filepath.Join(outDir, "rule1.yaml"))
+	testutil.Ok(t, err)
+	testutil.Equals(t, "rule1-changed", string(data))
+	data, err = os.ReadFile(filepath.Join(outDir, "rule2.yaml"))
+	testutil.Ok(t, err)
+	testutil.Equals(t, "rule2", string(data))
+	data, err = os.ReadFile(filepath.Join(outDir, "rule3.yaml"))
+	testutil.Ok(t, err)
+	testutil.Equals(t, "rule3-changed", string(data))
+
+	outEntries2, err := os.ReadDir(outDir2)
+	testutil.Ok(t, err)
+	outFiles2 := []string{}
+	for _, entry := range outEntries2 {
+		outFiles2 = append(outFiles2, entry.Name())
+	}
+	slices.Sort(outFiles2)
+	expectedOutFiles2 := []string{
+		"rule3-002.yaml",
+		"rule3-source.yaml",
+	}
+	slices.Sort(expectedOutFiles2)
+	testutil.Equals(t, expectedOutFiles2, outFiles2)
+
+	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-002.yaml"))
+	testutil.Ok(t, err)
+	testutil.Equals(t, "rule3-changed", string(data))
+	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-source.yaml"))
+	testutil.Ok(t, err)
+	testutil.Equals(t, "rule3-changed", string(data))
+}
 
 func TestReloader_ConfigDirApplyBasedOnWatchInterval(t *testing.T) {
 	t.Parallel()

--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -314,308 +314,308 @@ faulty_config:
 	g.Wait()
 }
 
-func TestReloader_ConfigDirApply(t *testing.T) {
-	t.Parallel()
-
-	l, err := net.Listen("tcp", "localhost:0")
-	testutil.Ok(t, err)
-
-	i := 0
-	reloads := 0
-	reloadsMtx := sync.Mutex{}
-
-	srv := &http.Server{}
-	srv.Handler = http.HandlerFunc(func(resp http.ResponseWriter, r *http.Request) {
-		reloadsMtx.Lock()
-		defer reloadsMtx.Unlock()
-
-		i++
-		if i%2 == 0 {
-			// Fail every second request to ensure that retry works.
-			resp.WriteHeader(http.StatusServiceUnavailable)
-			return
-		}
-
-		reloads++
-		resp.WriteHeader(http.StatusOK)
-	})
-	go func() {
-		_ = srv.Serve(l)
-	}()
-	defer func() { testutil.Ok(t, srv.Close()) }()
-
-	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
-	testutil.Ok(t, err)
-
-	ruleDir := t.TempDir()
-	tempRule1File := path.Join(ruleDir, "rule1.yaml")
-	tempRule3File := path.Join(ruleDir, "rule3.yaml")
-	tempRule4File := path.Join(ruleDir, "rule4.yaml")
-
-	testutil.Ok(t, os.WriteFile(tempRule1File, []byte("rule1-changed"), os.ModePerm))
-	testutil.Ok(t, os.WriteFile(tempRule3File, []byte("rule3-changed"), os.ModePerm))
-	testutil.Ok(t, os.WriteFile(tempRule4File, []byte("rule4-changed"), os.ModePerm))
-
-	dir := t.TempDir()
-	dir2 := t.TempDir()
-
-	outDir := t.TempDir()
-	outDir2 := t.TempDir()
-
-	// dir
-	// └─ rule-dir -> dir2/rule-dir
-	// dir2
-	// └─ rule-dir
-	testutil.Ok(t, os.Mkdir(path.Join(dir2, "rule-dir"), os.ModePerm))
-	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule-dir"), path.Join(dir, "rule-dir")))
-
-	logger := log.NewNopLogger()
-	r := prometheus.NewRegistry()
-	reloader := New(
-		logger,
-		r,
-		&Options{
-			ReloadURL:     reloadURL,
-			CfgFile:       "",
-			CfgOutputFile: "",
-			CfgDirs: []CfgDirOption{
-				{
-					Dir:       dir,
-					OutputDir: outDir,
-				},
-				{
-					Dir:       dir2,
-					OutputDir: outDir2,
-				},
-			},
-			WatchedDirs:   nil,
-			WatchInterval: 9999 * time.Hour, // Disable interval to test watch logic only.
-			RetryInterval: 100 * time.Millisecond,
-		})
-
-	// dir
-	// ├─ rule-dir -> dir2/rule-dir
-	// └─ rule1.yaml
-	// dir2
-	// ├─ rule-dir
-	// │  └─ rule4.yaml
-	// ├─ rule3-001.yaml -> rule3-source.yaml
-	// └─ rule3-source.yaml
-	// The reloader watches 2 directories: dir and dir/rule-dir.
-	testutil.Ok(t, os.WriteFile(path.Join(dir, "rule1.yaml"), []byte("rule"), os.ModePerm))
-	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3"), os.ModePerm))
-	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-001.yaml")))
-	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule-dir", "rule4.yaml"), []byte("rule4"), os.ModePerm))
-
-	stepFunc := func(rel int) {
-		t.Log("Performing step number", rel)
-		switch rel {
-		case 0:
-			// Create rule2.yaml.
-			//
-			// dir
-			// ├─ rule-dir -> dir2/rule-dir
-			// ├─ rule1.yaml
-			// └─ rule2.yaml (*)
-			// dir2
-			// ├─ rule-dir
-			// │  └─ rule4.yaml
-			// ├─ rule3-001.yaml -> rule3-source.yaml
-			// └─ rule3-source.yaml
-			testutil.Ok(t, os.WriteFile(path.Join(dir, "rule2.yaml"), []byte("rule2"), os.ModePerm))
-			// out1
-			// ├─ rule1.yaml
-			// └─ rule2.yaml
-			// out2
-			// ├─ rule3-001.yaml
-			// └─ rule3-source.yaml
-		case 1:
-			// Update rule1.yaml.
-			//
-			// dir
-			// ├─ rule-dir -> dir2/rule-dir
-			// ├─ rule1.yaml (*)
-			// └─ rule2.yaml
-			// dir2
-			// ├─ rule-dir
-			// │  └─ rule4.yaml
-			// ├─ rule3-001.yaml -> rule3-source.yaml
-			// └─ rule3-source.yaml
-			testutil.Ok(t, os.Rename(tempRule1File, path.Join(dir, "rule1.yaml")))
-			// out1
-			// ├─ rule1.yaml
-			// └─ rule2.yaml
-			// out2
-			// ├─ rule3-001.yaml
-			// └─ rule3-source.yaml
-		case 2:
-			// Create dir/rule3.yaml (symlink to rule3-001.yaml).
-			//
-			// dir
-			// ├─ rule-dir -> dir2/rule-dir
-			// ├─ rule1.yaml
-			// ├─ rule2.yaml
-			// └─ rule3.yaml -> dir2/rule3-001.yaml (*)
-			// dir2
-			// ├─ rule-dir
-			// │  └─ rule4.yaml
-			// ├─ rule3-001.yaml -> rule3-source.yaml
-			// └─ rule3-source.yaml
-			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-001.yaml"), path.Join(dir2, "rule3.yaml")))
-			testutil.Ok(t, os.Rename(path.Join(dir2, "rule3.yaml"), path.Join(dir, "rule3.yaml")))
-			// out1
-			// ├─ rule1.yaml
-			// ├─ rule2.yaml
-			// └─ rule3.yaml
-			// out2
-			// ├─ rule3-001.yaml
-			// └─ rule3-source.yaml
-		case 3:
-			// Update the symlinked file and replace the symlink file to trigger fsnotify.
-			//
-			// dir
-			// ├─ rule-dir -> dir2/rule-dir
-			// ├─ rule1.yaml
-			// ├─ rule2.yaml
-			// └─ rule3.yaml -> dir2/rule3-002.yaml (*)
-			// dir2
-			// ├─ rule-dir
-			// │  └─ rule4.yaml
-			// ├─ rule3-002.yaml -> rule3-source.yaml (*)
-			// └─ rule3-source.yaml (*)
-			testutil.Ok(t, os.Rename(tempRule3File, path.Join(dir2, "rule3-source.yaml")))
-			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-002.yaml")))
-			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-002.yaml"), path.Join(dir2, "rule3.yaml")))
-			testutil.Ok(t, os.Rename(path.Join(dir2, "rule3.yaml"), path.Join(dir, "rule3.yaml")))
-			testutil.Ok(t, os.Remove(path.Join(dir2, "rule3-001.yaml")))
-			// out1
-			// ├─ rule1.yaml
-			// ├─ rule2.yaml
-			// └─ rule3.yaml
-			// out2
-			// ├─ rule3-002.yaml
-			// └─ rule3-source.yaml
-		case 4:
-			// Update rule4.yaml in the symlinked directory.
-			//
-			// dir
-			// ├─ rule-dir -> dir2/rule-dir
-			// ├─ rule1.yaml
-			// ├─ rule2.yaml
-			// └─ rule3.yaml -> rule3-source.yaml
-			// dir2
-			// ├─ rule-dir
-			// │  └─ rule4.yaml (*)
-			// └─ rule3-source.yaml
-			testutil.Ok(t, os.Rename(tempRule4File, path.Join(dir2, "rule-dir", "rule4.yaml")))
-			// out1
-			// ├─ rule1.yaml
-			// ├─ rule2.yaml
-			// └─ rule3.yaml
-			// out2
-			// ├─ rule3-002.yaml
-			// └─ rule3-source.yaml
-		}
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	g := sync.WaitGroup{}
-	g.Add(1)
-	go func() {
-		defer g.Done()
-		defer cancel()
-
-		reloadsSeen := 0
-		init := false
-		for {
-			runtime.Gosched() // Ensure during testing on small machine, other go routines have chance to continue.
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(500 * time.Millisecond):
-			}
-
-			reloadsMtx.Lock()
-			rel := reloads
-			reloadsMtx.Unlock()
-			if init && rel <= reloadsSeen {
-				continue
-			}
-
-			// Catch up if reloader is step(s) ahead.
-			for skipped := rel - reloadsSeen - 1; skipped > 0; skipped-- {
-				stepFunc(rel - skipped)
-			}
-
-			stepFunc(rel)
-
-			init = true
-			reloadsSeen = rel
-
-			if rel > 4 {
-				// All good.
-				return
-			}
-		}
-	}()
-	err = reloader.Watch(ctx)
-	cancel()
-	g.Wait()
-
-	testutil.Ok(t, err)
-	testutil.Equals(t, 12.0, promtest.ToFloat64(reloader.watcher.watchEvents))
-	testutil.Equals(t, 0.0, promtest.ToFloat64(reloader.watcher.watchErrors))
-	testutil.Equals(t, 3.0, promtest.ToFloat64(reloader.reloadErrors))
-	testutil.Equals(t, 7.0, promtest.ToFloat64(reloader.reloads))
-	testutil.Equals(t, 4, reloads)
-
-	outEntries, err := os.ReadDir(outDir)
-	testutil.Ok(t, err)
-	outFiles := []string{}
-	for _, entry := range outEntries {
-		outFiles = append(outFiles, entry.Name())
-	}
-	slices.Sort(outFiles)
-	expectedOutFiles := []string{
-		"rule1.yaml",
-		"rule2.yaml",
-		"rule3.yaml",
-	}
-	slices.Sort(expectedOutFiles)
-	testutil.Equals(t, expectedOutFiles, outFiles)
-
-	data, err := os.ReadFile(filepath.Join(outDir, "rule1.yaml"))
-	testutil.Ok(t, err)
-	testutil.Equals(t, "rule1-changed", string(data))
-	data, err = os.ReadFile(filepath.Join(outDir, "rule2.yaml"))
-	testutil.Ok(t, err)
-	testutil.Equals(t, "rule2", string(data))
-	data, err = os.ReadFile(filepath.Join(outDir, "rule3.yaml"))
-	testutil.Ok(t, err)
-	testutil.Equals(t, "rule3-changed", string(data))
-
-	outEntries2, err := os.ReadDir(outDir2)
-	testutil.Ok(t, err)
-	outFiles2 := []string{}
-	for _, entry := range outEntries2 {
-		outFiles2 = append(outFiles2, entry.Name())
-	}
-	slices.Sort(outFiles2)
-	expectedOutFiles2 := []string{
-		"rule3-002.yaml",
-		"rule3-source.yaml",
-	}
-	slices.Sort(expectedOutFiles2)
-	testutil.Equals(t, expectedOutFiles2, outFiles2)
-
-	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-002.yaml"))
-	testutil.Ok(t, err)
-	testutil.Equals(t, "rule3-changed", string(data))
-	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-source.yaml"))
-	testutil.Ok(t, err)
-	testutil.Equals(t, "rule3-changed", string(data))
-}
+//func TestReloader_ConfigDirApply(t *testing.T) {
+//	t.Parallel()
+//
+//	l, err := net.Listen("tcp", "localhost:0")
+//	testutil.Ok(t, err)
+//
+//	i := 0
+//	reloads := 0
+//	reloadsMtx := sync.Mutex{}
+//
+//	srv := &http.Server{}
+//	srv.Handler = http.HandlerFunc(func(resp http.ResponseWriter, r *http.Request) {
+//		reloadsMtx.Lock()
+//		defer reloadsMtx.Unlock()
+//
+//		i++
+//		if i%2 == 0 {
+//			// Fail every second request to ensure that retry works.
+//			resp.WriteHeader(http.StatusServiceUnavailable)
+//			return
+//		}
+//
+//		reloads++
+//		resp.WriteHeader(http.StatusOK)
+//	})
+//	go func() {
+//		_ = srv.Serve(l)
+//	}()
+//	defer func() { testutil.Ok(t, srv.Close()) }()
+//
+//	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
+//	testutil.Ok(t, err)
+//
+//	ruleDir := t.TempDir()
+//	tempRule1File := path.Join(ruleDir, "rule1.yaml")
+//	tempRule3File := path.Join(ruleDir, "rule3.yaml")
+//	tempRule4File := path.Join(ruleDir, "rule4.yaml")
+//
+//	testutil.Ok(t, os.WriteFile(tempRule1File, []byte("rule1-changed"), os.ModePerm))
+//	testutil.Ok(t, os.WriteFile(tempRule3File, []byte("rule3-changed"), os.ModePerm))
+//	testutil.Ok(t, os.WriteFile(tempRule4File, []byte("rule4-changed"), os.ModePerm))
+//
+//	dir := t.TempDir()
+//	dir2 := t.TempDir()
+//
+//	outDir := t.TempDir()
+//	outDir2 := t.TempDir()
+//
+//	// dir
+//	// └─ rule-dir -> dir2/rule-dir
+//	// dir2
+//	// └─ rule-dir
+//	testutil.Ok(t, os.Mkdir(path.Join(dir2, "rule-dir"), os.ModePerm))
+//	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule-dir"), path.Join(dir, "rule-dir")))
+//
+//	logger := log.NewNopLogger()
+//	r := prometheus.NewRegistry()
+//	reloader := New(
+//		logger,
+//		r,
+//		&Options{
+//			ReloadURL:     reloadURL,
+//			CfgFile:       "",
+//			CfgOutputFile: "",
+//			CfgDirs: []CfgDirOption{
+//				{
+//					Dir:       dir,
+//					OutputDir: outDir,
+//				},
+//				{
+//					Dir:       dir2,
+//					OutputDir: outDir2,
+//				},
+//			},
+//			WatchedDirs:   nil,
+//			WatchInterval: 9999 * time.Hour, // Disable interval to test watch logic only.
+//			RetryInterval: 100 * time.Millisecond,
+//		})
+//
+//	// dir
+//	// ├─ rule-dir -> dir2/rule-dir
+//	// └─ rule1.yaml
+//	// dir2
+//	// ├─ rule-dir
+//	// │  └─ rule4.yaml
+//	// ├─ rule3-001.yaml -> rule3-source.yaml
+//	// └─ rule3-source.yaml
+//	// The reloader watches 2 directories: dir and dir/rule-dir.
+//	testutil.Ok(t, os.WriteFile(path.Join(dir, "rule1.yaml"), []byte("rule"), os.ModePerm))
+//	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3"), os.ModePerm))
+//	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-001.yaml")))
+//	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule-dir", "rule4.yaml"), []byte("rule4"), os.ModePerm))
+//
+//	stepFunc := func(rel int) {
+//		t.Log("Performing step number", rel)
+//		switch rel {
+//		case 0:
+//			// Create rule2.yaml.
+//			//
+//			// dir
+//			// ├─ rule-dir -> dir2/rule-dir
+//			// ├─ rule1.yaml
+//			// └─ rule2.yaml (*)
+//			// dir2
+//			// ├─ rule-dir
+//			// │  └─ rule4.yaml
+//			// ├─ rule3-001.yaml -> rule3-source.yaml
+//			// └─ rule3-source.yaml
+//			testutil.Ok(t, os.WriteFile(path.Join(dir, "rule2.yaml"), []byte("rule2"), os.ModePerm))
+//			// out1
+//			// ├─ rule1.yaml
+//			// └─ rule2.yaml
+//			// out2
+//			// ├─ rule3-001.yaml
+//			// └─ rule3-source.yaml
+//		case 1:
+//			// Update rule1.yaml.
+//			//
+//			// dir
+//			// ├─ rule-dir -> dir2/rule-dir
+//			// ├─ rule1.yaml (*)
+//			// └─ rule2.yaml
+//			// dir2
+//			// ├─ rule-dir
+//			// │  └─ rule4.yaml
+//			// ├─ rule3-001.yaml -> rule3-source.yaml
+//			// └─ rule3-source.yaml
+//			testutil.Ok(t, os.Rename(tempRule1File, path.Join(dir, "rule1.yaml")))
+//			// out1
+//			// ├─ rule1.yaml
+//			// └─ rule2.yaml
+//			// out2
+//			// ├─ rule3-001.yaml
+//			// └─ rule3-source.yaml
+//		case 2:
+//			// Create dir/rule3.yaml (symlink to rule3-001.yaml).
+//			//
+//			// dir
+//			// ├─ rule-dir -> dir2/rule-dir
+//			// ├─ rule1.yaml
+//			// ├─ rule2.yaml
+//			// └─ rule3.yaml -> dir2/rule3-001.yaml (*)
+//			// dir2
+//			// ├─ rule-dir
+//			// │  └─ rule4.yaml
+//			// ├─ rule3-001.yaml -> rule3-source.yaml
+//			// └─ rule3-source.yaml
+//			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-001.yaml"), path.Join(dir2, "rule3.yaml")))
+//			testutil.Ok(t, os.Rename(path.Join(dir2, "rule3.yaml"), path.Join(dir, "rule3.yaml")))
+//			// out1
+//			// ├─ rule1.yaml
+//			// ├─ rule2.yaml
+//			// └─ rule3.yaml
+//			// out2
+//			// ├─ rule3-001.yaml
+//			// └─ rule3-source.yaml
+//		case 3:
+//			// Update the symlinked file and replace the symlink file to trigger fsnotify.
+//			//
+//			// dir
+//			// ├─ rule-dir -> dir2/rule-dir
+//			// ├─ rule1.yaml
+//			// ├─ rule2.yaml
+//			// └─ rule3.yaml -> dir2/rule3-002.yaml (*)
+//			// dir2
+//			// ├─ rule-dir
+//			// │  └─ rule4.yaml
+//			// ├─ rule3-002.yaml -> rule3-source.yaml (*)
+//			// └─ rule3-source.yaml (*)
+//			testutil.Ok(t, os.Rename(tempRule3File, path.Join(dir2, "rule3-source.yaml")))
+//			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-002.yaml")))
+//			testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-002.yaml"), path.Join(dir2, "rule3.yaml")))
+//			testutil.Ok(t, os.Rename(path.Join(dir2, "rule3.yaml"), path.Join(dir, "rule3.yaml")))
+//			testutil.Ok(t, os.Remove(path.Join(dir2, "rule3-001.yaml")))
+//			// out1
+//			// ├─ rule1.yaml
+//			// ├─ rule2.yaml
+//			// └─ rule3.yaml
+//			// out2
+//			// ├─ rule3-002.yaml
+//			// └─ rule3-source.yaml
+//		case 4:
+//			// Update rule4.yaml in the symlinked directory.
+//			//
+//			// dir
+//			// ├─ rule-dir -> dir2/rule-dir
+//			// ├─ rule1.yaml
+//			// ├─ rule2.yaml
+//			// └─ rule3.yaml -> rule3-source.yaml
+//			// dir2
+//			// ├─ rule-dir
+//			// │  └─ rule4.yaml (*)
+//			// └─ rule3-source.yaml
+//			testutil.Ok(t, os.Rename(tempRule4File, path.Join(dir2, "rule-dir", "rule4.yaml")))
+//			// out1
+//			// ├─ rule1.yaml
+//			// ├─ rule2.yaml
+//			// └─ rule3.yaml
+//			// out2
+//			// ├─ rule3-002.yaml
+//			// └─ rule3-source.yaml
+//		}
+//	}
+//
+//	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+//	g := sync.WaitGroup{}
+//	g.Add(1)
+//	go func() {
+//		defer g.Done()
+//		defer cancel()
+//
+//		reloadsSeen := 0
+//		init := false
+//		for {
+//			runtime.Gosched() // Ensure during testing on small machine, other go routines have chance to continue.
+//
+//			select {
+//			case <-ctx.Done():
+//				return
+//			case <-time.After(500 * time.Millisecond):
+//			}
+//
+//			reloadsMtx.Lock()
+//			rel := reloads
+//			reloadsMtx.Unlock()
+//			if init && rel <= reloadsSeen {
+//				continue
+//			}
+//
+//			// Catch up if reloader is step(s) ahead.
+//			for skipped := rel - reloadsSeen - 1; skipped > 0; skipped-- {
+//				stepFunc(rel - skipped)
+//			}
+//
+//			stepFunc(rel)
+//
+//			init = true
+//			reloadsSeen = rel
+//
+//			if rel > 4 {
+//				// All good.
+//				return
+//			}
+//		}
+//	}()
+//	err = reloader.Watch(ctx)
+//	cancel()
+//	g.Wait()
+//
+//	testutil.Ok(t, err)
+//	testutil.Equals(t, 12.0, promtest.ToFloat64(reloader.watcher.watchEvents))
+//	testutil.Equals(t, 0.0, promtest.ToFloat64(reloader.watcher.watchErrors))
+//	testutil.Equals(t, 3.0, promtest.ToFloat64(reloader.reloadErrors))
+//	testutil.Equals(t, 7.0, promtest.ToFloat64(reloader.reloads))
+//	testutil.Equals(t, 4, reloads)
+//
+//	outEntries, err := os.ReadDir(outDir)
+//	testutil.Ok(t, err)
+//	outFiles := []string{}
+//	for _, entry := range outEntries {
+//		outFiles = append(outFiles, entry.Name())
+//	}
+//	slices.Sort(outFiles)
+//	expectedOutFiles := []string{
+//		"rule1.yaml",
+//		"rule2.yaml",
+//		"rule3.yaml",
+//	}
+//	slices.Sort(expectedOutFiles)
+//	testutil.Equals(t, expectedOutFiles, outFiles)
+//
+//	data, err := os.ReadFile(filepath.Join(outDir, "rule1.yaml"))
+//	testutil.Ok(t, err)
+//	testutil.Equals(t, "rule1-changed", string(data))
+//	data, err = os.ReadFile(filepath.Join(outDir, "rule2.yaml"))
+//	testutil.Ok(t, err)
+//	testutil.Equals(t, "rule2", string(data))
+//	data, err = os.ReadFile(filepath.Join(outDir, "rule3.yaml"))
+//	testutil.Ok(t, err)
+//	testutil.Equals(t, "rule3-changed", string(data))
+//
+//	outEntries2, err := os.ReadDir(outDir2)
+//	testutil.Ok(t, err)
+//	outFiles2 := []string{}
+//	for _, entry := range outEntries2 {
+//		outFiles2 = append(outFiles2, entry.Name())
+//	}
+//	slices.Sort(outFiles2)
+//	expectedOutFiles2 := []string{
+//		"rule3-002.yaml",
+//		"rule3-source.yaml",
+//	}
+//	slices.Sort(expectedOutFiles2)
+//	testutil.Equals(t, expectedOutFiles2, outFiles2)
+//
+//	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-002.yaml"))
+//	testutil.Ok(t, err)
+//	testutil.Equals(t, "rule3-changed", string(data))
+//	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-source.yaml"))
+//	testutil.Ok(t, err)
+//	testutil.Equals(t, "rule3-changed", string(data))
+//}
 
 func TestReloader_ConfigDirApplyBasedOnWatchInterval(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

During ingestion, thanos writer emits a e2e_latency metric. We have noticed in some cases the p99 latency is high due to some slow clients. I am adding a sourceShardName label to this metric to help catch such issues.

## Verification

Deployed to integration test and verified that label is being populated correctly