### PR TITLE
Per-tenant compaction

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -363,9 +363,11 @@ func runCompact(
 		if isMultiTenant {
 			tenantReg = prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantPrefix}, reg)
 			tenantLogger = log.With(logger, "tenant", tenantPrefix)
-			// Use empty string for bucket name to avoid constant label conflicts
-			// The tenant label from WrapRegistererWith will differentiate metrics
-			insBkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), ""))
+			// Only wrap with tracing, not metrics
+			// WrapRegistererWith adds the tenant as a constant label, which causes conflicts
+			// when multiple tenants register the same bucket metrics to the same base registry.
+			// Per-tenant metrics are still available for compaction operations via tenantReg.
+			insBkt = objstoretracing.WrapWithTraces(bkt)
 		} else {
 			tenantReg = reg
 			tenantLogger = logger

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -63,7 +63,7 @@ func (r *idempotentRegisterer) Register(c prometheus.Collector) error {
 	err := r.Registerer.Register(c)
 	if err != nil {
 		// Check if this is a duplicate registration error - if so, ignore it
-		if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		if _, isDupError := err.(prometheus.AlreadyRegisteredError); isDupError {
 			return nil
 		}
 	}

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -514,10 +514,16 @@ func runCompactForTenant(
 		return errors.Wrap(err, "create compactor")
 	}
 
-	var (
-		compactDir      = path.Join(conf.dataDir, "compact")
+	var compactDir, downsamplingDir string
+	if tenant != "" {
+		// In multi-tenant mode, each tenant gets its own working directory to avoid conflicts
+		compactDir = path.Join(conf.dataDir, "compact", tenant)
+		downsamplingDir = path.Join(conf.dataDir, "downsample", tenant)
+	} else {
+		// Single-tenant mode uses the base directories
+		compactDir = path.Join(conf.dataDir, "compact")
 		downsamplingDir = path.Join(conf.dataDir, "downsample")
-	)
+	}
 
 	if err := os.MkdirAll(compactDir, os.ModePerm); err != nil {
 		return errors.Wrap(err, "create working compact directory")

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -394,7 +394,7 @@ func runCompact(
 			insBkt = globalInsBkt
 		}
 
-		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, globalBaseMetaFetcher)
+		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, globalBaseMetaFetcher, tenantPrefix)
 
 		if isMultiTenant {
 			runutil.CloseWithLogOnErr(tenantLogger, insBkt, "bucket client")
@@ -426,6 +426,7 @@ func runCompactForTenant(
 	progressRegistry *compact.ProgressRegistry,
 	downsampleMetrics *DownsampleMetrics,
 	baseMetaFetcher *block.BaseFetcher,
+	tenant string,
 ) error {
 	// While fetching blocks, we filter out blocks that were marked for deletion by using IgnoreDeletionMarkFilter.
 	// The delay of deleteDelay/2 is added to ensure we fetch blocks that are meant to be deleted but do not have a replacement yet.
@@ -736,7 +737,7 @@ func runCompactForTenant(
 		cancel()
 	})
 
-	runCleanup(g, ctx, logger, cancel, reg, &conf, progressRegistry, compactMetrics, tsdbPlanner, sy, retentionByResolution, cleanPartialMarked, grouper)
+	runCleanup(g, ctx, logger, cancel, reg, &conf, progressRegistry, compactMetrics, tsdbPlanner, sy, retentionByResolution, cleanPartialMarked, grouper, tenant)
 
 	return nil
 }
@@ -818,6 +819,7 @@ func runCleanup(
 	retentionByResolution map[compact.ResolutionLevel]time.Duration,
 	cleanPartialMarked func(*compact.Progress) error,
 	grouper *compact.DefaultGrouper,
+	tenant string,
 ) {
 	if conf.wait {
 		// Periodically remove partial blocks and blocks marked for deletion
@@ -845,11 +847,11 @@ func runCleanup(
 		// Periodically calculate the progress of compaction, downsampling and retention.
 		if conf.progressCalculateInterval > 0 {
 			g.Add(func() error {
-				ps := compact.NewCompactionProgressCalculator(reg, tsdbPlanner)
-				rs := compact.NewRetentionProgressCalculator(reg, retentionByResolution)
+				ps := compact.NewCompactionProgressCalculator(reg, tsdbPlanner, tenant)
+				rs := compact.NewRetentionProgressCalculator(reg, retentionByResolution, tenant)
 				var ds *compact.DownsampleProgressCalculator
 				if !conf.disableDownsampling {
-					ds = compact.NewDownsampleProgressCalculator(reg)
+					ds = compact.NewDownsampleProgressCalculator(reg, tenant)
 				}
 
 				return runutil.Repeat(conf.progressCalculateInterval, ctx.Done(), func() error {

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -396,10 +396,6 @@ func runCompact(
 
 		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, globalBaseMetaFetcher, tenantPrefix)
 
-		if isMultiTenant {
-			runutil.CloseWithLogOnErr(tenantLogger, insBkt, "bucket client")
-		}
-
 		if err != nil {
 			return err
 		}

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -53,6 +53,29 @@ import (
 	"github.com/thanos-io/thanos/pkg/ui"
 )
 
+// idempotentRegisterer wraps a prometheus.Registerer and ignores duplicate registration errors.
+// This allows running runCompactForTenant multiple times with the same registry without panicking.
+type idempotentRegisterer struct {
+	prometheus.Registerer
+}
+
+func (r *idempotentRegisterer) Register(c prometheus.Collector) error {
+	err := r.Registerer.Register(c)
+	if err != nil {
+		// Check if this is a duplicate registration error - if so, ignore it
+		if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return nil
+		}
+	}
+	return err
+}
+
+func (r *idempotentRegisterer) MustRegister(cs ...prometheus.Collector) {
+	for _, c := range cs {
+		_ = r.Register(c) // Ignores duplicates
+	}
+}
+
 var (
 	compactions = compactionSet{
 		1 * time.Hour,
@@ -361,12 +384,11 @@ func runCompact(
 		var tenantLogger log.Logger
 
 		if isMultiTenant {
-			tenantReg = prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantPrefix}, reg)
+			// Use idempotent registerer to ignore duplicate metric registrations across tenants.
+			// Components extract tenant from block metadata and use it as a variable label.
+			tenantReg = &idempotentRegisterer{Registerer: reg}
 			tenantLogger = log.With(logger, "tenant", tenantPrefix)
-			// Only wrap with tracing, not metrics
-			// WrapRegistererWith adds the tenant as a constant label, which causes conflicts
-			// when multiple tenants register the same bucket metrics to the same base registry.
-			// Per-tenant metrics are still available for compaction operations via tenantReg.
+			// Only wrap with tracing, not metrics (to avoid duplicate bucket metric registration)
 			insBkt = objstoretracing.WrapWithTraces(bkt)
 		} else {
 			tenantReg = reg

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -360,9 +360,8 @@ func runCompact(
 		var insBkt objstore.InstrumentedBucket
 		if isMultiTenant {
 			tenantReg = prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantPrefix}, reg)
-			// Use tenant-specific bucket name for metrics to avoid conflicts
-			bucketNameForMetrics := fmt.Sprintf("%s/%s", bkt.Name(), tenantPrefix)
-			insBkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), bucketNameForMetrics))
+			// Use only tenant prefix as the distinguishing part for bucket metrics
+			insBkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), tenantPrefix))
 		} else {
 			tenantReg = reg
 			insBkt = globalInsBkt

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -269,8 +269,14 @@ func runCompact(
 			level.Warn(logger).Log("msg", "no tenants assigned to this shard", "ordinal", ordinal)
 		}
 
+		// Deduplicate tenants to avoid duplicate metric registration
+		seenTenants := make(map[string]bool)
 		for _, tenant := range assignedTenants {
-			tenantPrefixes = append(tenantPrefixes, path.Join(conf.commonPathPrefix, tenant))
+			tenantPrefix := path.Join(conf.commonPathPrefix, tenant)
+			if !seenTenants[tenantPrefix] {
+				seenTenants[tenantPrefix] = true
+				tenantPrefixes = append(tenantPrefixes, tenantPrefix)
+			}
 		}
 
 		level.Info(logger).Log("msg", "tenant partitioning setup complete", "tenant_prefixes", strings.Join(tenantPrefixes, ","))

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -316,7 +316,7 @@ func runCompact(
 			return errors.Wrap(err, "failed to get tenant resources")
 		}
 
-		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, baseMetaFetcher, tenantPrefix)
+		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, baseMetaFetcher, tenantPrefix, api)
 
 		if err != nil {
 			return err
@@ -345,6 +345,7 @@ func runCompactForTenant(
 	downsampleMetrics *DownsampleMetrics,
 	baseMetaFetcher *block.BaseFetcher,
 	tenant string,
+	api *blocksAPI.BlocksAPI,
 ) error {
 	// While fetching blocks, we filter out blocks that were marked for deletion by using IgnoreDeletionMarkFilter.
 	// The delay of deleteDelay/2 is added to ensure we fetch blocks that are meant to be deleted but do not have a replacement yet.
@@ -359,10 +360,7 @@ func runCompactForTenant(
 
 	enableVerticalCompaction, dedupReplicaLabels := checkVerticalCompaction(logger, &conf)
 
-	var (
-		api = blocksAPI.NewBlocksAPI(logger, conf.webConf.disableCORS, conf.label, flagsMap, insBkt)
-		sy  *compact.Syncer
-	)
+	var sy *compact.Syncer
 	{
 		filters := []block.MetadataFilter{
 			timePartitionMetaFilter,

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -354,7 +354,9 @@ func runCompact(
 		var insBkt objstore.InstrumentedBucket
 		if isMultiTenant {
 			tenantReg = prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantPrefix}, reg)
-			insBkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), bkt.Name()))
+			// Use tenant-specific bucket name for metrics to avoid conflicts
+			bucketNameForMetrics := fmt.Sprintf("%s/%s", bkt.Name(), tenantPrefix)
+			insBkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), bucketNameForMetrics))
 		} else {
 			tenantReg = reg
 			insBkt = globalInsBkt

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -358,20 +358,18 @@ func runCompact(
 
 		var tenantReg prometheus.Registerer
 		var insBkt objstore.InstrumentedBucket
+		var tenantLogger log.Logger
+
 		if isMultiTenant {
 			tenantReg = prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantPrefix}, reg)
-			// Use only tenant prefix as the distinguishing part for bucket metrics
-			insBkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), tenantPrefix))
+			tenantLogger = log.With(logger, "tenant", tenantPrefix)
+			// Use empty string for bucket name to avoid constant label conflicts
+			// The tenant label from WrapRegistererWith will differentiate metrics
+			insBkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), ""))
 		} else {
 			tenantReg = reg
-			insBkt = globalInsBkt
-		}
-
-		var tenantLogger log.Logger
-		if isMultiTenant {
-			tenantLogger = log.With(logger, "tenant", tenantPrefix)
-		} else {
 			tenantLogger = logger
+			insBkt = globalInsBkt
 		}
 
 		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, globalBaseMetaFetcher)

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/client"
@@ -218,15 +219,66 @@ func runCompact(
 		return err
 	}
 
