### PR TITLE
[v2] special metric group falls back to hashmod tenant if not in hashring

### DIFF
--- a/pkg/pantheon/tenant_attribution_test.go
+++ b/pkg/pantheon/tenant_attribution_test.go
@@ -85,35 +85,24 @@ func TestGetTenantFromScope(t *testing.T) {
 			wantErr:     true,
 			errContains: "scope 'nonexistent' not found",
 		},
-		{
-			name:        "nil cluster",
-			scope:       "hgcp",
-			metricName:  "some_metric",
-			wantErr:     true,
-			errContains: "pantheon cluster configuration is nil",
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var testCluster *PantheonCluster
-			if tt.name == "nil cluster" {
-				testCluster = nil
-			} else {
-				testCluster = cluster
-			}
-
-			gotTenant, err := GetTenantFromScope(tt.scope, tt.metricName, testCluster)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetTenantFromScope() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if tt.wantErr && tt.errContains != "" && err != nil {
-				if !contains(err.Error(), tt.errContains) {
-					t.Errorf("GetTenantFromScope() error = %v, want error containing %v", err, tt.errContains)
+			metricScope := GetMetricScope(tt.scope, cluster)
+			if tt.wantErr {
+				if metricScope != nil {
+					t.Errorf("GetMetricScope() expected nil but got %v", metricScope)
 				}
 				return
 			}
+
+			if metricScope == nil {
+				t.Errorf("GetMetricScope() unexpected nil")
+				return
+			}
+
+			gotTenant := GetTenantFromScope(tt.metricName, metricScope)
 			if gotTenant != tt.wantTenant {
 				t.Errorf("GetTenantFromScope() = %v, want %v", gotTenant, tt.wantTenant)
 			}
@@ -215,15 +204,67 @@ func TestComputeMetricShard(t *testing.T) {
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && findSubstring(s, substr))
-}
-
-func findSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+func TestGetMetricScope(t *testing.T) {
+	cluster := &PantheonCluster{
+		MetricScopes: []MetricScope{
+			{
+				ScopeName: "hgcp",
+				Shards:    10,
+			},
+			{
+				ScopeName: "meta",
+				Shards:    5,
+			},
+		},
 	}
-	return false
+
+	tests := []struct {
+		name        string
+		scope       string
+		wantErr     bool
+		errContains string
+		wantShards  int
+	}{
+		{
+			name:       "valid scope hgcp",
+			scope:      "hgcp",
+			wantShards: 10,
+		},
+		{
+			name:       "valid scope meta",
+			scope:      "meta",
+			wantShards: 5,
+		},
+		{
+			name:        "scope not found",
+			scope:       "nonexistent",
+			wantErr:     true,
+			errContains: "scope 'nonexistent' not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetMetricScope(tt.scope, cluster)
+			if tt.wantErr {
+				if got != nil {
+					t.Errorf("GetMetricScope() expected nil but got %v", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Errorf("GetMetricScope() returned nil MetricScope")
+				return
+			}
+
+			if got.ScopeName != tt.scope {
+				t.Errorf("GetMetricScope() ScopeName = %v, want %v", got.ScopeName, tt.scope)
+			}
+
+			if got.Shards != tt.wantShards {
+				t.Errorf("GetMetricScope() Shards = %v, want %v", got.Shards, tt.wantShards)
+			}
+		})
+	}
 }

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -90,8 +90,9 @@ var (
 	errNotReady          = errors.New("target not ready")
 	errUnavailable       = errors.New("target not available")
 	errInternal          = errors.New("internal error")
-	errInvalidPantheon   = errors.New("invalid pantheon request")
 	errMissingMetricName = errors.New("metric name (__name__) not found in time series labels")
+	errMissingScope      = errors.New("scope header is required when pantheon cluster is configured")
+	errUnknownScope      = errors.New("scope not found in pantheon configuration")
 )
 
 type WriteableStoreAsyncClient interface {
@@ -689,9 +690,11 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 			responseStatusCode = http.StatusConflict
 		case errBadReplica:
 			responseStatusCode = http.StatusBadRequest
-		case errInvalidPantheon:
-			responseStatusCode = http.StatusBadRequest
 		case errMissingMetricName:
+			responseStatusCode = http.StatusBadRequest
+		case errMissingScope:
+			responseStatusCode = http.StatusBadRequest
+		case errUnknownScope:
 			responseStatusCode = http.StatusBadRequest
 		default:
 			level.Error(tLogger).Log("err", err, "msg", "internal server error")
@@ -963,23 +966,31 @@ func (h *Handler) distributeTimeseriesToReplicas(
 	localWrites := make(map[endpointReplica]map[string]trackedSeries)
 	for tsIndex, ts := range timeseries {
 		var tenant = tenantHTTP
+		var pantheonMetricScope *pantheon.MetricScope
+		var pantheonMetricName string
 
 		// Priority 1: Pantheon-based tenant override (if config is set and scope is provided).
-		if pc := h.pantheonCluster.Load(); pc != nil && scopeHTTP != "" {
+		if pc := h.pantheonCluster.Load(); pc != nil {
+			if scopeHTTP == "" {
+				return nil, nil, errMissingScope
+			}
+
 			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
 			metricName := lbls.Get(labels.MetricName)
 			if metricName == "" {
-				return nil, nil, errors.Wrap(errMissingMetricName, errInvalidPantheon.Error())
+				return nil, nil, errMissingMetricName
 			}
 
-			pantheonTenant, err := pantheon.GetTenantFromScope(scopeHTTP, metricName, pc)
-			if err != nil {
-				level.Error(h.logger).Log("msg", "failed to get tenant from pantheon scope", "scope", scopeHTTP, "metric", metricName, "err", err)
-				return nil, nil, errors.Wrap(errInvalidPantheon, err.Error())
+			metricScope := pantheon.GetMetricScope(scopeHTTP, pc)
+			if metricScope == nil {
+				return nil, nil, errUnknownScope
 			}
 
+			pantheonTenant := pantheon.GetTenantFromScope(metricName, metricScope)
 			level.Debug(h.logger).Log("msg", "tenant overridden by pantheon scope", "original_tenant", tenantHTTP, "scope", scopeHTTP, "metric", metricName, "new_tenant", pantheonTenant)
 			tenant = pantheonTenant
+			pantheonMetricScope = metricScope
+			pantheonMetricName = metricName
 		} else if h.splitTenantLabelName != "" {
 			// Priority 2: Split-tenant-label override (if no pantheon override happened).
 			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
@@ -1000,7 +1011,22 @@ func (h *Handler) distributeTimeseriesToReplicas(
 		for _, rn := range replicas {
 			endpoint, err := h.hashring.GetN(tenant, &ts, rn)
 			if err != nil {
-				return nil, nil, err
+				// If pantheon tenant doesn't match any hashring and we have pantheon context,
+				// fallback to hashmod-based tenant attribution.
+				if pantheonMetricScope != nil && errors.Is(err, ErrNoMatchingHashring) {
+					fallbackTenant := pantheon.GetHashmodTenant(pantheonMetricName, pantheonMetricScope)
+
+					level.Debug(h.logger).Log("msg", "falling back to hashmod tenant", "original_tenant", tenant, "fallback_tenant", fallbackTenant, "scope", pantheonMetricScope.ScopeName, "metric", pantheonMetricName)
+					tenant = fallbackTenant
+
+					// Retry with fallback tenant
+					endpoint, err = h.hashring.GetN(tenant, &ts, rn)
+					if err != nil {
+						return nil, nil, err
+					}
+				} else {
+					return nil, nil, err
+				}
 			}
 			endpointReplica := endpointReplica{endpoint: endpoint, replica: rn}
 			var writeDestination = remoteWrites

--- a/pkg/receive/handler_pantheon_test.go
+++ b/pkg/receive/handler_pantheon_test.go
@@ -102,7 +102,7 @@ func TestDistributeTimeseriesToReplicas_WithPantheon(t *testing.T) {
 				},
 			},
 			wantErr:         true,
-			errContains:     "invalid pantheon request",
+			errContains:     "metric name (__name__) not found",
 			pantheonCluster: pantheonCluster,
 		},
 		{
@@ -116,7 +116,7 @@ func TestDistributeTimeseriesToReplicas_WithPantheon(t *testing.T) {
 				},
 			},
 			wantErr:         true,
-			errContains:     "invalid pantheon request",
+			errContains:     "scope not found in pantheon configuration",
 			pantheonCluster: pantheonCluster,
 		},
 		{
@@ -133,7 +133,7 @@ func TestDistributeTimeseriesToReplicas_WithPantheon(t *testing.T) {
 			pantheonCluster: nil,
 		},
 		{
-			name:  "no scope provided - fallback to tenant header",
+			name:  "no scope provided - should error",
 			scope: "",
 			timeseries: []prompb.TimeSeries{
 				{
@@ -142,7 +142,8 @@ func TestDistributeTimeseriesToReplicas_WithPantheon(t *testing.T) {
 					)),
 				},
 			},
-			wantTenants:     []string{"default-tenant"}, // Falls back to tenantHTTP
+			wantErr:         true,
+			errContains:     "scope header is required",
 			pantheonCluster: pantheonCluster,
 		},
 	}
@@ -199,6 +200,100 @@ func TestDistributeTimeseriesToReplicas_WithPantheon(t *testing.T) {
 				require.True(t, allTenants[wantTenant], "expected tenant %s not found", wantTenant)
 			}
 			require.Equal(t, len(tt.wantTenants), len(allTenants), "unexpected number of tenants")
+		})
+	}
+}
+
+func TestDistributeTimeseriesToReplicas_WithPantheonFallback(t *testing.T) {
+	// Create a pantheon cluster config with a special metric group.
+	pantheonCluster := &pantheon.PantheonCluster{
+		MetricScopes: []pantheon.MetricScope{
+			{
+				ScopeName: "test-scope",
+				Shards:    3,
+				SpecialMetricGroups: []pantheon.SpecialMetricGroup{
+					{
+						GroupName:   "special-group",
+						MetricNames: []string{"special_metric"},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		scope           string
+		timeseries      []prompb.TimeSeries
+		hashringTenants []string // Tenants configured in the hashring
+		expectedTenant  string   // The tenant that should be used after fallback
+		pantheonCluster *pantheon.PantheonCluster
+	}{
+		{
+			name:  "special group tenant missing in hashring - fallback to hashmod",
+			scope: "test-scope",
+			timeseries: []prompb.TimeSeries{
+				{
+					Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings(
+						"__name__", "special_metric",
+						"pod", "test-pod",
+					)),
+				},
+			},
+			// Hashring only has hashmod tenants, not the special group
+			hashringTenants: []string{"test-scope_0-of-3", "test-scope_1-of-3", "test-scope_2-of-3"},
+			expectedTenant:  "test-scope_0-of-3", // Fallback to hashmod for "special_metric"
+			pantheonCluster: pantheonCluster,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.NewNopLogger()
+
+			h := NewHandler(logger, &Options{
+				Endpoint: "localhost:8080",
+			})
+			h.SetPantheonCluster(tt.pantheonCluster)
+
+			// Create a multi-hashring with only the hashmod tenants (not the special group).
+			hashringConfigs := make([]HashringConfig, 0)
+			for _, tenant := range tt.hashringTenants {
+				hashringConfigs = append(hashringConfigs, HashringConfig{
+					Endpoints: []Endpoint{{Address: "localhost:8080"}},
+					Tenants:   []string{tenant},
+				})
+			}
+
+			hashring, err := NewMultiHashring(AlgorithmHashmod, 1, hashringConfigs)
+			require.NoError(t, err)
+			h.Hashring(hashring)
+
+			localWrites, remoteWrites, err := h.distributeTimeseriesToReplicas(
+				"default-tenant",
+				tt.scope,
+				[]uint64{0},
+				tt.timeseries,
+			)
+
+			require.NoError(t, err)
+
+			// Collect all tenants from local and remote writes.
+			allTenants := make(map[string]bool)
+			for _, writes := range localWrites {
+				for tenant := range writes {
+					allTenants[tenant] = true
+				}
+			}
+			for _, writes := range remoteWrites {
+				for tenant := range writes {
+					allTenants[tenant] = true
+				}
+			}
+
+			// Verify the expected fallback tenant is used.
+			require.True(t, allTenants[tt.expectedTenant], "expected tenant %s not found", tt.expectedTenant)
+			require.Equal(t, 1, len(allTenants), "should have exactly one tenant")
 		})
 	}
 }

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -51,6 +51,9 @@ func (i *insufficientNodesError) Error() string {
 	return fmt.Sprintf("insufficient nodes; have %d, want %d", i.have, i.want)
 }
 
+// ErrNoMatchingHashring is returned when no hashring matches the given tenant.
+var ErrNoMatchingHashring = errors.New("no matching hashring to handle tenant")
+
 // Hashring finds the correct node to handle a given time series
 // for a specified tenant.
 // It returns the node and any error encountered.
@@ -326,7 +329,7 @@ func (m *multiHashring) GetN(tenant string, ts *prompb.TimeSeries, n uint64) (En
 			return m.hashrings[i].GetN(tenant, ts, n)
 		}
 	}
-	return Endpoint{}, errors.New("no matching hashring to handle tenant")
+	return Endpoint{}, ErrNoMatchingHashring
 }
 
 func (m *multiHashring) Nodes() []Endpoint {


### PR DESCRIPTION
Receive controller could update the hashring not in-sync with pantheon writer. In this case, a newly added special metric group tenant might not be in hashring yet, so we need to fallback to the hashmod tenant on writer.