### PR TITLE
Add label-based tenant attribution

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -317,7 +317,6 @@ func runReceive(
 		Tracer:                  tracer,
 		TLSConfig:               rwTLSConfig,
 		SplitTenantLabelName:    conf.splitTenantLabelName,
-		TenantSourceLabelName:   conf.tenantSourceLabelName,
 		DialOpts:                dialOpts,
 		ForwardTimeout:          time.Duration(*conf.forwardTimeout),
 		MaxBackoff:              time.Duration(*conf.maxBackoff),
@@ -1000,11 +999,10 @@ type receiveConfig struct {
 	tsdbHeadChunksWriteBufferSize int
 	tsdbStripeSize                int
 
-	walCompression        bool
-	noLockFile            bool
-	writerInterning       bool
-	splitTenantLabelName  string
-	tenantSourceLabelName string
+	walCompression       bool
+	noLockFile           bool
+	writerInterning      bool
+	splitTenantLabelName string
 
 	hashFunc string
 
@@ -1090,8 +1088,6 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.default-tenant-id", "Default tenant ID to use when none is provided via a header.").Default(tenancy.DefaultTenant).StringVar(&rc.defaultTenantID)
 
 	cmd.Flag("receive.split-tenant-label-name", "Label name through which the request will be split into multiple tenants. This takes precedence over the HTTP header.").Default("").StringVar(&rc.splitTenantLabelName)
-
-	cmd.Flag("receive.tenant-source-label", "Label name to use as tenant source. When set, the value of this label determines the tenant for each series, overriding the HTTP tenant header. If a series does not have this label, the default tenant ID is used. The label is preserved in the series (not removed).").Default("").StringVar(&rc.tenantSourceLabelName)
 
 	cmd.Flag("receive.tenant-label-name", "Label name through which the tenant will be announced.").Default(tenancy.DefaultTenantLabel).StringVar(&rc.tenantLabelName)
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -317,6 +317,7 @@ func runReceive(
 		Tracer:                  tracer,
 		TLSConfig:               rwTLSConfig,
 		SplitTenantLabelName:    conf.splitTenantLabelName,
+		TenantSourceLabelName:   conf.tenantSourceLabelName,
 		DialOpts:                dialOpts,
 		ForwardTimeout:          time.Duration(*conf.forwardTimeout),
 		MaxBackoff:              time.Duration(*conf.maxBackoff),
@@ -999,10 +1000,11 @@ type receiveConfig struct {
 	tsdbHeadChunksWriteBufferSize int
 	tsdbStripeSize                int
 
-	walCompression       bool
-	noLockFile           bool
-	writerInterning      bool
-	splitTenantLabelName string
+	walCompression        bool
+	noLockFile            bool
+	writerInterning       bool
+	splitTenantLabelName  string
+	tenantSourceLabelName string
 
 	hashFunc string
 
@@ -1088,6 +1090,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.default-tenant-id", "Default tenant ID to use when none is provided via a header.").Default(tenancy.DefaultTenant).StringVar(&rc.defaultTenantID)
 
 	cmd.Flag("receive.split-tenant-label-name", "Label name through which the request will be split into multiple tenants. This takes precedence over the HTTP header.").Default("").StringVar(&rc.splitTenantLabelName)
+
+	cmd.Flag("receive.tenant-source-label", "Label name to use as tenant source. When set, the value of this label determines the tenant for each series, overriding the HTTP tenant header. If a series does not have this label, the default tenant ID is used. The label is preserved in the series (not removed).").Default("").StringVar(&rc.tenantSourceLabelName)
 
 	cmd.Flag("receive.tenant-label-name", "Label name through which the tenant will be announced.").Default(tenancy.DefaultTenantLabel).StringVar(&rc.tenantLabelName)
 

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -107,6 +107,7 @@ type Options struct {
 	Endpoint                string
 	ReplicationFactor       uint64
 	SplitTenantLabelName    string
+	TenantSourceLabelName   string
 	ReceiverMode            ReceiverMode
 	Tracer                  opentracing.Tracer
 	TLSConfig               *tls.Config
@@ -122,12 +123,13 @@ type Options struct {
 
 // Handler serves a Prometheus remote write receiving HTTP endpoint.
 type Handler struct {
-	logger               log.Logger
-	writer               *Writer
-	router               *route.Router
-	options              *Options
-	splitTenantLabelName string
-	httpSrv              *http.Server
+	logger                log.Logger
+	writer                *Writer
+	router                *route.Router
+	options               *Options
+	splitTenantLabelName  string
+	tenantSourceLabelName string
+	httpSrv               *http.Server
 
 	mtx          sync.RWMutex
 	hashring     Hashring
@@ -164,11 +166,12 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 	level.Info(logger).Log("msg", "Starting receive handler with async forward workers", "workers", workers)
 
 	h := &Handler{
-		logger:               logger,
-		writer:               o.Writer,
-		router:               route.New(),
-		options:              o,
-		splitTenantLabelName: o.SplitTenantLabelName,
+		logger:                logger,
+		writer:                o.Writer,
+		router:                route.New(),
+		options:               o,
+		splitTenantLabelName:  o.SplitTenantLabelName,
+		tenantSourceLabelName: o.TenantSourceLabelName,
 		peers: newPeerGroup(
 			logger,
 			backoff.Backoff{
@@ -925,7 +928,17 @@ func (h *Handler) distributeTimeseriesToReplicas(
 	for tsIndex, ts := range timeseries {
 		var tenant = tenantHTTP
 
-		if h.splitTenantLabelName != "" {
+		if h.tenantSourceLabelName != "" {
+			// tenant-source-label: extract tenant from label, fall back to default tenant
+			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
+			if tenantFromLabel := lbls.Get(h.tenantSourceLabelName); tenantFromLabel != "" {
+				tenant = h.tenantSourceLabelName + ":" + tenantFromLabel
+			} else {
+				// Label missing: use default tenant, NOT HTTP header
+				tenant = h.options.DefaultTenantID
+			}
+			// NOTE: label is NOT removed from ts.Labels
+		} else if h.splitTenantLabelName != "" {
 			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
 
 			tenantLabel := lbls.Get(h.splitTenantLabelName)

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -31,7 +31,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/route"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
@@ -107,7 +106,6 @@ type Options struct {
 	Endpoint                string
 	ReplicationFactor       uint64
 	SplitTenantLabelName    string
-	TenantSourceLabelName   string
 	ReceiverMode            ReceiverMode
 	Tracer                  opentracing.Tracer
 	TLSConfig               *tls.Config
@@ -123,13 +121,12 @@ type Options struct {
 
 // Handler serves a Prometheus remote write receiving HTTP endpoint.
 type Handler struct {
-	logger                log.Logger
-	writer                *Writer
-	router                *route.Router
-	options               *Options
-	splitTenantLabelName  string
-	tenantSourceLabelName string
-	httpSrv               *http.Server
+	logger               log.Logger
+	writer               *Writer
+	router               *route.Router
+	options              *Options
+	splitTenantLabelName string
+	httpSrv              *http.Server
 
 	mtx          sync.RWMutex
 	hashring     Hashring
@@ -166,12 +163,11 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 	level.Info(logger).Log("msg", "Starting receive handler with async forward workers", "workers", workers)
 
 	h := &Handler{
-		logger:                logger,
-		writer:                o.Writer,
-		router:                route.New(),
-		options:               o,
-		splitTenantLabelName:  o.SplitTenantLabelName,
-		tenantSourceLabelName: o.TenantSourceLabelName,
+		logger:               logger,
+		writer:               o.Writer,
+		router:               route.New(),
+		options:              o,
+		splitTenantLabelName: o.SplitTenantLabelName,
 		peers: newPeerGroup(
 			logger,
 			backoff.Backoff{
@@ -928,29 +924,14 @@ func (h *Handler) distributeTimeseriesToReplicas(
 	for tsIndex, ts := range timeseries {
 		var tenant = tenantHTTP
 
-		if h.tenantSourceLabelName != "" {
-			// tenant-source-label: extract tenant from label, fall back to default tenant
-			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
-			if tenantFromLabel := lbls.Get(h.tenantSourceLabelName); tenantFromLabel != "" {
-				tenant = h.tenantSourceLabelName + ":" + tenantFromLabel
-			} else {
-				// Label missing: use default tenant, NOT HTTP header
-				tenant = h.options.DefaultTenantID
-			}
-			// NOTE: label is NOT removed from ts.Labels
-		} else if h.splitTenantLabelName != "" {
+		if h.splitTenantLabelName != "" {
 			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
 
 			tenantLabel := lbls.Get(h.splitTenantLabelName)
 			if tenantLabel != "" {
-				tenant = tenantLabel
-
-				newLabels := labels.NewBuilder(lbls)
-				newLabels.Del(h.splitTenantLabelName)
-
-				ts.Labels = labelpb.ZLabelsFromPromLabels(
-					newLabels.Labels(),
-				)
+				tenant = h.splitTenantLabelName + ":" + tenantLabel
+			} else {
+				tenant = h.options.DefaultTenantID
 			}
 		}
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1883,6 +1883,60 @@ func TestDistributeSeries(t *testing.T) {
 	require.Equal(t, map[string]struct{}{"bar": {}, "boo": {}}, hr.seenTenants)
 }
 
+func TestDistributeSeriesWithTenantSourceLabel(t *testing.T) {
+	t.Parallel()
+
+	const tenantSourceLabelName = "cluster"
+	const defaultTenantID = "default-tenant"
+	h := NewHandler(nil, &Options{
+		TenantSourceLabelName: tenantSourceLabelName,
+		DefaultTenantID:       defaultTenantID,
+	})
+
+	endpoint := Endpoint{Address: "http://localhost:9090", CapNProtoAddress: "http://localhost:19391"}
+	hashring, err := newSimpleHashring([]Endpoint{endpoint})
+	require.NoError(t, err)
+	hr := &hashringSeenTenants{Hashring: hashring}
+	h.Hashring(hr)
+
+	_, remote, err := h.distributeTimeseriesToReplicas(
+		"http-tenant",
+		[]uint64{0},
+		[]prompb.TimeSeries{
+			{
+				// Has cluster label -> tenant should be "cluster:prod"
+				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("__name__", "metric1", "cluster", "prod")),
+			},
+			{
+				// Has cluster label -> tenant should be "cluster:staging"
+				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("__name__", "metric2", "cluster", "staging")),
+			},
+			{
+				// No cluster label -> tenant should be default tenant
+				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("__name__", "metric3", "other", "value")),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, remote, 1)
+
+	// Verify tenant names are in format "label_name:label_value"
+	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}]["cluster:prod"].timeSeries, 1)
+	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}]["cluster:staging"].timeSeries, 1)
+	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}][defaultTenantID].timeSeries, 1)
+
+	// Verify labels are preserved (not removed like splitTenantLabelName)
+	require.Equal(t, 2, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}]["cluster:prod"].timeSeries[0].Labels).Len())
+	require.Equal(t, 2, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}]["cluster:staging"].timeSeries[0].Labels).Len())
+
+	// Verify seen tenants
+	require.Equal(t, map[string]struct{}{
+		"cluster:prod":    {},
+		"cluster:staging": {},
+		defaultTenantID:   {},
+	}, hr.seenTenants)
+}
+
 func TestHandlerFlippingHashrings(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1874,67 +1874,13 @@ func TestDistributeSeries(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, remote, 1)
-	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}]["bar"].timeSeries, 1)
-	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}]["boo"].timeSeries, 1)
+	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}][tenantIDLabelName+":bar"].timeSeries, 1)
+	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}][tenantIDLabelName+":boo"].timeSeries, 1)
 
