### PR TITLE
Refactor runCompact into several functions

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -240,7 +240,7 @@ func runCompact(
 
 	// Ensure we close up everything properly.
 	defer func() {
-		if err != nil {
+		if rerr != nil {
 			runutil.CloseWithLogOnErr(logger, insBkt, "bucket client")
 		}
 	}()

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -256,9 +256,7 @@ func runCompact(
 
 	api := blocksAPI.NewBlocksAPI(logger, conf.webConf.disableCORS, conf.label, flagsMap, insBkt)
 
-	if err := runWebServer(g, ctx, logger, cancel, reg, &conf, component, tracer, progressRegistry, globalBaseMetaFetcher, api, srv); err != nil {
-		return errors.Wrap(err, "web server")
-	}
+	runWebServer(g, ctx, logger, cancel, reg, &conf, component, tracer, progressRegistry, globalBaseMetaFetcher, api, srv)
 
 	err = runCompactForTenant(g, ctx, logger, cancel, reg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics)
 	if err != nil {
@@ -602,10 +600,8 @@ func runCompactForTenant(
 		cancel()
 	})
 
-	err = runCleanup(g, ctx, logger, cancel, reg, &conf, progressRegistry, compactMetrics, tsdbPlanner, sy, retentionByResolution, downsampleMetrics, cleanPartialMarked, grouper)
-	if err != nil {
-		return errors.Wrap(err, "cleanup")
-	}
+	runCleanup(g, ctx, logger, cancel, reg, &conf, progressRegistry, compactMetrics, tsdbPlanner, sy, retentionByResolution, downsampleMetrics, cleanPartialMarked, grouper)
+
 	return nil
 }
 
@@ -622,7 +618,7 @@ func runWebServer(
 	baseMetaFetcher *block.BaseFetcher,
 	api *blocksAPI.BlocksAPI,
 	srv *httpserver.Server,
-) error {
+) {
 	if conf.wait {
 		if !conf.disableWeb {
 			r := route.New()
@@ -670,7 +666,6 @@ func runWebServer(
 			})
 		}
 	}
-	return nil
 }
 
 func runCleanup(
@@ -685,10 +680,9 @@ func runCleanup(
 	tsdbPlanner compact.Planner,
 	sy *compact.Syncer,
 	retentionByResolution map[compact.ResolutionLevel]time.Duration,
-	downsampleMetrics *DownsampleMetrics,
 	cleanPartialMarked func(*compact.Progress) error,
 	grouper *compact.DefaultGrouper,
-) error {
+) {
 	if conf.wait {
 		// Periodically remove partial blocks and blocks marked for deletion
 		// since one iteration potentially could take a long time.
@@ -780,7 +774,6 @@ func runCleanup(
 			})
 		}
 	}
-	return nil
 }
 
 func getBlockLister(logger log.Logger, conf *compactConfig, insBkt objstore.InstrumentedBucketReader) (block.Lister, error) {

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -600,7 +600,7 @@ func runCompactForTenant(
 		cancel()
 	})
 