-	bkt, err := client.NewBucket(logger, confContentYaml, component.String(), nil)
-	if conf.enableFolderDeletion {
-		bkt, err = block.WrapWithAzDataLakeSdk(logger, confContentYaml, bkt)
-		level.Info(logger).Log("msg", "azdatalake sdk wrapper enabled", "name", bkt.Name())
+	var initialBucketConf client.BucketConfig
+	if err := yaml.Unmarshal(confContentYaml, &initialBucketConf); err != nil {
+		return errors.Wrap(err, "failed to parse initial bucket configuration")
 	}
-	if err != nil {
-		return err
+
+	// Set up tenant partitioning if enabled
+	var tenantPrefixes []string
+	var isMultiTenant bool
+
+	if conf.enableTenantPathPrefix {
+		isMultiTenant = true
+
+		hostname := os.Getenv("HOSTNAME")
+		ordinal, err := extractOrdinalFromHostname(hostname)
+		if err != nil {
+			return errors.Wrapf(err, "failed to extract ordinal from hostname %s", hostname)
+		}
+
+		totalShards := conf.replicas / conf.replicationFactor
+		if conf.replicas%conf.replicationFactor != 0 || conf.replicationFactor <= 0 {
+			return errors.Errorf("replicas %d must be divisible by replication factor %d and total shards must be greater than 0", conf.replicas, conf.replicationFactor)
+		}
+
+		if ordinal >= totalShards {
+			return errors.Errorf("ordinal %d is greater than total shards %d", ordinal, totalShards)
+		}
+
+		tenantWeightsPath := conf.tenantWeightsFile.Path()
+		if tenantWeightsPath == "" {
+			return errors.New("tenant weights file is not set")
+		}
+
+		discoveryBkt, err := client.NewBucket(logger, confContentYaml, component.String(), nil)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create discovery bucket")
+		}
+
+		level.Info(logger).Log("msg", "setting up tenant partitioning", "ordinal", ordinal, "total_shards", totalShards)
+
+		tenantAssignments, err := compact.SetupTenantPartitioning(ctx, discoveryBkt, logger, tenantWeightsPath, conf.commonPathPrefix, totalShards)
+		runutil.CloseWithLogOnErr(logger, discoveryBkt, "discovery bucket")
+		if err != nil {
+			return errors.Wrap(err, "failed to setup tenant partitioning")
+		}
+
+		assignedTenants := tenantAssignments[ordinal]
+		if len(assignedTenants) == 0 {
+			level.Warn(logger).Log("msg", "no tenants assigned to this shard", "ordinal", ordinal)
+		}
+
+		for _, tenant := range assignedTenants {
+			tenantPrefixes = append(tenantPrefixes, path.Join(conf.commonPathPrefix, tenant))
+		}
+
+		level.Info(logger).Log("msg", "tenant partitioning setup complete", "tenant_prefixes", strings.Join(tenantPrefixes, ","))
+	} else {
+		isMultiTenant = false
+		tenantPrefixes = []string{""}
+		level.Info(logger).Log("msg", "single tenant mode")
 	}
-	insBkt := objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", reg), bkt.Name()))
 
 	relabelContentYaml, err := conf.selectorRelabelConf.Content()
 	if err != nil {
@@ -238,32 +290,81 @@ func runCompact(
 		return err
 	}
 
+	globalBkt, err := client.NewBucket(logger, confContentYaml, component.String(), nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create global bucket")
+	}
+	globalInsBkt := objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(globalBkt, extprom.WrapRegistererWithPrefix("thanos_", reg), globalBkt.Name()))
+
 	// Ensure we close up everything properly.
 	defer func() {
-		if err != nil {
-			runutil.CloseWithLogOnErr(logger, insBkt, "bucket client")
+		if rerr != nil {
+			runutil.CloseWithLogOnErr(logger, globalInsBkt, "global bucket client")
 		}
 	}()
 
-	globalBlockLister, err := getBlockLister(logger, &conf, insBkt)
+	globalBlockLister, err := getBlockLister(logger, &conf, globalInsBkt)
 	if err != nil {
 		return errors.Wrap(err, "create global block lister")
 	}
-	globalBaseMetaFetcher, err := block.NewBaseFetcher(logger, conf.blockMetaFetchConcurrency, insBkt, globalBlockLister, conf.dataDir, extprom.WrapRegistererWithPrefix("thanos_", reg))
+	globalBaseMetaFetcher, err := block.NewBaseFetcher(logger, conf.blockMetaFetchConcurrency, globalInsBkt, globalBlockLister, conf.dataDir, extprom.WrapRegistererWithPrefix("thanos_", reg))
 	if err != nil {
 		return errors.Wrap(err, "create global meta fetcher")
 	}
 
-	api := blocksAPI.NewBlocksAPI(logger, conf.webConf.disableCORS, conf.label, flagsMap, insBkt)
+	api := blocksAPI.NewBlocksAPI(logger, conf.webConf.disableCORS, conf.label, flagsMap, globalInsBkt)
 
 	runWebServer(g, ctx, logger, cancel, reg, &conf, component, tracer, progressRegistry, globalBaseMetaFetcher, api, srv)
 
-	err = runCompactForTenant(g, ctx, logger, cancel, reg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, globalBaseMetaFetcher)
-	if err != nil {
-		return err
+	for _, tenantPrefix := range tenantPrefixes {
+		bucketConf := &client.BucketConfig{
+			Type:   initialBucketConf.Type,
+			Config: initialBucketConf.Config,
+			Prefix: path.Join(initialBucketConf.Prefix, tenantPrefix),
+		}
+		level.Info(logger).Log("msg", "starting compaction loop for prefix", "prefix", bucketConf.Prefix)
+
+		tenantConfYaml, err := yaml.Marshal(bucketConf)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal tenant bucket configuration")
+		}
+
+		bkt, err := client.NewBucket(logger, tenantConfYaml, component.String(), nil)
+		if conf.enableFolderDeletion {
+			bkt, err = block.WrapWithAzDataLakeSdk(logger, tenantConfYaml, bkt)
+			level.Info(logger).Log("msg", "azdatalake sdk wrapper enabled", "prefix", bucketConf.Prefix, "name", bkt.Name())
+		}
+		if err != nil {
+			return errors.Wrap(err, "failed to create tenant bucket")
+		}
+
+		var tenantReg prometheus.Registerer
+		if isMultiTenant {
+			tenantReg = prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantPrefix}, reg)
+		} else {
+			tenantReg = reg
+		}
+		insBkt := objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), bkt.Name()))
+
+		var tenantLogger log.Logger
+		if isMultiTenant {
+			tenantLogger = log.With(logger, "tenant", tenantPrefix)
+		} else {
+			tenantLogger = logger
+		}
+
+		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, globalBaseMetaFetcher)
+
+		// Always close bucket client after compaction attempt
+		runutil.CloseWithLogOnErr(tenantLogger, insBkt, "bucket client")
+
+		if err != nil {
+			return err
+		}
+
+		level.Info(tenantLogger).Log("msg", "compact node for tenant finished")
 	}
 
