### PR TITLE
Promoting blocking bad regex in metric names into Production

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -605,6 +605,7 @@ func runQuery(
 	if len(blockedMetricPatterns) > 0 {
 		options = append(options, store.WithBlockedMetricPatterns(blockedMetricPatterns))
 	}
+
 	if forwardPartialStrategy {
 		options = append(options, store.WithoutForwardPartialStrategy())
 	}

--- a/pkg/query/testdata/promql/prometheus/selectors.test
+++ b/pkg/query/testdata/promql/prometheus/selectors.test
@@ -140,22 +140,22 @@ load 5m
 eval instant at 50m x{y="testvalue"}
 	x{y="testvalue"} 100
 
-# Basic Regex
-eval instant at 50m {__name__=~".+"}
-	http_requests{group="canary", instance="0", job="api-server"} 300
-	http_requests{group="canary", instance="0", job="app-server"} 700
-	http_requests{group="canary", instance="1", job="api-server"} 400
-	http_requests{group="canary", instance="1", job="app-server"} 800
-	http_requests{group="production", instance="0", job="api-server"} 100
-	http_requests{group="production", instance="0", job="app-server"} 500
-	http_requests{group="production", instance="1", job="api-server"} 200
-	http_requests{group="production", instance="1", job="app-server"} 600
-	x{y="testvalue"} 100
-	label_grouping_test{a="a", b="abb"} 200
-	label_grouping_test{a="aa", b="bb"} 100
-	cpu_count{instance="1", type="smp"} 200
-	cpu_count{instance="0", type="smp"} 100
-	cpu_count{instance="0", type="numa"} 300
+# Basic Regex - Commented out: metric names containing '.' are blocked unconditionally
+# eval instant at 50m {__name__=~".+"}
+# 	http_requests{group="canary", instance="0", job="api-server"} 300
+# 	http_requests{group="canary", instance="0", job="app-server"} 700
+# 	http_requests{group="canary", instance="1", job="api-server"} 400
+# 	http_requests{group="canary", instance="1", job="app-server"} 800
+# 	http_requests{group="production", instance="0", job="api-server"} 100
+# 	http_requests{group="production", instance="0", job="app-server"} 500
+# 	http_requests{group="production", instance="1", job="api-server"} 200
+# 	http_requests{group="production", instance="1", job="app-server"} 600
+# 	x{y="testvalue"} 100
+# 	label_grouping_test{a="a", b="abb"} 200
+# 	label_grouping_test{a="aa", b="bb"} 100
+# 	cpu_count{instance="1", type="smp"} 200
+# 	cpu_count{instance="0", type="smp"} 100
+# 	cpu_count{instance="0", type="numa"} 300
 
 eval instant at 50m {job=~".+-server", job!~"api-.+"}
 	http_requests{group="canary", instance="0", job="app-server"} 700

--- a/pkg/query/testdata/promql/prometheus/selectors.test
+++ b/pkg/query/testdata/promql/prometheus/selectors.test
@@ -140,22 +140,22 @@ load 5m
 eval instant at 50m x{y="testvalue"}
 	x{y="testvalue"} 100
 
-# Basic Regex - Commented out: metric names containing '.' are blocked unconditionally
-# eval instant at 50m {__name__=~".+"}
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="production", instance="1", job="app-server"} 600
-# 	x{y="testvalue"} 100
-# 	label_grouping_test{a="a", b="abb"} 200
-# 	label_grouping_test{a="aa", b="bb"} 100
-# 	cpu_count{instance="1", type="smp"} 200
-# 	cpu_count{instance="0", type="smp"} 100
-# 	cpu_count{instance="0", type="numa"} 300
+# Basic Regex
+eval instant at 50m {__name__=~".+"}
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="1", job="app-server"} 600
+	x{y="testvalue"} 100
+	label_grouping_test{a="a", b="abb"} 200
+	label_grouping_test{a="aa", b="bb"} 100
+	cpu_count{instance="1", type="smp"} 200
+	cpu_count{instance="0", type="smp"} 100
+	cpu_count{instance="0", type="numa"} 300
 
 eval instant at 50m {job=~".+-server", job!~"api-.+"}
 	http_requests{group="canary", instance="0", job="app-server"} 700

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -1121,10 +1121,11 @@ func (s *ProxyStore) shouldBlockQuery(matchers []*labels.Matcher) (bool, string,
 
 	// If metric name contains '.', it's a regex pattern - ALWAYS block unconditionally
 	// This happens regardless of whether any blocking patterns are configured
-	if strings.Contains(metricName, ".") {
-		level.Debug(s.logger).Log("msg", "shouldBlockQuery: BLOCKED unconditionally (contains '.')", "metric_name", metricName)
-		return true, metricName, metricName, true
-	}
+	// TODO: @pranav.mishra: Add another flag to slowly roll out this feature.
+	// if strings.Contains(metricName, ".") {
+	// 	level.Debug(s.logger).Log("msg", "shouldBlockQuery: BLOCKED unconditionally (contains '.')", "metric_name", metricName)
+	// 	return true, metricName, metricName, true
+	// }
 
 	// If blocking is not configured at all, allow everything else
 	if s.blockedMetricPrefixes == nil && s.unconditionalBlockedMetrics == nil {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1280,29 +1280,30 @@ func TestProxyStore_Series(t *testing.T) {
 			blockedPatterns: []string{"pup"}, // prefix pattern - broader than exact match
 			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: high cardinality metric 'up' matches blocked pattern 'up', please add proper filters to reduce the amount of data to fetch"),
 		},
-		{
-			title: "blocked query: overly broad regex pattern .+",
-			storeAPIs: []Client{
-				&storetestutil.TestClient{
-					StoreClient: &mockedStoreAPI{
-						RespSeries: []*storepb.SeriesResponse{
-							storeSeriesResponse(t, labels.FromStrings("__name__", "some_metric"), []sample{{0, 0}, {2, 1}}),
-						},
-					},
-					MinTime: 1,
-					MaxTime: 300,
-				},
-			},
-			req: &storepb.SeriesRequest{
-				MinTime: 1,
-				MaxTime: 300,
-				Matchers: []storepb.LabelMatcher{
-					{Name: "__name__", Value: ".+", Type: storepb.LabelMatcher_RE},
-				},
-			},
-			blockedPatterns: []string{}, // No patterns needed - metric name contains '.' so it's blocked automatically
-			expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: metric name pattern '.+' is not allowed"),
-		},
+		//TODO: @pranav.mishra: Add test for overly broad regex pattern w/ "."
+		// {
+		// 	title: "blocked query: overly broad regex pattern .+",
+		// 	storeAPIs: []Client{
+		// 		&storetestutil.TestClient{
+		// 			StoreClient: &mockedStoreAPI{
+		// 				RespSeries: []*storepb.SeriesResponse{
+		// 					storeSeriesResponse(t, labels.FromStrings("__name__", "some_metric"), []sample{{0, 0}, {2, 1}}),
+		// 				},
+		// 			},
+		// 			MinTime: 1,
+		// 			MaxTime: 300,
+		// 		},
+		// 	},
+		// 	req: &storepb.SeriesRequest{
+		// 		MinTime: 1,
+		// 		MaxTime: 300,
+		// 		Matchers: []storepb.LabelMatcher{
+		// 			{Name: "__name__", Value: ".+", Type: storepb.LabelMatcher_RE},
+		// 		},
+		// 	},
+		// 	blockedPatterns: []string{}, // No patterns needed - metric name contains '.' so it's blocked automatically
+		// 	expectedErr:     errors.New("rpc error: code = InvalidArgument desc = query blocked: metric name pattern '.+' is not allowed"),
+		// },
 		{
 			title: "not blocked query: exact match __name__ is NOT blocked by broad regex check",
 			storeAPIs: []Client{


### PR DESCRIPTION
Cherry picking https://github.com/databricks/thanos/pull/250 and https://github.com/databricks/thanos/pull/256 into release branch in order to promote functionality for blocking bad regex in metric names into prod. 