### PR TITLE
add shuffle sharding feature for aligned ketama hashring

### DIFF
--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -140,8 +140,13 @@ type ShuffleShardingConfig struct {
 	CacheSize int `json:"cache_size"`
 	// ZoneAwarenessDisabled disables zone awareness. We still try to spread the load
 	// across the available zones, but we don't try to balance the shards across zones.
-	ZoneAwarenessDisabled bool                            `json:"zone_awareness_disabled"`
-	Overrides             []ShuffleShardingOverrideConfig `json:"overrides,omitempty"`
+	ZoneAwarenessDisabled bool `json:"zone_awareness_disabled"`
+	// AlignedOrdinalSharding enables aligned ordinal selection for shuffle sharding.
+	// When true and using aligned_ketama algorithm, the same ordinals are selected
+	// across all AZs, preserving strict replica alignment. ShardSize represents the
+	// number of ordinals to select (resulting in ShardSize * numAZs total endpoints).
+	AlignedOrdinalSharding bool                            `json:"aligned_ordinal_sharding"`
+	Overrides              []ShuffleShardingOverrideConfig `json:"overrides,omitempty"`
 }
 
 type tenantMatcher string


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
This PR adds support for aligned ordinal selection in shuffle sharding when using the aligned_ketama algorithm.

  Problem: The current shuffle sharding implementation selects nodes independently per AZ, which breaks the aligned_ketama invariant where replicas should have the same ordinal across all AZs.

  Solution: When aligned_ordinal_sharding is enabled, shuffle sharding selects ordinals (not nodes) based on tenant hash, then takes the same ordinal from each AZ.

  How It Works

  With 3 AZs, 5 pods per AZ, shard_size: 2, and aligned_ordinal_sharding: true:

  1. Tenant "foo" is assigned 2 ordinals via consistent hashing (e.g., ordinals 1 and 4)
  2. The tenant's shard contains 6 endpoints: a-1, b-1, c-1, a-4, b-4, c-4
  3. Series are distributed across the selected ordinals:
    - Series hashing to ordinal 1 → replicated to a-1, b-1, c-1 (same data)
    - Series hashing to ordinal 4 → replicated to a-4, b-4, c-4 (same data)

  Tenant "foo" shard:

    Ordinal 1 (RF=3):              Ordinal 4 (RF=3):
    ┌─────┐ ┌─────┐ ┌─────┐       ┌─────┐ ┌─────┐ ┌─────┐
    │ a-1 │ │ b-1 │ │ c-1 │       │ a-4 │ │ b-4 │ │ c-4 │
    └─────┘ └─────┘ └─────┘       └─────┘ └─────┘ └─────┘
       └───────┴───────┘             └───────┴───────┘
          same series                   same series
         (different from ordinal 4)

  Example Configuration
```
  {
      "endpoints": [
          {"address": "pod-a-0.svc.cluster.local:10901", "az": "az-a"},
          {"address": "pod-a-1.svc.cluster.local:10901", "az": "az-a"},
          {"address": "pod-a-2.svc.cluster.local:10901", "az": "az-a"},
          {"address": "pod-b-0.svc.cluster.local:10901", "az": "az-b"},
          {"address": "pod-b-1.svc.cluster.local:10901", "az": "az-b"},
          {"address": "pod-b-2.svc.cluster.local:10901", "az": "az-b"},
          {"address": "pod-c-0.svc.cluster.local:10901", "az": "az-c"},
          {"address": "pod-c-1.svc.cluster.local:10901", "az": "az-c"},
          {"address": "pod-c-2.svc.cluster.local:10901", "az": "az-c"}
      ],
      "hashring": "my-ring",
      "algorithm": "aligned_ketama",
      "shuffle_sharding_config": {
          "shard_size": 2,
          "aligned_ordinal_sharding": true
      }
  }
```
  - shard_size: 2 = number of ordinals per tenant
  - Total endpoints per tenant = shard_size × num_AZs = 2 × 3 = 6

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
