### PR TITLE
skip zombie tenants in downscale probe

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -376,10 +376,10 @@ func runReceive(
 			httpserver.WithTLSConfig(*conf.httpTLSConfig),
 		)
 		srv.Handle("/-/downscale", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			tenants := dbs.GetTenants()
-			n := len(tenants)
+			activeTenants := dbs.GetActiveTenants()
+			n := len(activeTenants)
 			w.Header().Set("Tenant-Count", strconv.Itoa(n))
-			for _, tname := range tenants {
+			for _, tname := range activeTenants {
 				w.Header().Add("Tenants", tname)
 			}
 			if n > 0 {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -160,10 +160,15 @@ func (t *MultiTSDB) isNoUploadTenant(tenantID string) bool {
 }
 
 func (t *MultiTSDB) GetActiveTenants() []string {
-	t.mtx.RLock()
-	defer t.mtx.RUnlock()
-	activeTenants := make([]string, 0, len(t.tenants))
-	for tname, tenantInstance := range t.tenants {
+    tenants := make(map[string]*tenant)
+    t.mtx.RLock()
+    for tname, tenantInstance := range t.tenants {
+        tenants[tname] = tenantInstance
+    }
+    t.mtx.RUnlock()
+
+	activeTenants := make([]string, 0, len(tenants))
+	for tname, tenantInstance := range tenants {
 		tenantTSDB := tenantInstance.readyStorage()
 		if tenantTSDB == nil {
 			continue

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -160,12 +160,12 @@ func (t *MultiTSDB) isNoUploadTenant(tenantID string) bool {
 }
 
 func (t *MultiTSDB) GetActiveTenants() []string {
-    tenants := make(map[string]*tenant)
-    t.mtx.RLock()
-    for tname, tenantInstance := range t.tenants {
-        tenants[tname] = tenantInstance
-    }
-    t.mtx.RUnlock()
+	tenants := make(map[string]*tenant)
+	t.mtx.RLock()
+	for tname, tenantInstance := range t.tenants {
+		tenants[tname] = tenantInstance
+	}
+	t.mtx.RUnlock()
 
 	activeTenants := make([]string, 0, len(tenants))
 	for tname, tenantInstance := range tenants {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -159,14 +159,31 @@ func (t *MultiTSDB) isNoUploadTenant(tenantID string) bool {
 	return false
 }
 
-func (t *MultiTSDB) GetTenants() []string {
+func (t *MultiTSDB) GetActiveTenants() []string {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
-	tenants := make([]string, 0, len(t.tenants))
-	for tname := range t.tenants {
-		tenants = append(tenants, tname)
+	activeTenants := make([]string, 0, len(t.tenants))
+	for tname, tenantInstance := range t.tenants {
+		tenantTSDB := tenantInstance.readyStorage()
+		if tenantTSDB == nil {
+			continue
+		}
+		tenantTSDB.mtx.RLock()
+		if tenantTSDB.a == nil || tenantTSDB.a.db == nil {
+			tenantTSDB.mtx.RUnlock()
+			continue
+		}
+		tdb := tenantTSDB.a.db
+		head := tdb.Head()
+		if head.MaxTime() < 0 {
+			tenantTSDB.mtx.RUnlock()
+			level.Info(t.logger).Log("msg", "skipping zombie tenant", "tenant", tname)
+			continue
+		}
+		tenantTSDB.mtx.RUnlock()
+		activeTenants = append(activeTenants, tname)
 	}
-	return tenants
+	return activeTenants
 }
 
 // testGetTenant returns the tenant with the given tenantID for testing purposes.


### PR DESCRIPTION
Some zombie tenants with maxTime < 0 and activeSeries = 0 are blocking downscale operation. We still don't know why they are created, and this PR works around it.