-	runCleanup(g, ctx, logger, cancel, reg, &conf, progressRegistry, compactMetrics, tsdbPlanner, sy, retentionByResolution, downsampleMetrics, cleanPartialMarked, grouper)
+	runCleanup(g, ctx, logger, cancel, reg, &conf, progressRegistry, compactMetrics, tsdbPlanner, sy, retentionByResolution, cleanPartialMarked, grouper)
 
 	return nil
 }

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -240,7 +240,7 @@ func runCompact(
 
 	// Ensure we close up everything properly.
 	defer func() {
-		if rerr != nil {
+		if err != nil {
 			runutil.CloseWithLogOnErr(logger, insBkt, "bucket client")
 		}
 	}()
@@ -258,7 +258,7 @@ func runCompact(
 
 	runWebServer(g, ctx, logger, cancel, reg, &conf, component, tracer, progressRegistry, globalBaseMetaFetcher, api, srv)
 
-	err = runCompactForTenant(g, ctx, logger, cancel, reg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics)
+	err = runCompactForTenant(g, ctx, logger, cancel, reg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, globalBaseMetaFetcher)
 	if err != nil {
 		return err
 	}
@@ -282,6 +282,7 @@ func runCompactForTenant(
 	compactMetrics *compactMetrics,
 	progressRegistry *compact.ProgressRegistry,
 	downsampleMetrics *DownsampleMetrics,
+	baseMetaFetcher *block.BaseFetcher,
 ) error {
 	// While fetching blocks, we filter out blocks that were marked for deletion by using IgnoreDeletionMarkFilter.
 	// The delay of deleteDelay/2 is added to ensure we fetch blocks that are meant to be deleted but do not have a replacement yet.
@@ -293,15 +294,6 @@ func runCompactForTenant(
 	labelShardedMetaFilter := block.NewLabelShardedMetaFilter(relabelConfig)
 	consistencyDelayMetaFilter := block.NewConsistencyDelayMetaFilter(logger, conf.consistencyDelay, extprom.WrapRegistererWithPrefix("thanos_", reg))
 	timePartitionMetaFilter := block.NewTimePartitionMetaFilter(conf.filterConf.MinTime, conf.filterConf.MaxTime)
-
-	blockLister, err := getBlockLister(logger, &conf, insBkt)
-	if err != nil {
-		return errors.Wrap(err, "create block lister")
-	}
-	baseMetaFetcher, err := block.NewBaseFetcher(logger, conf.blockMetaFetchConcurrency, insBkt, blockLister, conf.dataDir, extprom.WrapRegistererWithPrefix("thanos_", reg))
-	if err != nil {
-		return errors.Wrap(err, "create meta fetcher")
-	}
 
 	enableVerticalCompaction, dedupReplicaLabels := checkVerticalCompaction(logger, &conf)
 
@@ -336,6 +328,7 @@ func runCompactForTenant(
 		if !conf.wait {
 			syncMetasTimeout = 0
 		}
+		var err error
 		sy, err = compact.NewMetaSyncer(
 			logger,
 			reg,

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
+	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 
@@ -179,6 +180,16 @@ func runCompact(
 	progressRegistry := compact.NewProgressRegistry(reg, logger)
 	downsampleMetrics := newDownsampleMetrics(reg)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = tracing.ContextWithTracer(ctx, tracer)
+	ctx = objstoretracing.ContextWithTracer(ctx, tracer) // objstore tracing uses a different tracer key in context.
+
+	defer func() {
+		if rerr != nil {
+			cancel()
+		}
+	}()
+
 	httpProbe := prober.NewHTTP()
 	statusProber := prober.Combine(
 		httpProbe,
@@ -234,6 +245,46 @@ func runCompact(
 		}
 	}()
 
+	globalBlockLister, err := getBlockLister(logger, &conf, insBkt)
+	if err != nil {
+		return errors.Wrap(err, "create global block lister")
+	}
+	globalBaseMetaFetcher, err := block.NewBaseFetcher(logger, conf.blockMetaFetchConcurrency, insBkt, globalBlockLister, conf.dataDir, extprom.WrapRegistererWithPrefix("thanos_", reg))
+	if err != nil {
+		return errors.Wrap(err, "create global meta fetcher")
+	}
+
+	api := blocksAPI.NewBlocksAPI(logger, conf.webConf.disableCORS, conf.label, flagsMap, insBkt)
+
+	if err := runWebServer(g, ctx, logger, cancel, reg, &conf, component, tracer, progressRegistry, globalBaseMetaFetcher, api, srv); err != nil {
+		return errors.Wrap(err, "web server")
+	}
+
+	err = runCompactForTenant(g, ctx, logger, cancel, reg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics)
+	if err != nil {
+		return err
+	}
+
+	level.Info(logger).Log("msg", "starting compact node")
+	statusProber.Ready()
+	return nil
+}
+
+func runCompactForTenant(
+	g *run.Group,
+	ctx context.Context,
+	logger log.Logger,
+	cancel context.CancelFunc,
+	reg *prometheus.Registry,
+	insBkt objstore.InstrumentedBucket,
+	deleteDelay time.Duration,
+	conf compactConfig,
+	relabelConfig []*relabel.Config,
+	flagsMap map[string]string,
+	compactMetrics *compactMetrics,
+	progressRegistry *compact.ProgressRegistry,
+	downsampleMetrics *DownsampleMetrics,
+) error {
 	// While fetching blocks, we filter out blocks that were marked for deletion by using IgnoreDeletionMarkFilter.
 	// The delay of deleteDelay/2 is added to ensure we fetch blocks that are meant to be deleted but do not have a replacement yet.
 	// This is to make sure compactor will not accidentally perform compactions with gap instead.
@@ -307,16 +358,6 @@ func runCompact(
 	if err != nil {
 		return err
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	ctx = tracing.ContextWithTracer(ctx, tracer)
-	ctx = objstoretracing.ContextWithTracer(ctx, tracer) // objstore tracing uses a different tracer key in context.
-
-	defer func() {
-		if rerr != nil {
-			cancel()
-		}
-	}()
 
 	mergeFunc, err := getMergeFunc(&conf, dedupReplicaLabels)
 	if err != nil {
@@ -561,6 +602,27 @@ func runCompact(
 		cancel()
 	})
 
+	err = runCleanup(g, ctx, logger, cancel, reg, &conf, progressRegistry, compactMetrics, tsdbPlanner, sy, retentionByResolution, downsampleMetrics, cleanPartialMarked, grouper)
+	if err != nil {
+		return errors.Wrap(err, "cleanup")
+	}
+	return nil
+}
+
+func runWebServer(
+	g *run.Group,
+	ctx context.Context,
+	logger log.Logger,
+	cancel context.CancelFunc,
+	reg *prometheus.Registry,
+	conf *compactConfig,
+	component component.Component,
+	tracer opentracing.Tracer,
+	progressRegistry *compact.ProgressRegistry,
+	baseMetaFetcher *block.BaseFetcher,
+	api *blocksAPI.BlocksAPI,
+	srv *httpserver.Server,
+) error {
 	if conf.wait {
 		if !conf.disableWeb {
 			r := route.New()
@@ -607,7 +669,27 @@ func runCompact(
 				cancel()
 			})
 		}
+	}
+	return nil
+}
 
+func runCleanup(
+	g *run.Group,
+	ctx context.Context,
+	logger log.Logger,
+	cancel context.CancelFunc,
+	reg *prometheus.Registry,
+	conf *compactConfig,
+	progressRegistry *compact.ProgressRegistry,
+	compactMetrics *compactMetrics,
+	tsdbPlanner compact.Planner,
+	sy *compact.Syncer,
+	retentionByResolution map[compact.ResolutionLevel]time.Duration,
+	downsampleMetrics *DownsampleMetrics,
+	cleanPartialMarked func(*compact.Progress) error,
+	grouper *compact.DefaultGrouper,
+) error {
+	if conf.wait {
 		// Periodically remove partial blocks and blocks marked for deletion
 		// since one iteration potentially could take a long time.
 		if conf.cleanupBlocksInterval > 0 {
@@ -698,9 +780,6 @@ func runCompact(
 			})
 		}
 	}
-
-	level.Info(logger).Log("msg", "starting compact node")
-	statusProber.Ready()
 	return nil
 }
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -605,7 +605,7 @@ type CompactionProgressCalculator struct {
 }
 
 // NewCompactProgressCalculator creates a new CompactionProgressCalculator.
-func NewCompactionProgressCalculator(reg prometheus.Registerer, planner *tsdbBasedPlanner) *CompactionProgressCalculator {
+func NewCompactionProgressCalculator(reg prometheus.Registerer, planner Planner) *CompactionProgressCalculator {
 	return &CompactionProgressCalculator{
 		planner: planner,
 		CompactProgressMetrics: &CompactProgressMetrics{


### PR DESCRIPTION
## Changes

- `runCompact` split up into several functions to allow for tenant partitioning later
  - `runCompactForTenant` contains logic that should be performed per-tenant
  - `runWebServer` contains logic for running the UI which should only be performed once
  - `runCleanup` contains cleanup logic which should be performed once per tenant (called in the `runCompactForTenant` function)
- Had to change `NewCompactionProgressCalculator` function signature to accept `Planner` argument instead of `tsdbBasedPlanner` which is not exported 
- Note that multitenant compaction is **not** implemented yet -- this logic matches the current single-tenant flow, just with a refactor that is required before per-tenant compaction is enabled.

## Verification

- Logic is the same
