### PR TITLE
Blocking Bronson Queries w/ High-Cardinality Metrics w/o Prefixes: Exclude Grafana

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -321,7 +321,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 	}
 
 	// Check if the query should be blocked due to insufficient filters
-	shouldBlock, metricName, matchedPattern := s.shouldBlockQuery(matchers)
+	shouldBlock, metricName, matchedPattern := s.shouldBlockQuery(srv.Context(), matchers)
 	if shouldBlock {
 		// Log the blocked query with structured logging
 		filterCount := s.countAllFilters(matchers)
@@ -956,9 +956,26 @@ func (s *ProxyStore) countAllFilters(matchers []*labels.Matcher) int {
 }
 
 // shouldBlockQuery determines if a query should be blocked based on metric patterns and label filters.
+// Only blocks queries from Bronson (identified by X-Source header).
 // Returns (shouldBlock, metricName, matchedPattern).
-func (s *ProxyStore) shouldBlockQuery(matchers []*labels.Matcher) (bool, string, string) {
+func (s *ProxyStore) shouldBlockQuery(ctx context.Context, matchers []*labels.Matcher) (bool, string, string) {
 	if s.blockedMetricPatterns == nil {
+		return false, "", ""
+	}
+
+	// Only apply blocking for Bronson requests (identified by X-Source header)
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if sources := md.Get("x-source"); len(sources) > 0 {
+			if sources[0] != "Bronson" {
+				// Not from Bronson, don't block
+				return false, "", ""
+			}
+		} else {
+			// No X-Source header, don't block
+			return false, "", ""
+		}
+	} else {
+		// No metadata context, don't block
 		return false, "", ""
 	}
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -980,7 +980,7 @@ func (s *ProxyStore) countAllFilters(matchers []*labels.Matcher) int {
 	return filterCount
 }
 
-// isBronsonRequest checks if the request is from Bronson by examining the X-Source header
+// isBronsonRequest checks if the request is from Bronson by examining the X-Source header.
 func (s *ProxyStore) isBronsonRequest(ctx context.Context) bool {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		if sources := md.Get("x-source"); len(sources) > 0 {

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -980,7 +980,7 @@ func (s *ProxyStore) countAllFilters(matchers []*labels.Matcher) int {
 // shouldBlockQuery determines if a query should be blocked based on metric patterns and label filters.
 // Only blocks queries from Bronson (identified by X-Source header).
 // Returns (shouldBlock, metricName, matchedPattern).
-func (s *ProxyStore) shouldBlockQuery(matchers []*labels.Matcher) (bool, string, string) {
+func (s *ProxyStore) shouldBlockQuery(ctx context.Context, matchers []*labels.Matcher) (bool, string, string) {
 	if s.blockedMetricPrefixes == nil && s.blockedMetricExacts == nil {
 		return false, "", ""
 	}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -342,8 +342,11 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 		return status.Error(codes.InvalidArgument, errors.New("no matchers specified (excluding selector labels)").Error())
 	}
 
+	// Check X-Source header once for performance
+	isBronsonRequest := s.isBronsonRequest(srv.Context())
+	
 	// Check if the query should be blocked due to insufficient filters
-	shouldBlock, metricName, matchedPattern := s.shouldBlockQuery(srv.Context(), matchers)
+	shouldBlock, metricName, matchedPattern := s.shouldBlockQuery(isBronsonRequest, matchers)
 	if shouldBlock {
 		// Log the blocked query with structured logging
 		filterCount := s.countAllFilters(matchers)
@@ -977,27 +980,26 @@ func (s *ProxyStore) countAllFilters(matchers []*labels.Matcher) int {
 	return filterCount
 }
 
+// isBronsonRequest checks if the request is from Bronson by examining the X-Source header
+func (s *ProxyStore) isBronsonRequest(ctx context.Context) bool {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if sources := md.Get("x-source"); len(sources) > 0 {
+			return sources[0] == "Bronson"
+		}
+	}
+	return false
+}
+
 // shouldBlockQuery determines if a query should be blocked based on metric patterns and label filters.
-// Only blocks queries from Bronson (identified by X-Source header).
+// Only blocks queries from Bronson (when isBronsonRequest is true).
 // Returns (shouldBlock, metricName, matchedPattern).
-func (s *ProxyStore) shouldBlockQuery(ctx context.Context, matchers []*labels.Matcher) (bool, string, string) {
+func (s *ProxyStore) shouldBlockQuery(isBronsonRequest bool, matchers []*labels.Matcher) (bool, string, string) {
 	if s.blockedMetricPrefixes == nil && s.blockedMetricExacts == nil {
 		return false, "", ""
 	}
 
-	// Only apply blocking for Bronson requests (identified by X-Source header)
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if sources := md.Get("x-source"); len(sources) > 0 {
-			if sources[0] != "Bronson" {
-				// Not from Bronson, don't block
-				return false, "", ""
-			}
-		} else {
-			// No X-Source header, don't block
-			return false, "", ""
-		}
-	} else {
-		// No metadata context, don't block
+	// Only apply blocking for Bronson requests
+	if !isBronsonRequest {
 		return false, "", ""
 	}
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -344,7 +344,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 
 	// Check X-Source header once for performance
 	isBronsonRequest := s.isBronsonRequest(srv.Context())
-	
+
 	// Check if the query should be blocked due to insufficient filters
 	shouldBlock, metricName, matchedPattern := s.shouldBlockQuery(isBronsonRequest, matchers)
 	if shouldBlock {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1453,8 +1453,8 @@ func TestProxyStore_Series(t *testing.T) {
 				},
 			},
 			blockedPatterns: []string{"up*"}, // wildcard pattern - broader than exact match
-		xSourceHeader:   "Bronson",
-		expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'up' matches blocked pattern 'up*', please add proper filters to reduce the amount of data to fetch"),
+			xSourceHeader:   "Bronson",
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'up' matches blocked pattern 'up*', please add proper filters to reduce the amount of data to fetch"),
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1069,15 +1069,9 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "__name__", Value: "high_cardinality_metric", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-<<<<<<< HEAD
-			blockedPatterns: []string{"high_cardinality"},
-			xSourceHeader:   "Bronson",
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality', please add proper filters to reduce the amount of data to fetch"),
-=======
 			blockedPatterns: []string{"high_cardinality_"},
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality_', please add proper filters to reduce the amount of data to fetch"),
->>>>>>> db_main
-		},
+			xSourceHeader:   "Bronson",
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality_', please add proper filters to reduce the amount of data to fetch")},
 		{
 			title: "blocked query: metric matches pattern but has sufficient filters - should succeed",
 			storeAPIs: []Client{
@@ -1221,57 +1215,6 @@ func TestProxyStore_Series(t *testing.T) {
 			},
 		},
 		{
-<<<<<<< HEAD
-			title: "blocked query: multiple blocked patterns - first pattern matches",
-			storeAPIs: []Client{
-				&storetestutil.TestClient{
-					StoreClient: &mockedStoreAPI{
-						RespSeries: []*storepb.SeriesResponse{
-							storeSeriesResponse(t, labels.FromStrings("__name__", "high_cardinality_metric"), []sample{{0, 0}, {2, 1}}),
-						},
-					},
-					MinTime: 1,
-					MaxTime: 300,
-				},
-			},
-			req: &storepb.SeriesRequest{
-				MinTime: 1,
-				MaxTime: 300,
-				Matchers: []storepb.LabelMatcher{
-					{Name: "__name__", Value: "high_cardinality_metric", Type: storepb.LabelMatcher_EQ},
-				},
-			},
-			blockedPatterns: []string{"high_cardinality", "another_pattern"},
-			xSourceHeader:   "Bronson",
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality', please add proper filters to reduce the amount of data to fetch"),
-		},
-		{
-			title: "blocked query: multiple blocked patterns - second pattern matches",
-			storeAPIs: []Client{
-				&storetestutil.TestClient{
-					StoreClient: &mockedStoreAPI{
-						RespSeries: []*storepb.SeriesResponse{
-							storeSeriesResponse(t, labels.FromStrings("__name__", "another_pattern_metric"), []sample{{0, 0}, {2, 1}}),
-						},
-					},
-					MinTime: 1,
-					MaxTime: 300,
-				},
-			},
-			req: &storepb.SeriesRequest{
-				MinTime: 1,
-				MaxTime: 300,
-				Matchers: []storepb.LabelMatcher{
-					{Name: "__name__", Value: "another_pattern_metric", Type: storepb.LabelMatcher_EQ},
-				},
-			},
-			blockedPatterns: []string{"high_cardinality", "another_pattern"},
-			xSourceHeader:   "Bronson",
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'another_pattern_metric' matches blocked pattern 'another_pattern', please add proper filters to reduce the amount of data to fetch"),
-		},
-		{
-=======
->>>>>>> db_main
 			title: "not blocked query: multiple exact filters should be allowed",
 			storeAPIs: []Client{
 				&storetestutil.TestClient{
@@ -1407,15 +1350,9 @@ func TestProxyStore_Series(t *testing.T) {
 					{Name: "__name__", Value: "upstream_connections", Type: storepb.LabelMatcher_EQ},
 				},
 			},
-<<<<<<< HEAD
-			blockedPatterns: []string{"high", "high_cardinality", "high_cardinality_detailed"},
+			blockedPatterns: []string{"upstream*"},
 			xSourceHeader:   "Bronson",
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_detailed_metric' matches blocked pattern 'high_cardinality_detailed', please add proper filters to reduce the amount of data to fetch"),
-=======
-			blockedPatterns: []string{"up*"},
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'upstream_connections' matches blocked pattern 'up*', please add proper filters to reduce the amount of data to fetch"),
->>>>>>> db_main
-		},
+			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'upstream_connections' matches blocked pattern 'upstream*', please add proper filters to reduce the amount of data to fetch")},
 		{
 			title: "not blocked query: no prefix match",
 			storeAPIs: []Client{
@@ -1516,7 +1453,8 @@ func TestProxyStore_Series(t *testing.T) {
 				},
 			},
 			blockedPatterns: []string{"up*"}, // wildcard pattern - broader than exact match
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'up' matches blocked pattern 'up*', please add proper filters to reduce the amount of data to fetch"),
+		xSourceHeader:   "Bronson",
+		expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'up' matches blocked pattern 'up*', please add proper filters to reduce the amount of data to fetch"),
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1430,6 +1430,7 @@ func TestProxyStore_Series(t *testing.T) {
 				},
 			},
 			blockedPatterns: []string{"up"}, // exact match pattern (no * or _)
+			xSourceHeader:   "Bronson",
 			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'up' matches blocked pattern 'up', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/efficientgo/core/testutil"
 
@@ -99,6 +100,7 @@ func TestProxyStore_Series(t *testing.T) {
 		req                *storepb.SeriesRequest
 		storeDebugMatchers [][]*labels.Matcher
 		blockedPatterns    []string
+		xSourceHeader      string // X-Source header value for blocking tests
 
 		expectedSeries      []rawSeries
 		expectedErr         error
@@ -1068,6 +1070,7 @@ func TestProxyStore_Series(t *testing.T) {
 				},
 			},
 			blockedPatterns: []string{"high_cardinality"},
+			xSourceHeader:   "Bronson",
 			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{
@@ -1233,6 +1236,7 @@ func TestProxyStore_Series(t *testing.T) {
 				},
 			},
 			blockedPatterns: []string{"high_cardinality", "another_pattern"},
+			xSourceHeader:   "Bronson",
 			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_metric' matches blocked pattern 'high_cardinality', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{
@@ -1256,6 +1260,7 @@ func TestProxyStore_Series(t *testing.T) {
 				},
 			},
 			blockedPatterns: []string{"high_cardinality", "another_pattern"},
+			xSourceHeader:   "Bronson",
 			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'another_pattern_metric' matches blocked pattern 'another_pattern', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{
@@ -1395,6 +1400,7 @@ func TestProxyStore_Series(t *testing.T) {
 				},
 			},
 			blockedPatterns: []string{"high", "high_cardinality", "high_cardinality_detailed"},
+			xSourceHeader:   "Bronson",
 			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'high_cardinality_detailed_metric' matches blocked pattern 'high_cardinality_detailed', please add proper filters to reduce the amount of data to fetch"),
 		},
 		{
@@ -1457,6 +1463,11 @@ func TestProxyStore_Series(t *testing.T) {
 							ctx := context.Background()
 							if len(tc.storeDebugMatchers) > 0 {
 								ctx = context.WithValue(ctx, StoreMatcherKey, tc.storeDebugMatchers)
+							}
+							// Add X-Source header if specified for blocking tests
+							if tc.xSourceHeader != "" {
+								md := metadata.New(map[string]string{"x-source": tc.xSourceHeader})
+								ctx = metadata.NewIncomingContext(ctx, md)
 							}
 
 							s := newStoreSeriesServer(ctx)


### PR DESCRIPTION
Due to discovery that large number of Grafana dashboards would immediately be affected (large blast radius) if we blocked high cardinality metrics without prefixes, this is an alternative to only block high cardinality metric queries which are queried through Bronson. See [Announcement Tab (Comment w/ Joey and Pranav)](https://docs.google.com/document/d/1_1EFGHvav7PiZI-dRNCn-1YknsW6kZ-6O-6WpqoqJzA/edit?usp=sharing)

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added a check for XSource header when blocking, should only block when XSource header is present and is Bronson. Modified unit tests so they would pass. 

## Verification

Modified unit tests in relevant proxy_test.go file. 