### PR TITLE
 Cherry-pick upstream goroutine leak fixes from OSS Thanos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#8378](https://github.com/thanos-io/thanos/pull/8378): Store: fix the reuse of dirty posting slices
+
 ### Added
 
 ### Changed

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/util/zeropool"
 	"github.com/weaveworks/common/httpgrpc"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
@@ -125,7 +126,21 @@ const (
 var (
 	errBlockSyncConcurrencyNotValid = errors.New("the block sync concurrency must be equal or greater than 1.")
 	hashPool                        = sync.Pool{New: func() interface{} { return xxhash.New() }}
+	postingsPool                    zeropool.Pool[[]storage.SeriesRef]
 )
+
+func getPostingsSlice() []storage.SeriesRef {
+	if p := postingsPool.Get(); p != nil {
+		return p
+	}
+
+	// Pre-allocate slice with initial capacity.
+	return make([]storage.SeriesRef, 0, 1024)
+}
+
+func putPostingsSlice(p []storage.SeriesRef) {
+	postingsPool.Put(p[:0])
+}
 
 type bucketStoreMetrics struct {
 	blocksLoaded          prometheus.Gauge
@@ -2542,6 +2557,10 @@ type bucketIndexReader struct {
 
 	indexVersion int
 	logger       log.Logger
+
+	// Posting slice to return to the postings pool on close.
+	// A single bucketIndexReader should have at most 1 postings slice to return.
+	postings []storage.SeriesRef
 }
 
 func newBucketIndexReader(block *bucketBlock, logger log.Logger) *bucketIndexReader {
@@ -2662,13 +2681,13 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms sortedMatch
 
 // ExpandPostingsWithContext returns the postings expanded as a slice and considers context.
 func ExpandPostingsWithContext(ctx context.Context, p index.Postings) ([]storage.SeriesRef, error) {
-	res := make([]storage.SeriesRef, 0, 1024) // Pre-allocate slice with initial capacity
+	res := getPostingsSlice()
 	i := 0
 	for p.Next() {
 		i++
 		if i%checkContextEveryNIterations == 0 {
 			if err := ctx.Err(); err != nil {
-				return nil, err
+				return res, err
 			}
 		}
 		res = append(res, p.At())
@@ -2961,6 +2980,7 @@ func (r *bucketIndexReader) fetchExpandedPostingsFromCache(ctx context.Context, 
 	}
 
 	ps, err := ExpandPostingsWithContext(ctx, p)
+	r.postings = ps
 	if err != nil {
 		level.Error(r.logger).Log("msg", "failed to expand cached expanded postings, refetch postings", "id", r.block.meta.ULID.String(), "err", err)
 		return false, nil, nil
@@ -3397,6 +3417,10 @@ func (r *bucketIndexReader) LoadSeriesForTime(ref storage.SeriesRef, lset *[]sym
 // Close released the underlying resources of the reader.
 func (r *bucketIndexReader) Close() error {
 	r.block.pendingReaders.Done()
+
+	if r.postings != nil {
+		putPostingsSlice(r.postings)
+	}
 	return nil
 }
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1693,6 +1693,9 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 			err = g.Wait()
 		})
 		if err != nil {
+			for _, resp := range respSets {
+				resp.Close()
+			}
 			code := codes.Aborted
 			if s, ok := status.FromError(errors.Cause(err)); ok {
 				code = s.Code()

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -131,7 +131,7 @@ func prepareTestBlocks(t testing.TB, now time.Time, count int, dir string, bkt o
 	return
 }
 
-func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, manyParts bool, chunksLimiterFactory ChunksLimiterFactory, seriesLimiterFactory SeriesLimiterFactory, bytesLimiterFactory BytesLimiterFactory, relabelConfig []*relabel.Config, filterConf *FilterConfig) *storeSuite {
+func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, manyParts bool, chunksLimiterFactory ChunksLimiterFactory, seriesLimiterFactory SeriesLimiterFactory, bytesLimiterFactory BytesLimiterFactory, relabelConfig []*relabel.Config, filterConf *FilterConfig, opts ...BucketStoreOption) *storeSuite {
 	series := []labels.Labels{
 		labels.FromStrings("a", "1", "b", "1"),
 		labels.FromStrings("a", "1", "b", "2"),
@@ -176,10 +176,10 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		true,
 		true,
 		time.Minute,
-		WithLogger(s.logger),
-		WithIndexCache(s.cache),
-		WithFilterConfig(filterConf),
-		WithRegistry(reg),
+		append(opts, WithLogger(s.logger),
+			WithIndexCache(s.cache),
+			WithFilterConfig(filterConf),
+			WithRegistry(reg))...,
 	)
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, store.Close()) }()
@@ -619,6 +619,7 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 		maxChunksLimit uint64
 		maxSeriesLimit uint64
 		maxBytesLimit  int64
+		storeOpts      []BucketStoreOption
 		expectedErr    string
 		code           codes.Code
 	}{
@@ -630,10 +631,23 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 			expectedErr:    "exceeded chunks limit",
 			code:           codes.ResourceExhausted,
 		},
+		"should fail if the max chunks limit is exceeded - ResourceExhausted (sortingStrategyNone)": {
+			maxChunksLimit: expectedChunks - 1,
+			expectedErr:    "exceeded chunks limit",
+			storeOpts:      []BucketStoreOption{WithDontResort(true)},
+			code:           codes.ResourceExhausted,
+		},
 		"should fail if the max series limit is exceeded - ResourceExhausted": {
 			maxChunksLimit: expectedChunks,
 			expectedErr:    "exceeded series limit",
 			maxSeriesLimit: 1,
+			code:           codes.ResourceExhausted,
+		},
+		"should fail if the max series limit is exceeded - ResourceExhausted (sortingStrategyNone)": {
+			maxChunksLimit: expectedChunks,
+			expectedErr:    "exceeded series limit",
+			maxSeriesLimit: 1,
+			storeOpts:      []BucketStoreOption{WithDontResort(true)},
 			code:           codes.ResourceExhausted,
 		},
 		"should fail if the max bytes limit is exceeded - ResourceExhausted": {
@@ -641,6 +655,14 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 			expectedErr:    "exceeded bytes limit",
 			maxSeriesLimit: 2,
 			maxBytesLimit:  1,
+			code:           codes.ResourceExhausted,
+		},
+		"should fail if the max bytes limit is exceeded - ResourceExhausted (sortingStrategyNone)": {
+			maxChunksLimit: expectedChunks,
+			expectedErr:    "exceeded bytes limit",
+			maxSeriesLimit: 2,
+			maxBytesLimit:  1,
+			storeOpts:      []BucketStoreOption{WithDontResort(true)},
 			code:           codes.ResourceExhausted,
 		},
 	}
@@ -653,7 +675,7 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 
 			dir := t.TempDir()
 
-			s := prepareStoreWithTestBlocks(t, dir, bkt, false, NewChunksLimiterFactory(testData.maxChunksLimit), NewSeriesLimiterFactory(testData.maxSeriesLimit), NewBytesLimiterFactory(units.Base2Bytes(testData.maxBytesLimit)), emptyRelabelConfig, allowAllFilterConf)
+			s := prepareStoreWithTestBlocks(t, dir, bkt, false, NewChunksLimiterFactory(testData.maxChunksLimit), NewSeriesLimiterFactory(testData.maxSeriesLimit), NewBytesLimiterFactory(units.Base2Bytes(testData.maxBytesLimit)), emptyRelabelConfig, allowAllFilterConf, testData.storeOpts...)
 			testutil.Ok(t, s.store.SyncBlocks(ctx))
 
 			req := &storepb.SeriesRequest{

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -2971,7 +2971,7 @@ func TestExpandPostingsWithContextCancel(t *testing.T) {
 	res, err := ExpandPostingsWithContext(ctx, p)
 	testutil.NotOk(t, err)
 	testutil.Equals(t, context.Canceled, err)
-	testutil.Equals(t, []storage.SeriesRef(nil), res)
+	testutil.Equals(t, true, cap(res) == 1024)
 }
 
 func samePostingGroup(a, b *postingGroup) bool {

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -809,6 +809,7 @@ func (l *eagerRespSet) Close() {
 	if l.closeSeries != nil {
 		l.closeSeries()
 	}
+	l.wg.Wait()
 	l.shardMatcher.Close()
 	_ = l.cl.CloseSend()
 }

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -2055,10 +2055,6 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 			return
 		}
 	}
-
-	// Wait until the last goroutine exits which is stuck on time.Sleep().
-	// Otherwise, goleak complains.
-	time.Sleep(5 * time.Second)
 }
 
 func TestProxyStore_Series_RequestParamsProxied(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
We recently experienced a bunch of incidents where Pantheon DB pod went rogue. After investigation that might be related to goroutine leak in eagerRespSet since it does not wait for goroutines in Close(). This PR cherry picks a recent [upstream fix](https://github.com/thanos-io/thanos/pull/8035): , and also [another upstream change](https://github.com/thanos-io/thanos/pull/8035) to improve store performance by reducing memory allocations and garbage collections. 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