-	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}]["bar"].timeSeries[0].Labels).Len())
-	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}]["boo"].timeSeries[0].Labels).Len())
+	require.Equal(t, 2, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}][tenantIDLabelName+":bar"].timeSeries[0].Labels).Len())
+	require.Equal(t, 2, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}][tenantIDLabelName+":boo"].timeSeries[0].Labels).Len())
 
-	require.Equal(t, map[string]struct{}{"bar": {}, "boo": {}}, hr.seenTenants)
-}
-
-func TestDistributeSeriesWithTenantSourceLabel(t *testing.T) {
-	t.Parallel()
-
-	const tenantSourceLabelName = "cluster"
-	const defaultTenantID = "default-tenant"
-	h := NewHandler(nil, &Options{
-		TenantSourceLabelName: tenantSourceLabelName,
-		DefaultTenantID:       defaultTenantID,
-	})
-
-	endpoint := Endpoint{Address: "http://localhost:9090", CapNProtoAddress: "http://localhost:19391"}
-	hashring, err := newSimpleHashring([]Endpoint{endpoint})
-	require.NoError(t, err)
-	hr := &hashringSeenTenants{Hashring: hashring}
-	h.Hashring(hr)
-
-	_, remote, err := h.distributeTimeseriesToReplicas(
-		"http-tenant",
-		[]uint64{0},
-		[]prompb.TimeSeries{
-			{
-				// Has cluster label -> tenant should be "cluster:prod"
-				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("__name__", "metric1", "cluster", "prod")),
-			},
-			{
-				// Has cluster label -> tenant should be "cluster:staging"
-				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("__name__", "metric2", "cluster", "staging")),
-			},
-			{
-				// No cluster label -> tenant should be default tenant
-				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("__name__", "metric3", "other", "value")),
-			},
-		},
-	)
-	require.NoError(t, err)
-	require.Len(t, remote, 1)
-
-	// Verify tenant names are in format "label_name:label_value"
-	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}]["cluster:prod"].timeSeries, 1)
-	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}]["cluster:staging"].timeSeries, 1)
-	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}][defaultTenantID].timeSeries, 1)
-
-	// Verify labels are preserved (not removed like splitTenantLabelName)
-	require.Equal(t, 2, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}]["cluster:prod"].timeSeries[0].Labels).Len())
-	require.Equal(t, 2, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}]["cluster:staging"].timeSeries[0].Labels).Len())
-
-	// Verify seen tenants
-	require.Equal(t, map[string]struct{}{
-		"cluster:prod":    {},
-		"cluster:staging": {},
-		defaultTenantID:   {},
-	}, hr.seenTenants)
+	require.Equal(t, map[string]struct{}{tenantIDLabelName + ":bar": {}, tenantIDLabelName + ":boo": {}}, hr.seenTenants)
 }
 
 func TestHandlerFlippingHashrings(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Add a thanos router flag to set label name to use as tenant source. When set, the value of this label determines the tenant for each series, overriding the HTTP tenant header. If a series does not have this label, the default tenant ID is used. The label is preserved in the series.
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
