### PR TITLE
Only fan-out a query to a store endpoint when it has at least one health check success

### DIFF
--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -754,7 +754,7 @@ func (er *endpointRef) isQueryable() bool {
 	er.mtx.RLock()
 	defer er.mtx.RUnlock()
 
-	return er.isStrict || er.ignoreError || er.status.LastError == nil
+	return er.isStrict || er.status.LastError == nil
 }
 
 func (er *endpointRef) ComponentType() component.Component {


### PR DESCRIPTION
This is to avoid querying an unhealthy endpoint.