### PR TITLE
filter out lost+found dir for tenant discovery

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -435,6 +435,10 @@ func (t *MultiTSDB) Open() error {
 		if !f.IsDir() {
 			continue
 		}
+		// Skip the ext4 filesystem's lost+found directory.
+		if f.Name() == "lost+found" {
+			continue
+		}
 
 		g.Go(func() error {
 			_, err := t.getOrLoadTenant(f.Name(), true)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
found the ext4 file system's lost and found dir is identified as a tenant
<img width="1728" height="838" alt="image" src="https://github.com/user-attachments/assets/6285d8e7-376e-42e2-9644-1abc782a33c9" />


<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
