### PR TITLE
Prefix block directory in object store with tenant in multitsdb

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -162,6 +162,11 @@ func runReceive(
 		level.Info(logger).Log("msg", "configured tenants for local storage only", "tenants", strings.Join(*conf.noUploadTenants, ","))
 	}
 
+	if conf.tsdbEnableTenantPathPrefix {
+		multiTSDBOptions = append(multiTSDBOptions, receive.WithTenantPathPrefix())
+		level.Info(logger).Log("msg", "tenant path prefix feature enabled")
+	}
+
 	// Create a matcher converter if specified by command line to cache expensive regex matcher conversions.
 	// Proxy store and TSDB stores of all tenants share a single cache.
 	var matcherConverter *storepb.MatcherConverter
@@ -996,6 +1001,7 @@ type receiveConfig struct {
 	tsdbMemorySnapshotOnShutdown bool
 	tsdbDisableFlushOnShutdown   bool
 	tsdbEnableNativeHistograms   bool
+	tsdbEnableTenantPathPrefix   bool
 
 	walCompression       bool
 	noLockFile           bool
@@ -1160,6 +1166,10 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("tsdb.enable-native-histograms",
 		"[EXPERIMENTAL] Enables the ingestion of native histograms.").
 		Default("false").Hidden().BoolVar(&rc.tsdbEnableNativeHistograms)
+
+	cmd.Flag("tsdb.enable-tenant-path-prefix",
+		"[EXPERIMENTAL] Enables the tenant path prefix for object storage.").
+		Default("false").Hidden().BoolVar(&rc.tsdbEnableTenantPathPrefix)
 
 	cmd.Flag("writer.intern",
 		"[EXPERIMENTAL] Enables string interning in receive writer, for more optimized memory usage.").

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -167,6 +167,11 @@ func runReceive(
 		level.Info(logger).Log("msg", "tenant path prefix feature enabled")
 	}
 
+	if len(conf.tsdbPathSegmentsBeforeTenant) > 0 {
+		multiTSDBOptions = append(multiTSDBOptions, receive.WithPathSegmentsBeforeTenant(conf.tsdbPathSegmentsBeforeTenant))
+		level.Info(logger).Log("msg", "tenant path segments before tenant feature enabled", "segments", path.Join(conf.tsdbPathSegmentsBeforeTenant...))
+	}
+
 	// Create a matcher converter if specified by command line to cache expensive regex matcher conversions.
 	// Proxy store and TSDB stores of all tenants share a single cache.
 	var matcherConverter *storepb.MatcherConverter
@@ -1002,6 +1007,7 @@ type receiveConfig struct {
 	tsdbDisableFlushOnShutdown   bool
 	tsdbEnableNativeHistograms   bool
 	tsdbEnableTenantPathPrefix   bool
+	tsdbPathSegmentsBeforeTenant []string
 
 	walCompression       bool
 	noLockFile           bool
@@ -1170,6 +1176,11 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("tsdb.enable-tenant-path-prefix",
 		"[EXPERIMENTAL] Enables the tenant path prefix for object storage.").
 		Default("false").Hidden().BoolVar(&rc.tsdbEnableTenantPathPrefix)
+
+	cmd.Flag("tsdb.path-segments-before-tenant",
+		"[EXPERIMENTAL] Specifies the path segments before the tenant for object storage."+
+			"Must only be used in combination with tsdb.enable-tenant-path-prefix.").
+		Default("raw").Hidden().StringsVar(&rc.tsdbPathSegmentsBeforeTenant)
 
 	cmd.Flag("writer.intern",
 		"[EXPERIMENTAL] Enables string interning in receive writer, for more optimized memory usage.").

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -65,10 +65,11 @@ type MultiTSDB struct {
 	tsdbClients     []store.Client
 	exemplarClients map[string]*exemplars.TSDB
 
-	metricNameFilterEnabled bool
-	matcherConverter        *storepb.MatcherConverter
-	noUploadTenants         []string // Support both exact matches and prefix patterns (e.g., "tenant1", "prod-*")
-	enableTenantPathPrefix  bool
+	metricNameFilterEnabled  bool
+	matcherConverter         *storepb.MatcherConverter
+	noUploadTenants          []string // Support both exact matches and prefix patterns (e.g., "tenant1", "prod-*")
+	enableTenantPathPrefix   bool
+	pathSegmentsBeforeTenant []string
 }
 
 // MultiTSDBOption is a functional option for MultiTSDB.
@@ -100,6 +101,13 @@ func WithNoUploadTenants(tenants []string) MultiTSDBOption {
 func WithTenantPathPrefix() MultiTSDBOption {
 	return func(s *MultiTSDB) {
 		s.enableTenantPathPrefix = true
+	}
+}
+
+// WithPathSegmentsBeforeTenant sets the path segments before the tenant for object store.
+func WithPathSegmentsBeforeTenant(segments []string) MultiTSDBOption {
+	return func(s *MultiTSDB) {
+		s.pathSegmentsBeforeTenant = segments
 	}
 }
 
@@ -781,8 +789,10 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	if t.bucket != nil && !t.isNoUploadTenant(tenantID) {
 		var tenantBucket objstore.Bucket
 		if t.enableTenantPathPrefix {
-			tenantPrefix := path.Join("v1", "raw", tenantID)
+			segmentsBeforeTenant := path.Join(t.pathSegmentsBeforeTenant...)
+			tenantPrefix := path.Join(segmentsBeforeTenant, tenantID)
 			tenantBucket = objstore.NewPrefixedBucket(t.bucket, tenantPrefix)
+			level.Info(logger).Log("msg", "assigning shipper bucket with tenant path prefix", "tenantPrefix", tenantPrefix)
 		} else {
 			tenantBucket = t.bucket
 		}

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -68,6 +68,7 @@ type MultiTSDB struct {
 	metricNameFilterEnabled bool
 	matcherConverter        *storepb.MatcherConverter
 	noUploadTenants         []string // Support both exact matches and prefix patterns (e.g., "tenant1", "prod-*")
+	enableTenantPathPrefix  bool
 }
 
 // MultiTSDBOption is a functional option for MultiTSDB.
@@ -92,6 +93,13 @@ func WithMatcherConverter(mc *storepb.MatcherConverter) MultiTSDBOption {
 func WithNoUploadTenants(tenants []string) MultiTSDBOption {
 	return func(s *MultiTSDB) {
 		s.noUploadTenants = tenants
+	}
+}
+
+// WithTenantPathPrefix enables the tenant path prefix for object store.
+func WithTenantPathPrefix() MultiTSDBOption {
+	return func(s *MultiTSDB) {
+		s.enableTenantPathPrefix = true
 	}
 }
 
@@ -771,11 +779,18 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	}
 	var ship *shipper.Shipper
 	if t.bucket != nil && !t.isNoUploadTenant(tenantID) {
+		var tenantBucket objstore.Bucket
+		if t.enableTenantPathPrefix {
+			tenantPrefix := path.Join("v1", "raw", tenantID)
+			tenantBucket = objstore.NewPrefixedBucket(t.bucket, tenantPrefix)
+		} else {
+			tenantBucket = t.bucket
+		}
 		ship = shipper.New(
 			logger,
 			reg,
 			dataDir,
-			t.bucket,
+			tenantBucket,
 			func() labels.Labels { return lset },
 			metadata.ReceiveSource,
 			nil,

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -1178,6 +1178,7 @@ func TestTenantBucketPrefixInUpload(t *testing.T) {
 		false,
 		metadata.NoneFunc,
 		WithTenantPathPrefix(),
+		WithPathSegmentsBeforeTenant([]string{"v1", "raw"}),
 	)
 	defer func() { testutil.Ok(t, m.Close()) }()
 

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -1158,3 +1158,103 @@ func TestNoUploadTenantsRetentionStillWorks(t *testing.T) {
 	// but we've verified the key fix: no-upload tenants don't get a shipper,
 	// so the pruning logic won't try to upload during retention cleanup.
 }
+
+func TestTenantBucketPrefixInUpload(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bucket := objstore.NewInMemBucket()
+
+	// Create MultiTSDB with bucket
+	m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
+		&tsdb.Options{
+			MinBlockDuration:  (2 * time.Hour).Milliseconds(),
+			MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
+			RetentionDuration: (6 * time.Hour).Milliseconds(),
+		},
+		labels.FromStrings("replica", "test"),
+		"tenant_id",
+		bucket,
+		false,
+		metadata.NoneFunc,
+		WithTenantPathPrefix(),
+	)
+	defer func() { testutil.Ok(t, m.Close()) }()
+
+	// Test with multiple tenants to ensure each gets their own prefix
+	tenantIDs := []string{"tenant-a", "tenant-b"}
+
+	for _, tenantID := range tenantIDs {
+		// Add samples over a longer time period to trigger block creation
+		baseTime := time.Now().Add(-4 * time.Hour)
+		for i := 0; i < 100; i++ {
+			sampleTime := baseTime.Add(time.Duration(i) * time.Minute)
+			testutil.Ok(t, appendSample(m, tenantID, sampleTime))
+		}
+	}
+
+	testutil.Ok(t, m.Flush())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	uploaded, err := m.Sync(ctx)
+	testutil.Ok(t, err)
+
+	t.Logf("Uploaded %d blocks", uploaded)
+
+	if uploaded > 0 {
+		// Verify that uploaded blocks are in directories with tenant prefixes
+		// Expected path format: "v1/raw/{tenantID}/{blockID}/{file}"
+		expectedPrefix1 := "v1/raw/tenant-a"
+		expectedPrefix2 := "v1/raw/tenant-b"
+		foundTenantA := false
+		foundTenantB := false
+
+		var allObjects []string
+		testutil.Ok(t, bucket.Iter(context.Background(), "", func(name string) error {
+			allObjects = append(allObjects, name)
+			return nil
+		}))
+
+		// Iterating within the expected prefixes
+		testutil.Ok(t, bucket.Iter(context.Background(), expectedPrefix1, func(name string) error {
+			t.Logf("Found tenant-a object: %s", name)
+			foundTenantA = true
+			return nil
+		}))
+
+		testutil.Ok(t, bucket.Iter(context.Background(), expectedPrefix2, func(name string) error {
+			t.Logf("Found tenant-b object: %s", name)
+			foundTenantB = true
+			return nil
+		}))
+
+		// Also show all top-level objects for debugging
+		testutil.Ok(t, bucket.Iter(context.Background(), "", func(name string) error {
+			t.Logf("Found top-level object: %s", name)
+			return nil
+		}))
+
+		testutil.Assert(t, foundTenantA, "uploaded blocks should contain tenant-a prefix path")
+		testutil.Assert(t, foundTenantB, "uploaded blocks should contain tenant-b prefix path")
+
+		// Also verify that objects don't exist at the block level without tenant prefixes
+		// The only objects at root should be the version directory "v1/"
+		rootObjects := 0
+		testutil.Ok(t, bucket.Iter(context.Background(), "", func(name string) error {
+			// Allow "v1/" directory but no direct block directories
+			if name != "v1/" && !strings.HasPrefix(name, "v1/raw/tenant-") {
+				rootObjects++
+				t.Logf("Found unexpected root object: %s", name)
+			}
+			return nil
+		}))
+		testutil.Equals(t, 0, rootObjects)
+	} else {
+		t.Logf("No blocks were uploaded, checking what's in the bucket anyway...")
+		testutil.Ok(t, bucket.Iter(context.Background(), "", func(name string) error {
+			t.Logf("Found object in bucket: %s", name)
+			return nil
+		}))
+	}
+}


### PR DESCRIPTION
## Context

In `multitsdb.go`, a tenant is assigned a shipper which detects directories on the local file system and uploads them to block storage. The current block storage system is flat, where blocks are immediate subdirectories of the environment region bucket, e.g., `s3://us-east-1/01ABCD1234ABCD1234ABCD12/`, regardless of the tenant associated.

We wish to include the tenant in the path for block discovery with filtration by tenant.

## Changes

- If `WithTenantPathPrefix()` is provided as a `MultiTSDBOption`, the tenant creates a shipper with a new prefixed bucket that contains the `v1/raw/<tenantID>` path.
- e.g., `tenant-a` will upload blocks like `s3://us-east-1/v1/raw/tenant-a/01ABCD1234ABCD1234ABCD12/`.


## Verification

- `TestTenantBucketPrefixInUpload` test ensures that uploaded blocks are in directories with tenant prefixes with the following path format: `v1/raw/{tenantID}/{blockID}/{file}`.
- Changes protected under feature flag using new `MultiTSDBOption` called `WithTenantPathPrefix()` with default `false` value. The new test fails when the `MultiTSDBOption`s exclude `WithTenantPathPrefix()`.
