### PR TITLE
fix capn client failure and add a regression test

### DIFF
--- a/pkg/receive/capnproto_client_test.go
+++ b/pkg/receive/capnproto_client_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thanos-io/thanos/pkg/receive/writecapnp"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+// TestCapNProtoClient_UnresponsiveServerDuringRestart verifies that the client
+// can recover after encountering an unresponsive server (e.g., during pod restart).
+// This is a regression test for: https://github.com/thanos-io/thanos/issues/8254
+func TestCapNProtoClient_UnresponsiveServerDuringRestart(t *testing.T) {
+	t.Parallel()
+	logger := log.NewNopLogger()
+
+	// Start an unresponsive server (accepts connections but never responds)
+	unresponsiveListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := unresponsiveListener.Addr().String()
+
+	var unresponsiveWg sync.WaitGroup
+	unresponsiveWg.Add(1)
+	go func() {
+		defer unresponsiveWg.Done()
+		for {
+			conn, err := unresponsiveListener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1024)
+				for {
+					c.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+					if _, err := c.Read(buf); err != nil {
+						if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+							continue
+						}
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	// Create client pointing to unresponsive server
+	client := writecapnp.NewRemoteWriteClient(writecapnp.NewTCPDialer(addr), logger)
+
+	// First request times out (expected)
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	_, err = client.RemoteWrite(ctx1, &storepb.WriteRequest{Tenant: "test"})
+	cancel1()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "context deadline exceeded")
+
+	// Shutdown unresponsive server and start working server on same address
+	unresponsiveListener.Close()
+	unresponsiveWg.Wait()
+	time.Sleep(100 * time.Millisecond)
+
+	workingListener, err := net.Listen("tcp", addr)
+	if err != nil {
+		time.Sleep(500 * time.Millisecond)
+		workingListener, err = net.Listen("tcp", addr)
+	}
+	require.NoError(t, err)
+	defer workingListener.Close()
+
+	handler := NewCapNProtoHandler(logger, NewCapNProtoWriter(
+		logger,
+		newFakeTenantAppendable(&fakeAppendable{appender: newFakeAppender(nil, nil, nil)}),
+		&CapNProtoWriterOptions{},
+	))
+	srv := NewCapNProtoServer(workingListener, handler, logger)
+	go srv.ListenAndServe()
+	defer srv.Shutdown()
+	time.Sleep(50 * time.Millisecond)
+
+	// Second request should succeed - client must recover by reconnecting
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	_, err = client.RemoteWrite(ctx2, &storepb.WriteRequest{Tenant: "test"})
+	cancel2()
+
+	require.NoError(t, err, "client should recover by reconnecting to working server")
+	client.Close()
+}

--- a/pkg/receive/capnproto_client_test.go
+++ b/pkg/receive/capnproto_client_test.go
@@ -42,7 +42,7 @@ func TestCapNProtoClient_UnresponsiveServerDuringRestart(t *testing.T) {
 				defer c.Close()
 				buf := make([]byte, 1024)
 				for {
-					c.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+					_ = c.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
 					if _, err := c.Read(buf); err != nil {
 						if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 							continue
@@ -83,7 +83,7 @@ func TestCapNProtoClient_UnresponsiveServerDuringRestart(t *testing.T) {
 		&CapNProtoWriterOptions{},
 	))
 	srv := NewCapNProtoServer(workingListener, handler, logger)
-	go srv.ListenAndServe()
+	go func() { _ = srv.ListenAndServe() }()
 	defer srv.Shutdown()
 	time.Sleep(50 * time.Millisecond)
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Issue: When using capnproto as the replication protocol, distributors get stuck in an endless retry loop if receiver pods restart chaotically (see https://github.com/thanos-io/thanos/issues/8254). The error `rpc: bootstrap: send message: context deadline exceeded` keeps occurring and the distributor cannot recover without being restarted.

Root cause: The client only triggered reconnection when capnp.IsDisconnected(err) returned true. However, timeout errors (context deadline exceeded) are not classified as "disconnected" by the capnp library, so the client kept reusing a stale connection instead of reconnecting.

Fix: Reconnect on any transport error from result.Struct(), not just IsDisconnected errors. Also clear the connection when reconnect attempts are exhausted so subsequent calls can establish fresh connections.

Testing: Added regression test TestCapNProtoClient_UnresponsiveServerDuringRestart that fails without the fix and passes with it.
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
