### PR TITLE
implement a fast per tenant deletion bucket tool

### DIFF
--- a/pkg/compact/retention.go
+++ b/pkg/compact/retention.go
@@ -6,9 +6,13 @@ package compact
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -18,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -172,5 +177,215 @@ func ApplyRetentionPolicyByTenant(
 		}
 	}
 	level.Info(logger).Log("msg", "tenant retention apply done", "deleted", deleted, "skipped", skipped, "notExpired", notExpired)
+	return nil
+}
+
+// ApplyFastRetentionByTenant applies tenant-based retention policies using streaming deletion.
+// Unlike ApplyRetentionPolicyByTenant, this processes blocks one-by-one without syncing all metadata first.
+// If cacheDir is set and contains block directories, it iterates from cache (enabling resume).
+// Otherwise, it lists blocks from the bucket.
+// Blocks without tenant label are deleted immediately as corrupt.
+func ApplyFastRetentionByTenant(
+	ctx context.Context,
+	logger log.Logger,
+	bkt objstore.Bucket,
+	retentionByTenant map[string]RetentionPolicy,
+	cacheDir string,
+	concurrency int,
+	dryRun bool,
+	blocksDeleted prometheus.Counter,
+) error {
+	if len(retentionByTenant) == 0 {
+		level.Info(logger).Log("msg", "fast retention is disabled due to no policy")
+		return nil
+	}
+
+	startTime := time.Now()
+	var scanned, deleted, corrupt, skipped, errCount int64
+
+	blockChan := make(chan ulid.ULID, concurrency*2)
+	eg, gCtx := errgroup.WithContext(ctx)
+
+	// Check if wildcard policy exists
+	wildcardPolicy, hasWildcard := retentionByTenant[wildCardTenant]
+
+	// Start producer goroutine
+	eg.Go(func() error {
+		defer close(blockChan)
+		return produceBlockIDs(gCtx, logger, bkt, cacheDir, blockChan)
+	})
+
+	// Start consumer goroutines
+	for i := 0; i < concurrency; i++ {
+		eg.Go(func() error {
+			for id := range blockChan {
+				atomic.AddInt64(&scanned, 1)
+
+				// Load meta from cache or bucket
+				meta, err := loadMetaFromCacheOrBucket(gCtx, logger, bkt, id, cacheDir)
+				if err != nil {
+					level.Error(logger).Log("msg", "failed to load meta", "id", id, "err", err)
+					atomic.AddInt64(&errCount, 1)
+					continue
+				}
+
+				tenant := meta.Thanos.GetTenant()
+
+				// Blocks without tenant label are corrupt - delete immediately
+				if tenant == metadata.DefaultTenant {
+					level.Warn(logger).Log("msg", "deleting corrupt block (no tenant label)", "id", id)
+					if !dryRun {
+						if err := deleteBlockAndCache(gCtx, logger, bkt, id, cacheDir); err != nil {
+							level.Error(logger).Log("msg", "failed to delete corrupt block", "id", id, "err", err)
+							atomic.AddInt64(&errCount, 1)
+							continue
+						}
+					}
+					blocksDeleted.Inc()
+					atomic.AddInt64(&corrupt, 1)
+					continue
+				}
+
+				// Look up retention policy (tenant-specific first, then wildcard)
+				policy, ok := retentionByTenant[tenant]
+				if !ok {
+					if hasWildcard {
+						policy = wildcardPolicy
+					} else {
+						atomic.AddInt64(&skipped, 1)
+						continue
+					}
+				}
+
+				// Default behavior: only delete level 1 blocks unless IsAll is true
+				if !policy.IsAll && meta.Compaction.Level != Level1 {
+					atomic.AddInt64(&skipped, 1)
+					continue
+				}
+
+				maxTime := time.Unix(meta.MaxTime/1000, 0)
+				if policy.isExpired(maxTime) {
+					level.Info(logger).Log("msg", "deleting expired block", "id", id, "tenant", tenant, "maxTime", maxTime.String())
+					if !dryRun {
+						if err := deleteBlockAndCache(gCtx, logger, bkt, id, cacheDir); err != nil {
+							level.Error(logger).Log("msg", "failed to delete block", "id", id, "err", err)
+							atomic.AddInt64(&errCount, 1)
+							continue
+						}
+					}
+					blocksDeleted.Inc()
+					atomic.AddInt64(&deleted, 1)
+				} else {
+					atomic.AddInt64(&skipped, 1)
+				}
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return errors.Wrap(err, "fast retention processing")
+	}
+
+	level.Info(logger).Log(
+		"msg", "fast retention completed",
+		"scanned", scanned,
+		"deleted", deleted,
+		"corrupt", corrupt,
+		"skipped", skipped,
+		"errors", errCount,
+		"duration", time.Since(startTime),
+		"dry_run", dryRun,
+	)
+	return nil
+}
+
+// produceBlockIDs sends block IDs to the channel, reading from cache or bucket.
+func produceBlockIDs(ctx context.Context, logger log.Logger, bkt objstore.Bucket, cacheDir string, blockChan chan<- ulid.ULID) error {
+	level.Info(logger).Log("msg", "starting block ID production", cacheDir, cacheDir)
+	// If cache dir is set and has block directories, iterate from cache
+	if cacheDir != "" {
+		entries, err := os.ReadDir(cacheDir)
+		if err == nil && len(entries) > 0 {
+			level.Info(logger).Log("msg", "iterating blocks from local cache", "cache_dir", cacheDir, "entries", len(entries))
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				id, ok := block.IsBlockDir(entry.Name())
+				if !ok {
+					continue
+				}
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case blockChan <- id:
+				}
+			}
+			return nil
+		}
+		if err != nil && !os.IsNotExist(err) {
+			level.Warn(logger).Log("msg", "failed to read cache dir, falling back to bucket", "err", err)
+		}
+	}
+
+	// Fallback: iterate from bucket
+	level.Info(logger).Log("msg", "iterating blocks from bucket")
+	return bkt.Iter(ctx, "", func(name string) error {
+		// Only process top-level directories (block ULIDs)
+		if strings.Count(name, "/") > 1 {
+			return nil
+		}
+		name = strings.TrimSuffix(name, "/")
+		id, ok := block.IsBlockDir(name)
+		if !ok {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case blockChan <- id:
+		}
+		return nil
+	})
+}
+
+// loadMetaFromCacheOrBucket loads meta.json from local cache first, then falls back to bucket.
+func loadMetaFromCacheOrBucket(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID, cacheDir string) (*metadata.Meta, error) {
+	// Try cache first
+	if cacheDir != "" {
+		cachedBlockDir := filepath.Join(cacheDir, id.String())
+		m, err := metadata.ReadFromDir(cachedBlockDir)
+		if err == nil {
+			return m, nil
+		}
+		if !os.IsNotExist(err) {
+			level.Debug(logger).Log("msg", "failed to read meta from cache", "id", id, "err", err)
+		}
+	}
+
+	// Fallback to bucket
+	m, err := block.DownloadMeta(ctx, logger, bkt, id)
+	if err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// deleteBlockAndCache deletes a block from bucket and removes from local cache.
+func deleteBlockAndCache(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID, cacheDir string) error {
+	// Delete from bucket first
+	if err := block.Delete(ctx, logger, bkt, id); err != nil {
+		return err
+	}
+
+	// Delete from local cache (best effort)
+	if cacheDir != "" {
+		cachedBlockDir := filepath.Join(cacheDir, id.String())
+		if err := os.RemoveAll(cachedBlockDir); err != nil && !os.IsNotExist(err) {
+			level.Warn(logger).Log("msg", "failed to remove block from cache", "id", id, "err", err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/compact/retention.go
+++ b/pkg/compact/retention.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -22,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore"
+	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/thanos-io/thanos/pkg/block"
@@ -201,7 +201,7 @@ func ApplyFastRetentionByTenant(
 	}
 
 	startTime := time.Now()
-	var scanned, deleted, corrupt, skipped, errCount int64
+	var scanned, deleted, corrupt, skipped, errCount atomic.Int64
 
 	blockChan := make(chan ulid.ULID, concurrency*2)
 	eg, gCtx := errgroup.WithContext(ctx)
@@ -219,13 +219,13 @@ func ApplyFastRetentionByTenant(
 	for i := 0; i < concurrency; i++ {
 		eg.Go(func() error {
 			for id := range blockChan {
-				atomic.AddInt64(&scanned, 1)
+				scanned.Inc()
 
 				// Load meta from cache or bucket
 				meta, err := loadMetaFromCacheOrBucket(gCtx, logger, bkt, id, cacheDir)
 				if err != nil {
 					level.Error(logger).Log("msg", "failed to load meta", "id", id, "err", err)
-					atomic.AddInt64(&errCount, 1)
+					errCount.Inc()
 					continue
 				}
 
@@ -237,12 +237,12 @@ func ApplyFastRetentionByTenant(
 					if !dryRun {
 						if err := deleteBlockAndCache(gCtx, logger, bkt, id, cacheDir); err != nil {
 							level.Error(logger).Log("msg", "failed to delete corrupt block", "id", id, "err", err)
-							atomic.AddInt64(&errCount, 1)
+							errCount.Inc()
 							continue
 						}
 					}
 					blocksDeleted.Inc()
-					atomic.AddInt64(&corrupt, 1)
+					corrupt.Inc()
 					continue
 				}
 
@@ -252,14 +252,14 @@ func ApplyFastRetentionByTenant(
 					if hasWildcard {
 						policy = wildcardPolicy
 					} else {
-						atomic.AddInt64(&skipped, 1)
+						skipped.Inc()
 						continue
 					}
 				}
 
 				// Default behavior: only delete level 1 blocks unless IsAll is true
 				if !policy.IsAll && meta.Compaction.Level != Level1 {
-					atomic.AddInt64(&skipped, 1)
+					skipped.Inc()
 					continue
 				}
 
@@ -269,14 +269,14 @@ func ApplyFastRetentionByTenant(
 					if !dryRun {
 						if err := deleteBlockAndCache(gCtx, logger, bkt, id, cacheDir); err != nil {
 							level.Error(logger).Log("msg", "failed to delete block", "id", id, "err", err)
-							atomic.AddInt64(&errCount, 1)
+							errCount.Inc()
 							continue
 						}
 					}
 					blocksDeleted.Inc()
-					atomic.AddInt64(&deleted, 1)
+					deleted.Inc()
 				} else {
-					atomic.AddInt64(&skipped, 1)
+					skipped.Inc()
 				}
 			}
 			return nil
@@ -289,11 +289,11 @@ func ApplyFastRetentionByTenant(
 
 	level.Info(logger).Log(
 		"msg", "fast retention completed",
-		"scanned", scanned,
-		"deleted", deleted,
-		"corrupt", corrupt,
-		"skipped", skipped,
-		"errors", errCount,
+		"scanned", scanned.Load(),
+		"deleted", deleted.Load(),
+		"corrupt", corrupt.Load(),
+		"skipped", skipped.Load(),
+		"errors", errCount.Load(),
 		"duration", time.Since(startTime),
 		"dry_run", dryRun,
 	)


### PR DESCRIPTION
 Summary

  Add thanos tools bucket fast-retention command for efficient large-scale block cleanup using streaming deletion.

  Unlike the existing bucket retention command which syncs all block metadata before processing, this command uses a producer-consumer pattern to process blocks one-by-one, making it suitable for buckets with massive backlogs where full metadata sync is prohibitively slow.

  Key Features

  - Streaming deletion: Processes blocks as they're discovered without loading all metadata into memory
  - Per-tenant retention: Uses --retention.tenant flag (format: tenant:30d, tenant:2024-01-01, or *:90d for wildcard)
  - Level control: Default deletes only level 1 blocks; use :all suffix to delete all compaction levels
  - Resume support: With --cache-dir, iterates from local cache (e.g., compactor's meta-syncer) enabling crash recovery
  - Cache cleanup: Deletes blocks from both bucket and local cache
  - Corrupt block handling: Blocks without __tenant__ label are deleted immediately as corrupt
  - Dry-run mode: Preview deletions without actually deleting
  - Azure HNS support: --enable-folder-deletion flag for Azure Blob hierarchical namespace

  Usage

  # Delete blocks older than 30 days for tenant "foo", 90 days for others
  thanos tools bucket fast-retention \
    --objstore.config-file=bucket.yaml \
    --retention.tenant="foo:30d" \
    --retention.tenant="*:90d" \
    --concurrency=64

  # Use compactor's cache for faster processing and resume support
  thanos tools bucket fast-retention \
    --objstore.config-file=bucket.yaml \
    --retention.tenant="*:2024-01-01:all" \
    --cache-dir=/var/thanos/data/meta-syncer

  # Dry run first
  thanos tools bucket fast-retention \
    --objstore.config-file=bucket.yaml \
    --retention.tenant="*:90d" \
    --dry-run

  Test plan

  - Unit tests for ApplyFastRetentionByTenant covering:
    - Empty bucket
    - Wildcard policy
    - Specific tenant policy precedence
    - Corrupt blocks (no tenant label)
    - Level 1 only vs all levels (:all flag)
    - Cutoff date-based retention
  - Unit tests for cache functionality (read from cache, delete from cache)
  - Unit tests for dry-run mode
  - Build compiles successfully
  - Manual testing with real bucket