### PR TITLE
Add query partial strategy forwarding option and instrumentation

### DIFF
--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -743,7 +743,10 @@ func (er *endpointRef) updateMetadata(metadata *endpointMetadata, err error) {
 	}
 
 	if err != nil && er.metadata == nil {
+		mint, maxt := er.timeRange()
 		er.metadata = maxRangeStoreMetadata()
+		er.metadata.Store.MinTime = mint
+		er.metadata.Store.MaxTime = maxt
 	}
 }
 

--- a/pkg/query/endpointset_test.go
+++ b/pkg/query/endpointset_test.go
@@ -1668,6 +1668,16 @@ func TestDefaultTimeRange(t *testing.T) {
 		now := time.Now()
 		testutil.Equals(t, now.Add(-9600*time.Hour).Unix()/60, minTime/(1000*60))
 		testutil.Equals(t, now.Add(-11490*time.Minute).Unix()/60, maxTime/(1000*60))
+
+		endpointRef.updateMetadata(maxRangeStoreMetadata(), errors.New("test err"))
+		minTime, maxTime = endpointRef.timeRange()
+		testutil.Equals(t, now.Add(-9600*time.Hour).Unix()/60, minTime/(1000*60))
+		testutil.Equals(t, now.Add(-11490*time.Minute).Unix()/60, maxTime/(1000*60))
+
+		endpointRef.updateMetadata(maxRangeStoreMetadata(), nil)
+		minTime, maxTime = endpointRef.timeRange()
+		testutil.Equals(t, int64(math.MinInt64), minTime)
+		testutil.Equals(t, int64(math.MaxInt64), maxTime)
 	}
 	{
 		endpointRef := &endpointRef{


### PR DESCRIPTION
The regional Querier needs to forward query partial strategy to the lower level Queriers.
Also added metrics for query fan-out.
Tested in a dev region
<img width="2508" height="951" alt="image" src="https://github.com/user-attachments/assets/d27ab725-3177-4c3d-9182-c66bb8e9677f" />