-	level.Info(logger).Log("msg", "starting compact node")
 	statusProber.Ready()
 	return nil
 }
@@ -273,7 +374,7 @@ func runCompactForTenant(
 	ctx context.Context,
 	logger log.Logger,
 	cancel context.CancelFunc,
-	reg *prometheus.Registry,
+	reg prometheus.Registerer,
 	insBkt objstore.InstrumentedBucket,
 	deleteDelay time.Duration,
 	conf compactConfig,
@@ -666,7 +767,7 @@ func runCleanup(
 	ctx context.Context,
 	logger log.Logger,
 	cancel context.CancelFunc,
-	reg *prometheus.Registry,
+	reg prometheus.Registerer,
 	conf *compactConfig,
 	progressRegistry *compact.ProgressRegistry,
 	compactMetrics *compactMetrics,
@@ -864,6 +965,11 @@ func getRetentionPolicies(logger log.Logger, conf *compactConfig) (map[compact.R
 	return retentionByResolution, retentionByTenant, nil
 }
 
+func extractOrdinalFromHostname(hostname string) (int, error) {
+	parts := strings.Split(hostname, "-")
+	return strconv.Atoi(parts[len(parts)-1])
+}
+
 type compactConfig struct {
 	haltOnError                                    bool
 	acceptMalformedIndex                           bool
@@ -902,6 +1008,11 @@ type compactConfig struct {
 	progressCalculateInterval                      time.Duration
 	filterConf                                     *store.FilterConfig
 	disableAdminOperations                         bool
+	tenantWeightsFile                              extflag.PathOrContent
+	replicas                                       int
+	replicationFactor                              int
+	commonPathPrefix                               string
+	enableTenantPathPrefix                         bool
 }
 
 func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
@@ -1017,6 +1128,20 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("web.disable", "Disable Block Viewer UI.").Default("false").BoolVar(&cc.disableWeb)
 
 	cc.selectorRelabelConf = *extkingpin.RegisterSelectorRelabelFlags(cmd)
+
+	cc.tenantWeightsFile = *extflag.RegisterPathOrContent(cmd, "compact.tenant-weights-file", "YAML file that contains the tenant weights for tenant partitioning.", extflag.WithEnvSubstitution())
+
+	cmd.Flag("compact.replicas", "Total replicas of the stateful set.").
+		Default("1").IntVar(&cc.replicas)
+
+	cmd.Flag("compact.replication-factor", "Replication factor of the stateful set.").
+		Default("1").IntVar(&cc.replicationFactor)
+
+	cmd.Flag("compact.common-path-prefix", "Common path prefix for tenant discovery when using tenant partitioning. This is the prefix before the tenant name in the object storage path.").
+		Default("v1/raw/").StringVar(&cc.commonPathPrefix)
+
+	cmd.Flag("compact.enable-tenant-path-prefix", "Enable tenant path prefix mode for backward compatibility. When disabled, compactor runs in single-tenant mode.").
+		Default("false").BoolVar(&cc.enableTenantPathPrefix)
 
 	cc.webConf.registerFlag(cmd)
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -245,66 +245,9 @@ func runCompact(
 		return errors.Wrap(err, "failed to parse initial bucket configuration")
 	}
 
-	// Set up tenant partitioning if enabled
-	var tenantPrefixes []string
-	var isMultiTenant bool
-
-	if conf.enableTenantPathPrefix {
-		isMultiTenant = true
-
-		hostname := os.Getenv("HOSTNAME")
-		ordinal, err := extractOrdinalFromHostname(hostname)
-		if err != nil {
-			return errors.Wrapf(err, "failed to extract ordinal from hostname %s", hostname)
-		}
-
-		totalShards := conf.replicas / conf.replicationFactor
-		if conf.replicas%conf.replicationFactor != 0 || conf.replicationFactor <= 0 {
-			return errors.Errorf("replicas %d must be divisible by replication factor %d and total shards must be greater than 0", conf.replicas, conf.replicationFactor)
-		}
-
-		if ordinal >= totalShards {
-			return errors.Errorf("ordinal %d is greater than total shards %d", ordinal, totalShards)
-		}
-
-		tenantWeightsPath := conf.tenantWeights.Path()
-		if tenantWeightsPath == "" {
-			return errors.New("tenant weights file is not set")
-		}
-
-		discoveryBkt, err := client.NewBucket(logger, confContentYaml, component.String(), nil)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create discovery bucket")
-		}
-
-		level.Info(logger).Log("msg", "setting up tenant partitioning", "ordinal", ordinal, "total_shards", totalShards)
-
-		tenantAssignments, err := compact.SetupTenantPartitioning(ctx, discoveryBkt, logger, tenantWeightsPath, conf.commonPathPrefix, totalShards)
-		runutil.CloseWithLogOnErr(logger, discoveryBkt, "discovery bucket")
-		if err != nil {
-			return errors.Wrap(err, "failed to setup tenant partitioning")
-		}
-
-		assignedTenants := tenantAssignments[ordinal]
-		if len(assignedTenants) == 0 {
-			level.Warn(logger).Log("msg", "no tenants assigned to this shard", "ordinal", ordinal)
-		}
-
-		// Deduplicate tenants to avoid duplicate metric registration
-		seenTenants := make(map[string]bool)
-		for _, tenant := range assignedTenants {
-			tenantPrefix := path.Join(conf.commonPathPrefix, tenant)
-			if !seenTenants[tenantPrefix] {
-				seenTenants[tenantPrefix] = true
-				tenantPrefixes = append(tenantPrefixes, tenantPrefix)
-			}
-		}
-
-		level.Info(logger).Log("msg", "tenant partitioning setup complete", "tenant_prefixes", strings.Join(tenantPrefixes, ","))
-	} else {
-		isMultiTenant = false
-		tenantPrefixes = []string{""}
-		level.Info(logger).Log("msg", "single tenant mode")
+	tenantPrefixes, isMultiTenant, err := getTenantsForCompactor(ctx, logger, conf, confContentYaml, component)
+	if err != nil {
+		return errors.Wrap(err, "failed to get tenants for compactor")
 	}
 
 	relabelContentYaml, err := conf.selectorRelabelConf.Content()
@@ -363,47 +306,14 @@ func runCompact(
 			return errors.Wrap(err, "failed to marshal tenant bucket configuration")
 		}
 
-		var bkt objstore.Bucket
-		if isMultiTenant {
-			bkt, err = client.NewBucket(logger, tenantConfYaml, component.String(), nil)
-			if conf.enableFolderDeletion {
-				bkt, err = block.WrapWithAzDataLakeSdk(logger, tenantConfYaml, bkt)
-				level.Info(logger).Log("msg", "azdatalake sdk wrapper enabled", "prefix", bucketConf.Prefix, "name", bkt.Name())
-			}
-			if err != nil {
-				return errors.Wrap(err, "failed to create tenant bucket")
-			}
-		} else {
-			bkt = globalBkt
+		bkt, err := getBucketForTenant(logger, isMultiTenant, tenantConfYaml, component, conf, bucketConf, globalBkt)
+		if err != nil {
+			return errors.Wrap(err, "failed to get bucket for tenant")
 		}
 
-		var tenantReg prometheus.Registerer
-		var insBkt objstore.InstrumentedBucket
-		var tenantLogger log.Logger
-		var baseMetaFetcher *block.BaseFetcher
-
-		if isMultiTenant {
-			// Use idempotent registerer to ignore duplicate metric registrations across tenants.
-			// Components extract tenant from block metadata and use it as a variable label.
-			tenantReg = &idempotentRegisterer{Registerer: reg}
-			tenantLogger = log.With(logger, "tenant", tenantPrefix)
-			// Only wrap with tracing, not metrics (to avoid duplicate bucket metric registration)
-			insBkt = objstoretracing.WrapWithTraces(bkt)
-
-			// Create tenant-scoped block lister and fetcher so each tenant only sees their own blocks
-			tenantBlockLister, err := getBlockLister(tenantLogger, &conf, insBkt)
-			if err != nil {
-				return errors.Wrap(err, "create tenant block lister")
-			}
-			baseMetaFetcher, err = block.NewBaseFetcher(tenantLogger, conf.blockMetaFetchConcurrency, insBkt, tenantBlockLister, conf.dataDir, extprom.WrapRegistererWithPrefix("thanos_", tenantReg))
-			if err != nil {
-				return errors.Wrap(err, "create tenant meta fetcher")
-			}
-		} else {
-			tenantReg = reg
-			tenantLogger = logger
-			insBkt = globalInsBkt
-			baseMetaFetcher = globalBaseMetaFetcher
+		tenantReg, insBkt, tenantLogger, baseMetaFetcher, err := getTenantResources(logger, isMultiTenant, tenantConfYaml, component, conf, bucketConf, reg, tenantPrefix, bkt, globalBkt, globalInsBkt, globalBaseMetaFetcher)
+		if err != nil {
+			return errors.Wrap(err, "failed to get tenant resources")
 		}
 
 		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, baseMetaFetcher, tenantPrefix)
@@ -926,6 +836,127 @@ func runCleanup(
 			})
 		}
 	}
+}
+
+func getTenantsForCompactor(ctx context.Context, logger log.Logger, conf compactConfig, confContentYaml []byte, component component.Component) ([]string, bool, error) {
+	var tenantPrefixes []string
+	var isMultiTenant bool
+
+	if conf.enableTenantPathPrefix {
+		isMultiTenant = true
+
+		hostname := os.Getenv("HOSTNAME")
+		ordinal, err := extractOrdinalFromHostname(hostname)
+		if err != nil {
+			return nil, true, errors.Wrapf(err, "failed to extract ordinal from hostname %s", hostname)
+		}
+
+		totalShards := conf.replicas / conf.replicationFactor
+		if conf.replicas%conf.replicationFactor != 0 || conf.replicationFactor <= 0 {
+			return nil, true, errors.Errorf("replicas %d must be divisible by replication factor %d and total shards must be greater than 0", conf.replicas, conf.replicationFactor)
+		}
+
+		if ordinal >= totalShards {
+			return nil, true, errors.Errorf("ordinal %d is greater than total shards %d", ordinal, totalShards)
+		}
+
+		tenantWeightsPath := conf.tenantWeights.Path()
+		if tenantWeightsPath == "" {
+			return nil, true, errors.New("tenant weights file is not set")
+		}
+
+		discoveryBkt, err := client.NewBucket(logger, confContentYaml, component.String(), nil)
+		if err != nil {
+			return nil, true, errors.Wrapf(err, "failed to create discovery bucket")
+		}
+
+		level.Info(logger).Log("msg", "setting up tenant partitioning", "ordinal", ordinal, "total_shards", totalShards)
+
+		tenantAssignments, err := compact.SetupTenantPartitioning(ctx, discoveryBkt, logger, tenantWeightsPath, conf.commonPathPrefix, totalShards)
+		runutil.CloseWithLogOnErr(logger, discoveryBkt, "discovery bucket")
+		if err != nil {
+			return nil, true, errors.Wrap(err, "failed to setup tenant partitioning")
+		}
+
+		assignedTenants := tenantAssignments[ordinal]
+		if len(assignedTenants) == 0 {
+			level.Warn(logger).Log("msg", "no tenants assigned to this shard", "ordinal", ordinal)
+		}
+
+		// Deduplicate tenants to avoid duplicate metric registration
+		seenTenants := make(map[string]bool)
+		for _, tenant := range assignedTenants {
+			tenantPrefix := path.Join(conf.commonPathPrefix, tenant)
+			if !seenTenants[tenantPrefix] {
+				seenTenants[tenantPrefix] = true
+				tenantPrefixes = append(tenantPrefixes, tenantPrefix)
+			}
+		}
+
+		level.Info(logger).Log("msg", "tenant partitioning setup complete", "tenant_prefixes", strings.Join(tenantPrefixes, ","))
+	} else {
+		isMultiTenant = false
+		tenantPrefixes = []string{""}
+		level.Info(logger).Log("msg", "single tenant mode")
+	}
+	return tenantPrefixes, isMultiTenant, nil
+}
+
+func getBucketForTenant(logger log.Logger, isMultiTenant bool, tenantConfYaml []byte, component component.Component, conf compactConfig, bucketConf *client.BucketConfig, globalBkt objstore.Bucket) (objstore.Bucket, error) {
+	if isMultiTenant {
+		bkt, err := client.NewBucket(logger, tenantConfYaml, component.String(), nil)
+		if conf.enableFolderDeletion {
+			bkt, err = block.WrapWithAzDataLakeSdk(logger, tenantConfYaml, bkt)
+			level.Info(logger).Log("msg", "azdatalake sdk wrapper enabled", "prefix", bucketConf.Prefix, "name", bkt.Name())
+		}
+		return bkt, err
+	}
+	return globalBkt, nil
+}
+
+func getTenantResources(
+	logger log.Logger,
+	isMultiTenant bool,
+	tenantConfYaml []byte,
+	component component.Component,
+	conf compactConfig,
+	bucketConf *client.BucketConfig,
+	reg prometheus.Registerer,
+	tenantPrefix string,
+	bkt objstore.Bucket,
+	globalBkt objstore.Bucket,
+	globalInsBkt objstore.InstrumentedBucket,
+	globalBaseMetaFetcher *block.BaseFetcher,
+) (prometheus.Registerer, objstore.InstrumentedBucket, log.Logger, *block.BaseFetcher, error) {
+	var tenantReg prometheus.Registerer
+	var insBkt objstore.InstrumentedBucket
+	var tenantLogger log.Logger
+	var baseMetaFetcher *block.BaseFetcher
+
+	if isMultiTenant {
+		// Use idempotent registerer to ignore duplicate metric registrations across tenants.
+		// Components extract tenant from block metadata and use it as a variable label.
+		tenantReg = &idempotentRegisterer{Registerer: reg}
+		tenantLogger = log.With(logger, "tenant", tenantPrefix)
+		// Only wrap with tracing, not metrics (to avoid duplicate bucket metric registration)
+		insBkt = objstoretracing.WrapWithTraces(bkt)
+
+		// Create tenant-scoped block lister and fetcher so each tenant only sees their own blocks
+		tenantBlockLister, err := getBlockLister(tenantLogger, &conf, insBkt)
+		if err != nil {
+			return nil, nil, nil, nil, errors.Wrap(err, "create tenant block lister")
+		}
+		baseMetaFetcher, err = block.NewBaseFetcher(tenantLogger, conf.blockMetaFetchConcurrency, insBkt, tenantBlockLister, conf.dataDir, extprom.WrapRegistererWithPrefix("thanos_", tenantReg))
+		if err != nil {
+			return nil, nil, nil, nil, errors.Wrap(err, "create tenant meta fetcher")
+		}
+	} else {
+		tenantReg = reg
+		tenantLogger = logger
+		insBkt = globalInsBkt
+		baseMetaFetcher = globalBaseMetaFetcher
+	}
+	return tenantReg, insBkt, tenantLogger, baseMetaFetcher, nil
 }
 
 func getBlockLister(logger log.Logger, conf *compactConfig, insBkt objstore.InstrumentedBucketReader) (block.Lister, error) {

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -61,11 +61,9 @@ type idempotentRegisterer struct {
 
 func (r *idempotentRegisterer) Register(c prometheus.Collector) error {
 	err := r.Registerer.Register(c)
-	if err != nil {
-		// Check if this is a duplicate registration error - if so, ignore it
-		if _, isDupError := err.(prometheus.AlreadyRegisteredError); isDupError {
-			return nil
-		}
+	// Ignore duplicate registration errors - expected in multi-tenant mode
+	if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		return nil
 	}
 	return err
 }

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -246,7 +246,7 @@ func runCompact(
 			return errors.Errorf("ordinal %d is greater than total shards %d", ordinal, totalShards)
 		}
 
-		tenantWeightsPath := conf.tenantWeightsFile.Path()
+		tenantWeightsPath := conf.tenantWeights.Path()
 		if tenantWeightsPath == "" {
 			return errors.New("tenant weights file is not set")
 		}
@@ -1023,7 +1023,7 @@ type compactConfig struct {
 	progressCalculateInterval                      time.Duration
 	filterConf                                     *store.FilterConfig
 	disableAdminOperations                         bool
-	tenantWeightsFile                              extflag.PathOrContent
+	tenantWeights                                  extflag.PathOrContent
 	replicas                                       int
 	replicationFactor                              int
 	commonPathPrefix                               string
@@ -1144,7 +1144,7 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cc.selectorRelabelConf = *extkingpin.RegisterSelectorRelabelFlags(cmd)
 
-	cc.tenantWeightsFile = *extflag.RegisterPathOrContent(cmd, "compact.tenant-weights-file", "YAML file that contains the tenant weights for tenant partitioning.", extflag.WithEnvSubstitution())
+	cc.tenantWeights = *extflag.RegisterPathOrContent(cmd, "compact.tenant-weights", "YAML file that contains the tenant weights for tenant partitioning.", extflag.WithEnvSubstitution())
 
 	cmd.Flag("compact.replicas", "Total replicas of the stateful set.").
 		Default("1").IntVar(&cc.replicas)

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -316,7 +316,7 @@ func runCompact(
 			return errors.Wrap(err, "failed to get tenant resources")
 		}
 
-		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, baseMetaFetcher, tenantPrefix, api)
+		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, compactMetrics, progressRegistry, downsampleMetrics, baseMetaFetcher, tenantPrefix, api)
 
 		if err != nil {
 			return err
@@ -339,7 +339,6 @@ func runCompactForTenant(
 	deleteDelay time.Duration,
 	conf compactConfig,
 	relabelConfig []*relabel.Config,
-	flagsMap map[string]string,
 	compactMetrics *compactMetrics,
 	progressRegistry *compact.ProgressRegistry,
 	downsampleMetrics *DownsampleMetrics,

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -311,7 +311,7 @@ func runCompact(
 			return errors.Wrap(err, "failed to get bucket for tenant")
 		}
 
-		tenantReg, insBkt, tenantLogger, baseMetaFetcher, err := getTenantResources(logger, isMultiTenant, tenantConfYaml, component, conf, bucketConf, reg, tenantPrefix, bkt, globalBkt, globalInsBkt, globalBaseMetaFetcher)
+		tenantReg, insBkt, tenantLogger, baseMetaFetcher, err := getTenantResources(logger, isMultiTenant, conf, reg, tenantPrefix, bkt, globalInsBkt, globalBaseMetaFetcher)
 		if err != nil {
 			return errors.Wrap(err, "failed to get tenant resources")
 		}
@@ -917,14 +917,10 @@ func getBucketForTenant(logger log.Logger, isMultiTenant bool, tenantConfYaml []
 func getTenantResources(
 	logger log.Logger,
 	isMultiTenant bool,
-	tenantConfYaml []byte,
-	component component.Component,
 	conf compactConfig,
-	bucketConf *client.BucketConfig,
 	reg prometheus.Registerer,
 	tenantPrefix string,
 	bkt objstore.Bucket,
-	globalBkt objstore.Bucket,
 	globalInsBkt objstore.InstrumentedBucket,
 	globalBaseMetaFetcher *block.BaseFetcher,
 ) (prometheus.Registerer, objstore.InstrumentedBucket, log.Logger, *block.BaseFetcher, error) {

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -294,6 +294,13 @@ func runCompact(
 	if err != nil {
 		return errors.Wrap(err, "failed to create global bucket")
 	}
+	if conf.enableFolderDeletion {
+		globalBkt, err = block.WrapWithAzDataLakeSdk(logger, confContentYaml, globalBkt)
+		if err != nil {
+			return errors.Wrap(err, "failed to wrap global bucket with Azure SDK")
+		}
+		level.Info(logger).Log("msg", "azdatalake sdk wrapper enabled for global bucket", "name", globalBkt.Name())
+	}
 	globalInsBkt := objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(globalBkt, extprom.WrapRegistererWithPrefix("thanos_", reg), globalBkt.Name()))
 
 	// Ensure we close up everything properly.
@@ -329,22 +336,29 @@ func runCompact(
 			return errors.Wrap(err, "failed to marshal tenant bucket configuration")
 		}
 
-		bkt, err := client.NewBucket(logger, tenantConfYaml, component.String(), nil)
-		if conf.enableFolderDeletion {
-			bkt, err = block.WrapWithAzDataLakeSdk(logger, tenantConfYaml, bkt)
-			level.Info(logger).Log("msg", "azdatalake sdk wrapper enabled", "prefix", bucketConf.Prefix, "name", bkt.Name())
-		}
-		if err != nil {
-			return errors.Wrap(err, "failed to create tenant bucket")
+		var bkt objstore.Bucket
+		if isMultiTenant {
+			bkt, err = client.NewBucket(logger, tenantConfYaml, component.String(), nil)
+			if conf.enableFolderDeletion {
+				bkt, err = block.WrapWithAzDataLakeSdk(logger, tenantConfYaml, bkt)
+				level.Info(logger).Log("msg", "azdatalake sdk wrapper enabled", "prefix", bucketConf.Prefix, "name", bkt.Name())
+			}
+			if err != nil {
+				return errors.Wrap(err, "failed to create tenant bucket")
+			}
+		} else {
+			bkt = globalBkt
 		}
 
 		var tenantReg prometheus.Registerer
+		var insBkt objstore.InstrumentedBucket
 		if isMultiTenant {
 			tenantReg = prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantPrefix}, reg)
+			insBkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), bkt.Name()))
 		} else {
 			tenantReg = reg
+			insBkt = globalInsBkt
 		}
-		insBkt := objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", tenantReg), bkt.Name()))
 
 		var tenantLogger log.Logger
 		if isMultiTenant {
@@ -355,8 +369,9 @@ func runCompact(
 
 		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, globalBaseMetaFetcher)
 
-		// Always close bucket client after compaction attempt
-		runutil.CloseWithLogOnErr(tenantLogger, insBkt, "bucket client")
+		if isMultiTenant {
+			runutil.CloseWithLogOnErr(tenantLogger, insBkt, "bucket client")
+		}
 
 		if err != nil {
 			return err

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -380,6 +380,7 @@ func runCompact(
 		var tenantReg prometheus.Registerer
 		var insBkt objstore.InstrumentedBucket
 		var tenantLogger log.Logger
+		var baseMetaFetcher *block.BaseFetcher
 
 		if isMultiTenant {
 			// Use idempotent registerer to ignore duplicate metric registrations across tenants.
@@ -388,13 +389,24 @@ func runCompact(
 			tenantLogger = log.With(logger, "tenant", tenantPrefix)
 			// Only wrap with tracing, not metrics (to avoid duplicate bucket metric registration)
 			insBkt = objstoretracing.WrapWithTraces(bkt)
+
+			// Create tenant-scoped block lister and fetcher so each tenant only sees their own blocks
+			tenantBlockLister, err := getBlockLister(tenantLogger, &conf, insBkt)
+			if err != nil {
+				return errors.Wrap(err, "create tenant block lister")
+			}
+			baseMetaFetcher, err = block.NewBaseFetcher(tenantLogger, conf.blockMetaFetchConcurrency, insBkt, tenantBlockLister, conf.dataDir, extprom.WrapRegistererWithPrefix("thanos_", tenantReg))
+			if err != nil {
+				return errors.Wrap(err, "create tenant meta fetcher")
+			}
 		} else {
 			tenantReg = reg
 			tenantLogger = logger
 			insBkt = globalInsBkt
+			baseMetaFetcher = globalBaseMetaFetcher
 		}
 
-		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, globalBaseMetaFetcher, tenantPrefix)
+		err = runCompactForTenant(g, ctx, tenantLogger, cancel, tenantReg, insBkt, deleteDelay, conf, relabelConfig, flagsMap, compactMetrics, progressRegistry, downsampleMetrics, baseMetaFetcher, tenantPrefix)
 
 		if err != nil {
 			return err

--- a/cmd/thanos/compact_test.go
+++ b/cmd/thanos/compact_test.go
@@ -1,0 +1,417 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"path"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+func TestExtractOrdinalFromHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     int
+		wantErr  bool
+	}{
+		{
+			name:     "valid statefulset hostname",
+			hostname: "thanos-compact-0",
+			want:     0,
+			wantErr:  false,
+		},
+		{
+			name:     "valid statefulset hostname with higher ordinal",
+			hostname: "thanos-compact-5",
+			want:     5,
+			wantErr:  false,
+		},
+		{
+			name:     "valid statefulset hostname with multiple dashes",
+			hostname: "my-thanos-compact-service-3",
+			want:     3,
+			wantErr:  false,
+		},
+		{
+			name:     "hostname with no dash",
+			hostname: "hostname0",
+			want:     0,
+			wantErr:  true,
+		},
+		{
+			name:     "hostname ending with non-numeric",
+			hostname: "thanos-compact-abc",
+			want:     0,
+			wantErr:  true,
+		},
+		{
+			name:     "empty hostname",
+			hostname: "",
+			want:     0,
+			wantErr:  true,
+		},
+		{
+			name:     "hostname with only dash",
+			hostname: "-",
+			want:     0,
+			wantErr:  true,
+		},
+		{
+			name:     "hostname ending with dash",
+			hostname: "thanos-compact-",
+			want:     0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractOrdinalFromHostname(tt.hostname)
+			if tt.wantErr {
+				testutil.NotOk(t, err)
+			} else {
+				testutil.Ok(t, err)
+				testutil.Equals(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestTenantPrefixPathJoin(t *testing.T) {
+	tests := []struct {
+		name           string
+		basePrefix     string
+		commonPrefix   string
+		tenant         string
+		expectedPrefix string
+	}{
+		{
+			name:           "single tenant mode with empty prefix",
+			basePrefix:     "",
+			commonPrefix:   "",
+			tenant:         "",
+			expectedPrefix: "",
+		},
+		{
+			name:           "single tenant mode with base prefix",
+			basePrefix:     "v1/raw",
+			commonPrefix:   "",
+			tenant:         "",
+			expectedPrefix: "v1/raw",
+		},
+		{
+			name:           "multi-tenant with all components",
+			basePrefix:     "prod",
+			commonPrefix:   "v1/raw",
+			tenant:         "tenant1",
+			expectedPrefix: "prod/v1/raw/tenant1",
+		},
+		{
+			name:           "multi-tenant with no base prefix",
+			basePrefix:     "",
+			commonPrefix:   "v1/raw",
+			tenant:         "tenant2",
+			expectedPrefix: "v1/raw/tenant2",
+		},
+		{
+			name:           "multi-tenant with complex tenant name",
+			basePrefix:     "base",
+			commonPrefix:   "v1/raw",
+			tenant:         "team-a/project-1",
+			expectedPrefix: "base/v1/raw/team-a/project-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate what happens in the code
+			tenantPrefix := path.Join(tt.commonPrefix, tt.tenant)
+			finalPrefix := path.Join(tt.basePrefix, tenantPrefix)
+			testutil.Equals(t, tt.expectedPrefix, finalPrefix)
+		})
+	}
+}
+
+func TestShardCalculation(t *testing.T) {
+	tests := []struct {
+		name              string
+		replicas          int
+		replicationFactor int
+		expectedShards    int
+		expectError       bool
+	}{
+		{
+			name:              "single replica, single factor",
+			replicas:          1,
+			replicationFactor: 1,
+			expectedShards:    1,
+			expectError:       false,
+		},
+		{
+			name:              "six replicas, three factor",
+			replicas:          6,
+			replicationFactor: 3,
+			expectedShards:    2,
+			expectError:       false,
+		},
+		{
+			name:              "nine replicas, three factor",
+			replicas:          9,
+			replicationFactor: 3,
+			expectedShards:    3,
+			expectError:       false,
+		},
+		{
+			name:              "not divisible",
+			replicas:          5,
+			replicationFactor: 2,
+			expectedShards:    0,
+			expectError:       true,
+		},
+		{
+			name:              "zero replication factor",
+			replicas:          3,
+			replicationFactor: 0,
+			expectedShards:    0,
+			expectError:       true,
+		},
+		{
+			name:              "negative replication factor",
+			replicas:          3,
+			replicationFactor: -1,
+			expectedShards:    0,
+			expectError:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the shard calculation logic from runCompact
+			// Check replication factor first to avoid division by zero or modulo by zero
+			if tt.replicationFactor <= 0 {
+				if !tt.expectError {
+					t.Errorf("expected no error but replication factor is invalid")
+				}
+				return
+			}
+
+			shouldError := tt.replicas%tt.replicationFactor != 0
+
+			if shouldError {
+				if !tt.expectError {
+					t.Errorf("expected no error but validation should fail")
+				}
+				return
+			}
+
+			if tt.expectError {
+				t.Errorf("expected error but validation passed")
+				return
+			}
+
+			totalShards := tt.replicas / tt.replicationFactor
+			testutil.Equals(t, tt.expectedShards, totalShards)
+		})
+	}
+}
+
+func TestOrdinalValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		ordinal     int
+		totalShards int
+		expectError bool
+	}{
+		{
+			name:        "ordinal 0 with 3 shards",
+			ordinal:     0,
+			totalShards: 3,
+			expectError: false,
+		},
+		{
+			name:        "ordinal 2 with 3 shards",
+			ordinal:     2,
+			totalShards: 3,
+			expectError: false,
+		},
+		{
+			name:        "ordinal equals total shards",
+			ordinal:     3,
+			totalShards: 3,
+			expectError: true,
+		},
+		{
+			name:        "ordinal greater than total shards",
+			ordinal:     5,
+			totalShards: 3,
+			expectError: true,
+		},
+		{
+			name:        "single shard",
+			ordinal:     0,
+			totalShards: 1,
+			expectError: false,
+		},
+		{
+			name:        "ordinal 1 with single shard",
+			ordinal:     1,
+			totalShards: 1,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the ordinal validation logic from runCompact
+			if tt.ordinal >= tt.totalShards {
+				if !tt.expectError {
+					t.Errorf("expected no error but ordinal %d >= totalShards %d", tt.ordinal, tt.totalShards)
+				}
+			} else {
+				if tt.expectError {
+					t.Errorf("expected error but ordinal %d < totalShards %d", tt.ordinal, tt.totalShards)
+				}
+			}
+		})
+	}
+}
+
+func TestTenantPrefixGeneration(t *testing.T) {
+	tests := []struct {
+		name          string
+		commonPrefix  string
+		tenants       []string
+		expectedPaths []string
+	}{
+		{
+			name:         "single tenant",
+			commonPrefix: "v1/raw",
+			tenants:      []string{"tenant1"},
+			expectedPaths: []string{
+				"v1/raw/tenant1",
+			},
+		},
+		{
+			name:         "multiple tenants",
+			commonPrefix: "v1/raw",
+			tenants:      []string{"tenant1", "tenant2", "tenant3"},
+			expectedPaths: []string{
+				"v1/raw/tenant1",
+				"v1/raw/tenant2",
+				"v1/raw/tenant3",
+			},
+		},
+		{
+			name:         "no common prefix",
+			commonPrefix: "",
+			tenants:      []string{"tenant1", "tenant2"},
+			expectedPaths: []string{
+				"tenant1",
+				"tenant2",
+			},
+		},
+		{
+			name:          "no tenants",
+			commonPrefix:  "v1/raw",
+			tenants:       []string{},
+			expectedPaths: []string{},
+		},
+		{
+			name:         "complex paths",
+			commonPrefix: "v1/raw",
+			tenants:      []string{"org/team-a", "org/team-b"},
+			expectedPaths: []string{
+				"v1/raw/org/team-a",
+				"v1/raw/org/team-b",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate tenant prefix generation from runCompact
+			var tenantPrefixes []string
+			for _, tenant := range tt.tenants {
+				tenantPrefixes = append(tenantPrefixes, path.Join(tt.commonPrefix, tenant))
+			}
+
+			testutil.Equals(t, len(tt.expectedPaths), len(tenantPrefixes))
+			for i, expected := range tt.expectedPaths {
+				testutil.Equals(t, expected, tenantPrefixes[i])
+			}
+		})
+	}
+}
+
+func TestSingleTenantModeBehavior(t *testing.T) {
+	// Test that single tenant mode behaves like the original code
+	tests := []struct {
+		name                   string
+		enableTenantPathPrefix bool
+		expectedTenantPrefixes []string
+		expectedIsMultiTenant  bool
+	}{
+		{
+			name:                   "single tenant mode (default)",
+			enableTenantPathPrefix: false,
+			expectedTenantPrefixes: []string{""},
+			expectedIsMultiTenant:  false,
+		},
+		{
+			name:                   "multi-tenant mode enabled",
+			enableTenantPathPrefix: true,
+			// Note: actual prefixes would come from SetupTenantPartitioning
+			// This test just validates the flag behavior
+			expectedTenantPrefixes: nil, // Would be populated by SetupTenantPartitioning
+			expectedIsMultiTenant:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tenantPrefixes []string
+			var isMultiTenant bool
+
+			if tt.enableTenantPathPrefix {
+				isMultiTenant = true
+				// In real code, this would call SetupTenantPartitioning
+				// For this test, we just verify the flag sets isMultiTenant correctly
+			} else {
+				isMultiTenant = false
+				tenantPrefixes = []string{""}
+			}
+
+			testutil.Equals(t, tt.expectedIsMultiTenant, isMultiTenant)
+
+			if !tt.enableTenantPathPrefix {
+				testutil.Equals(t, 1, len(tenantPrefixes))
+				testutil.Equals(t, "", tenantPrefixes[0])
+			}
+		})
+	}
+}
+
+func TestPathJoinPreservesPrefix(t *testing.T) {
+	// Critical test: verify that path.Join with empty string preserves the original prefix
+	// This ensures backward compatibility when enableTenantPathPrefix = false
+	tests := []struct {
+		prefix   string
+		expected string
+	}{
+		{"", ""},
+		{"v1/raw", "v1/raw"},
+		{"prod/v1/raw", "prod/v1/raw"},
+		{"/absolute/path", "/absolute/path"},
+		{"path/with/trailing/slash/", "path/with/trailing/slash"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.prefix, func(t *testing.T) {
+			result := path.Join(tt.prefix, "")
+			testutil.Equals(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -245,7 +245,7 @@ func TestRetentionProgressCalculate(t *testing.T) {
 		keys[ind] = meta.Thanos.GroupKey()
 	}
 
-	ps := NewRetentionProgressCalculator(reg, nil)
+	ps := NewRetentionProgressCalculator(reg, nil, "test-tenant")
 
 	for _, tcase := range []struct {
 		testName string
@@ -367,7 +367,7 @@ func TestCompactProgressCalculate(t *testing.T) {
 		keys[ind] = meta.Thanos.GroupKey()
 	}
 
-	ps := NewCompactionProgressCalculator(reg, planner)
+	ps := NewCompactionProgressCalculator(reg, planner, "test-tenant")
 
 	var bkt objstore.Bucket
 	temp := promauto.With(reg).NewCounter(prometheus.CounterOpts{Name: "test_metric_for_group", Help: "this is a test metric for compact progress tests"})
@@ -466,7 +466,7 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 		keys[ind] = meta.Thanos.GroupKey()
 	}
 
-	ds := NewDownsampleProgressCalculator(reg)
+	ds := NewDownsampleProgressCalculator(reg, "test-tenant")
 
 	var bkt objstore.Bucket
 	temp := promauto.With(reg).NewCounter(prometheus.CounterOpts{Name: "test_metric_for_group", Help: "this is a test metric for downsample progress tests"})

--- a/pkg/compact/overlapping.go
+++ b/pkg/compact/overlapping.go
@@ -38,7 +38,7 @@ type OverlappingCompactionLifecycleCallback struct {
 	noDownsampling    prometheus.Counter
 }
 
-func NewOverlappingCompactionLifecycleCallback(reg *prometheus.Registry, logger log.Logger, enabled bool) CompactionLifecycleCallback {
+func NewOverlappingCompactionLifecycleCallback(reg prometheus.Registerer, logger log.Logger, enabled bool) CompactionLifecycleCallback {
 	if enabled {
 		level.Info(logger).Log("msg", "enabled overlapping blocks compaction lifecycle callback")
 		return OverlappingCompactionLifecycleCallback{


### PR DESCRIPTION
## Changes
- Hooked up tenant discovery and run `runCompactForTenant` once per tenant when tenant path prefix is enabled

## Verification
- Unit tests
- Integration test for backward compatibility:
  - <img width="1445" height="491" alt="Screenshot 2026-01-05 at 12 47 19 PM" src="https://github.com/user-attachments/assets/113fa247-ac48-4367-bc0c-a2d5d6641b93" /> 
- Integration test for multitenant capability:
