### PR TITLE
Replace matcher cache with upstream singleflight-based implementation

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -29,7 +28,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/wlog"
-	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"google.golang.org/grpc"
 
 	"github.com/thanos-io/objstore"
@@ -172,20 +170,6 @@ func runReceive(
 	if len(conf.tsdbPathSegmentsBeforeTenant) > 0 {
 		multiTSDBOptions = append(multiTSDBOptions, receive.WithPathSegmentsBeforeTenant(conf.tsdbPathSegmentsBeforeTenant))
 		level.Info(logger).Log("msg", "tenant path segments before tenant feature enabled", "segments", path.Join(conf.tsdbPathSegmentsBeforeTenant...))
-	}
-
-	// Create a matcher converter if specified by command line to cache expensive regex matcher conversions.
-	// Proxy store and TSDB stores of all tenants share a single cache.
-	var matcherConverter *storepb.MatcherConverter
-	if conf.matcherConverterCacheCapacity > 0 {
-		var err error
-		matcherConverter, err = storepb.NewMatcherConverter(conf.matcherConverterCacheCapacity, reg)
-		if err != nil {
-			level.Error(logger).Log("msg", "failed to create matcher converter", "err", err)
-		}
-	}
-	if matcherConverter != nil {
-		multiTSDBOptions = append(multiTSDBOptions, receive.WithMatcherConverter(matcherConverter))
 	}
 
 	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), conf.rwServerCert, conf.rwServerKey, conf.rwServerClientCA, conf.rwServerTlsMinVersion)
@@ -399,25 +383,6 @@ func runReceive(
 				w.WriteHeader(http.StatusOK)
 			}
 		}))
-		srv.Handle("/-/matchers", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			if matcherConverter != nil {
-				labelMatchers := matcherConverter.Keys()
-				// Convert the slice to JSON
-				jsonData, err := json.Marshal(labelMatchers)
-				if err != nil {
-					http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
-					return
-				}
-
-				// Set the Content-Type header and write the response
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				if _, err := w.Write(jsonData); err != nil {
-					level.Error(logger).Log("msg", "failed to write matchers json", "err", err)
-				}
-			}
-		}))
 		g.Add(func() error {
 			statusProber.Healthy()
 			return srv.ListenAndServe()
@@ -443,9 +408,6 @@ func runReceive(
 			store.WithProxyStoreDebugLogging(debugLogging),
 			store.WithoutDedup(),
 			store.WithLazyRetrievalMaxBufferedResponsesForProxy(conf.lazyRetrievalMaxBufferedResponses),
-		}
-		if matcherConverter != nil {
-			options = append(options, store.WithProxyStoreMatcherConverter(matcherConverter))
 		}
 
 		proxy := store.NewProxyStore(
@@ -1022,7 +984,6 @@ type receiveConfig struct {
 	numTopMetricsPerTenant            int
 	topMetricsMinimumCardinality      uint64
 	topMetricsUpdateInterval          time.Duration
-	matcherConverterCacheCapacity     int
 	maxPendingGrpcWriteRequests       int
 	lazyRetrievalMaxBufferedResponses int
 
@@ -1210,8 +1171,6 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("10000").Uint64Var(&rc.topMetricsMinimumCardinality)
 	cmd.Flag("receive.top-metrics-update-interval", "The interval at which the top metrics are updated.").
 		Default("5m").DurationVar(&rc.topMetricsUpdateInterval)
-	cmd.Flag("receive.store-matcher-converter-cache-capacity", "The number of label matchers to cache in the matcher converter for the Store API. Set to 0 to disable to cache. Default is 0.").
-		Default("0").IntVar(&rc.matcherConverterCacheCapacity)
 	cmd.Flag("receive.max-pending-grcp-write-requests", "Reject right away gRPC write requests when this number of requests are pending. Value 0 disables this feature.").
 		Default("0").IntVar(&rc.maxPendingGrpcWriteRequests)
 	rc.featureList = cmd.Flag("enable-feature", "Experimental feature names to enable. The current list of features is "+metricNamesFilter+", "+grpcReadinessInterceptor+". Repeat this flag to enable multiple features.").Strings()

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -1170,7 +1170,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 			"about order.").
 		Default("false").Hidden().BoolVar(&rc.allowOutOfOrderUpload)
 
-	cmd.Flag("matcher-cache-size", "Max number of cached matchers items. Using 0 disables caching.").Default("0").IntVar(&rc.matcherCacheSize)
+	cmd.Flag("receive.store-matcher-converter-cache-capacity", "Max number of cached matchers items. Using 0 disables caching.").Default("0").IntVar(&rc.matcherCacheSize)
 
 	rc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -449,6 +449,8 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
+      --matcher-cache-size=0     Max number of cached matchers items. Using 0
+                                 disables caching.
       --objstore.config=<content>
                                  Alternative to 'objstore.config-file'
                                  flag (mutually exclusive). Content of

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -163,6 +163,8 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
+      --matcher-cache-size=0     Max number of cached matchers items. Using 0
+                                 disables caching.
       --max-time=9999-12-31T23:59:59Z
                                  End of time range limit to serve. Thanos Store
                                  will serve only blocks, which happened earlier

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/storage"
+
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/store"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/custom"
@@ -54,6 +56,8 @@ func TestQuerier_Proxy(t *testing.T) {
 	files, err := filepath.Glob("testdata/promql/**/*.test")
 	testutil.Ok(t, err)
 	testutil.Equals(t, 10, len(files), "%v", files)
+	cache, err := storecache.NewMatchersCache()
+	testutil.Ok(t, err)
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 	t.Run("proxy", func(t *testing.T) {
@@ -62,7 +66,7 @@ func TestQuerier_Proxy(t *testing.T) {
 			logger,
 			nil,
 			store.NewProxyStore(logger, nil, func() []store.Client { return sc.get() },
-				component.Debug, nil, 5*time.Minute, store.EagerRetrieval),
+				component.Debug, nil, 5*time.Minute, store.EagerRetrieval, store.WithMatcherCache(cache)),
 			1000000,
 			5*time.Minute,
 		)

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -6,6 +6,7 @@ package receive
 import (
 	"bytes"
 	"context"
+	goerrors "errors"
 	"fmt"
 	"io"
 	"math"
@@ -23,8 +24,6 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
-
-	goerrors "errors"
 
 	"github.com/alecthomas/units"
 	"github.com/efficientgo/core/testutil"

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -66,7 +66,6 @@ type MultiTSDB struct {
 	exemplarClients map[string]*exemplars.TSDB
 
 	metricNameFilterEnabled  bool
-	matcherConverter         *storepb.MatcherConverter
 	noUploadTenants          []string // Support both exact matches and prefix patterns (e.g., "tenant1", "prod-*")
 	enableTenantPathPrefix   bool
 	pathSegmentsBeforeTenant []string
@@ -79,13 +78,6 @@ type MultiTSDBOption func(mt *MultiTSDB)
 func WithMetricNameFilterEnabled() MultiTSDBOption {
 	return func(s *MultiTSDB) {
 		s.metricNameFilterEnabled = true
-	}
-}
-
-// WithMatcherConverter enables caching matcher converter consumed by children TSDB Stores.
-func WithMatcherConverter(mc *storepb.MatcherConverter) MultiTSDBOption {
-	return func(s *MultiTSDB) {
-		s.matcherConverter = mc
 	}
 }
 
@@ -110,6 +102,7 @@ func WithPathSegmentsBeforeTenant(segments []string) MultiTSDBOption {
 		s.pathSegmentsBeforeTenant = segments
 	}
 }
+
 
 // NewMultiTSDB creates new MultiTSDB.
 // NOTE: Passed labels must be sorted lexicographically (alphabetically).
@@ -838,10 +831,6 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	options := []store.TSDBStoreOption{}
 	if t.metricNameFilterEnabled {
 		options = append(options, store.WithCuckooMetricNameStoreFilter())
-	}
-	// Pass matcher converter to children TSDB Stores.
-	if t.matcherConverter != nil {
-		options = append(options, store.WithTSDBStoreMatcherConverter(t.matcherConverter))
 	}
 	tenant.set(store.NewTSDBStore(logger, s, component.Receive, lset, options...), s, ship, exemplars.NewTSDB(s, lset))
 	t.addTenantLocked(tenantID, tenant) // need to update the client list once store is ready & client != nil

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -17,17 +17,15 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
-	"golang.org/x/exp/slices"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
-
 	"github.com/thanos-io/objstore"
+	"go.uber.org/atomic"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
 
 	"github.com/thanos-io/thanos/pkg/api/status"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -37,6 +35,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/info/infopb"
 	"github.com/thanos-io/thanos/pkg/shipper"
 	"github.com/thanos-io/thanos/pkg/store"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
@@ -61,6 +60,8 @@ type MultiTSDB struct {
 	allowOutOfOrderUpload bool
 	hashFunc              metadata.HashFunc
 	hashringConfigs       []HashringConfig
+
+	matcherCache storecache.MatchersCache
 
 	tsdbClients     []store.Client
 	exemplarClients map[string]*exemplars.TSDB
@@ -103,6 +104,11 @@ func WithPathSegmentsBeforeTenant(segments []string) MultiTSDBOption {
 	}
 }
 
+func WithMatchersCache(cache storecache.MatchersCache) MultiTSDBOption {
+	return func(s *MultiTSDB) {
+		s.matcherCache = cache
+	}
+}
 
 // NewMultiTSDB creates new MultiTSDB.
 // NOTE: Passed labels must be sorted lexicographically (alphabetically).
@@ -136,6 +142,7 @@ func NewMultiTSDB(
 		bucket:                bucket,
 		allowOutOfOrderUpload: allowOutOfOrderUpload,
 		hashFunc:              hashFunc,
+		matcherCache:          storecache.NoopMatchersCache,
 	}
 
 	for _, option := range options {
@@ -828,9 +835,12 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 			shipper.DefaultMetaFilename,
 		)
 	}
-	options := []store.TSDBStoreOption{}
+	var options []store.TSDBStoreOption
 	if t.metricNameFilterEnabled {
 		options = append(options, store.WithCuckooMetricNameStoreFilter())
+	}
+	if t.matcherCache != nil {
+		options = append(options, store.WithMatcherCacheInstance(t.matcherCache))
 	}
 	tenant.set(store.NewTSDBStore(logger, s, component.Receive, lset, options...), s, ship, exemplars.NewTSDB(s, lset))
 	t.addTenantLocked(tenantID, tenant) // need to update the client list once store is ready & client != nil

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -46,21 +46,14 @@ func TestMultiTSDB(t *testing.T) {
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 	t.Run("run fresh", func(t *testing.T) {
-		m := NewMultiTSDB(
-			dir, logger, prometheus.NewRegistry(), &tsdb.Options{
-				MinBlockDuration:      (2 * time.Hour).Milliseconds(),
-				MaxBlockDuration:      (2 * time.Hour).Milliseconds(),
-				RetentionDuration:     (6 * time.Hour).Milliseconds(),
-				NoLockfile:            true,
-				MaxExemplars:          100,
-				EnableExemplarStorage: true,
-			},
-			labels.FromStrings("replica", "01"),
-			"tenant_id",
-			nil,
-			false,
-			metadata.NoneFunc,
-		)
+		m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+			MinBlockDuration:      (2 * time.Hour).Milliseconds(),
+			MaxBlockDuration:      (2 * time.Hour).Milliseconds(),
+			RetentionDuration:     (6 * time.Hour).Milliseconds(),
+			NoLockfile:            true,
+			MaxExemplars:          100,
+			EnableExemplarStorage: true,
+		}, labels.FromStrings("replica", "01"), "tenant_id", nil, false, metadata.NoneFunc)
 		defer func() { testutil.Ok(t, m.Close()) }()
 
 		testutil.Ok(t, m.Flush())
@@ -175,19 +168,12 @@ func TestMultiTSDB(t *testing.T) {
 
 	t.Run("flush with one sample produces a block", func(t *testing.T) {
 		const testTenant = "test_tenant"
-		m := NewMultiTSDB(
-			dir, logger, prometheus.NewRegistry(), &tsdb.Options{
-				MinBlockDuration:  (2 * time.Hour).Milliseconds(),
-				MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
-				RetentionDuration: (6 * time.Hour).Milliseconds(),
-				NoLockfile:        true,
-			},
-			labels.FromStrings("replica", "01"),
-			"tenant_id",
-			nil,
-			false,
-			metadata.NoneFunc,
-		)
+		m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+			MinBlockDuration:  (2 * time.Hour).Milliseconds(),
+			MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
+			RetentionDuration: (6 * time.Hour).Milliseconds(),
+			NoLockfile:        true,
+		}, labels.FromStrings("replica", "01"), "tenant_id", nil, false, metadata.NoneFunc)
 		defer func() { testutil.Ok(t, m.Close()) }()
 
 		testutil.Ok(t, m.Flush())

--- a/pkg/receive/receive_test.go
+++ b/pkg/receive/receive_test.go
@@ -8,13 +8,12 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/stretchr/testify/require"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
-
+	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
+
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/store"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thanos-io/thanos/pkg/receive/writecapnp"
-
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
@@ -24,6 +22,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/receive/writecapnp"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -394,6 +394,7 @@ type BucketStore struct {
 	fetcher         block.MetadataFetcher
 	dir             string
 	indexCache      storecache.IndexCache
+	matcherCache    storecache.MatchersCache
 	indexReaderPool *indexheader.ReaderPool
 	buffers         sync.Pool
 	chunkPool       pool.Pool[byte]
@@ -510,6 +511,13 @@ func WithIndexCache(cache storecache.IndexCache) BucketStoreOption {
 	}
 }
 
+// WithMatchersCache sets a matchers cache to use instead of a noopCache.
+func WithMatchersCache(cache storecache.MatchersCache) BucketStoreOption {
+	return func(s *BucketStore) {
+		s.matcherCache = cache
+	}
+}
+
 // WithQueryGate sets a queryGate to use instead of a noopGate.
 func WithQueryGate(queryGate gate.Gate) BucketStoreOption {
 	return func(s *BucketStore) {
@@ -613,11 +621,12 @@ func NewBucketStore(
 	options ...BucketStoreOption,
 ) (*BucketStore, error) {
 	s := &BucketStore{
-		logger:     log.NewNopLogger(),
-		bkt:        bkt,
-		fetcher:    fetcher,
-		dir:        dir,
-		indexCache: noopCache{},
+		logger:       log.NewNopLogger(),
+		bkt:          bkt,
+		fetcher:      fetcher,
+		dir:          dir,
+		indexCache:   noopCache{},
+		matcherCache: storecache.NoopMatchersCache,
 		buffers: sync.Pool{New: func() interface{} {
 			b := make([]byte, 0, initialBufSize)
 			return &b
@@ -1502,7 +1511,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 
 	tenant, _ := tenancy.GetTenantFromGRPCMetadata(srv.Context())
 
-	matchers, err := storepb.MatchersToPromMatchers(req.Matchers...)
+	matchers, err := storecache.MatchersToPromMatchersCached(s.matcherCache, req.Matchers...)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1677,6 +1677,8 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		MaxSize: 8889,
 	})
 	testutil.Ok(t, err)
+	matcherCache, err := storecache.NewMatchersCache(storecache.WithSize(10000))
+	testutil.Ok(t, err)
 
 	var b1 *bucketBlock
 
@@ -1770,6 +1772,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 	store := &BucketStore{
 		bkt:             objstore.WithNoopInstr(bkt),
 		logger:          logger,
+		matcherCache:    matcherCache,
 		indexCache:      indexCache,
 		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, indexheader.NewReaderPoolMetrics(nil), indexheader.AlwaysEagerDownloadIndexHeader),
 		metrics:         newBucketStoreMetrics(nil),
@@ -2076,6 +2079,9 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
 	testutil.Ok(tb, err)
 
+	matcherCache, err := storecache.NewMatchersCache(storecache.WithSize(1024))
+	testutil.Ok(tb, err)
+
 	store, err := NewBucketStore(
 		instrBkt,
 		fetcher,
@@ -2092,6 +2098,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 		0,
 		WithLogger(logger),
 		WithIndexCache(indexCache),
+		WithMatchersCache(matcherCache),
 	)
 	testutil.Ok(tb, err)
 	testutil.Ok(tb, store.SyncBlocks(context.Background()))

--- a/pkg/store/cache/matchers_cache.go
+++ b/pkg/store/cache/matchers_cache.go
@@ -1,0 +1,207 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storecache
+
+import (
+	"strings"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/model/labels"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+const DefaultCacheSize = 200
+
+type NewItemFunc func() (*labels.Matcher, error)
+
+type ConversionLabelMatcher interface {
+	GetValue() string
+	GetName() string
+	MatcherType() (labels.MatchType, error)
+}
+
+type MatchersCache interface {
+	// GetOrSet retrieves a matcher from cache or creates and stores it if not present.
+	// If the matcher is not in cache, it uses the provided newItem function to create it.
+	GetOrSet(m ConversionLabelMatcher, newItem NewItemFunc) (*labels.Matcher, error)
+}
+
+// Ensure implementations satisfy the interface.
+var (
+	_                 MatchersCache = (*LruMatchersCache)(nil)
+	NoopMatchersCache MatchersCache = &noopMatcherCache{}
+
+	defaultIsCacheableFunc = func(m ConversionLabelMatcher) bool {
+		t, err := m.MatcherType()
+		if err != nil {
+			return false
+		}
+
+		return t == labels.MatchRegexp || t == labels.MatchNotRegexp
+	}
+)
+
+type noopMatcherCache struct{}
+
+// GetOrSet implements MatchersCache by always creating a new matcher without caching.
+func (n *noopMatcherCache) GetOrSet(_ ConversionLabelMatcher, newItem NewItemFunc) (*labels.Matcher, error) {
+	return newItem()
+}
+
+// LruMatchersCache implements MatchersCache with an LRU cache and metrics.
+type LruMatchersCache struct {
+	reg     prometheus.Registerer
+	cache   *lru.Cache[string, *labels.Matcher]
+	metrics *matcherCacheMetrics
+	size    int
+	sf      singleflight.Group
+
+	isCacheable func(matcher ConversionLabelMatcher) bool
+}
+
+type MatcherCacheOption func(*LruMatchersCache)
+
+func WithPromRegistry(reg prometheus.Registerer) MatcherCacheOption {
+	return func(c *LruMatchersCache) {
+		c.reg = reg
+	}
+}
+
+func WithSize(size int) MatcherCacheOption {
+	return func(c *LruMatchersCache) {
+		c.size = size
+	}
+}
+
+// WithIsCacheableFunc sets the function that determines if the item should be cached or not.
+func WithIsCacheableFunc(f func(matcher ConversionLabelMatcher) bool) MatcherCacheOption {
+	return func(c *LruMatchersCache) {
+		c.isCacheable = f
+	}
+}
+
+func NewMatchersCache(opts ...MatcherCacheOption) (*LruMatchersCache, error) {
+	cache := &LruMatchersCache{
+		size:        DefaultCacheSize,
+		isCacheable: defaultIsCacheableFunc,
+	}
+
+	for _, opt := range opts {
+		opt(cache)
+	}
+	cache.metrics = newMatcherCacheMetrics(cache.reg)
+	cache.metrics.maxItems.Set(float64(cache.size))
+
+	lruCache, err := lru.NewWithEvict[string, *labels.Matcher](cache.size, cache.onEvict)
+	if err != nil {
+		return nil, err
+	}
+	cache.cache = lruCache
+
+	return cache, nil
+}
+
+func (c *LruMatchersCache) GetOrSet(m ConversionLabelMatcher, newItem NewItemFunc) (*labels.Matcher, error) {
+	if !c.isCacheable(m) {
+		return newItem()
+	}
+
+	c.metrics.requestsTotal.Inc()
+	key, err := cacheKey(m)
+
+	if err != nil {
+		return nil, err
+	}
+
+	v, err, _ := c.sf.Do(key, func() (interface{}, error) {
+		if item, ok := c.cache.Get(key); ok {
+			c.metrics.hitsTotal.Inc()
+			return item, nil
+		}
+
+		item, err := newItem()
+		if err != nil {
+			return nil, err
+		}
+		c.cache.Add(key, item)
+		c.metrics.numItems.Set(float64(c.cache.Len()))
+		return item, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return v.(*labels.Matcher), nil
+}
+
+func (c *LruMatchersCache) onEvict(_ string, _ *labels.Matcher) {
+	c.metrics.evicted.Inc()
+	c.metrics.numItems.Set(float64(c.cache.Len()))
+}
+
+type matcherCacheMetrics struct {
+	requestsTotal prometheus.Counter
+	hitsTotal     prometheus.Counter
+	numItems      prometheus.Gauge
+	maxItems      prometheus.Gauge
+	evicted       prometheus.Counter
+}
+
+func newMatcherCacheMetrics(reg prometheus.Registerer) *matcherCacheMetrics {
+	return &matcherCacheMetrics{
+		requestsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "thanos_matchers_cache_requests_total",
+			Help: "Total number of cache requests for series matchers",
+		}),
+		hitsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "thanos_matchers_cache_hits_total",
+			Help: "Total number of cache hits for series matchers",
+		}),
+		numItems: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "thanos_matchers_cache_items",
+			Help: "Total number of cached items",
+		}),
+		maxItems: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "thanos_matchers_cache_max_items",
+			Help: "Maximum number of items that can be cached",
+		}),
+		evicted: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "thanos_matchers_cache_evicted_total",
+			Help: "Total number of items evicted from the cache",
+		}),
+	}
+}
+
+// MatchersToPromMatchersCached returns Prometheus matchers from proto matchers.
+// Works analogously to MatchersToPromMatchers but uses cache to avoid unnecessary allocations and conversions.
+// NOTE: It allocates memory.
+func MatchersToPromMatchersCached(cache MatchersCache, ms ...storepb.LabelMatcher) ([]*labels.Matcher, error) {
+	res := make([]*labels.Matcher, 0, len(ms))
+	for i := range ms {
+		pm, err := cache.GetOrSet(&ms[i], func() (*labels.Matcher, error) { return storepb.MatcherToPromMatcher(ms[i]) })
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, pm)
+	}
+	return res, nil
+}
+
+func cacheKey(m ConversionLabelMatcher) (string, error) {
+	sb := strings.Builder{}
+	t, err := m.MatcherType()
+	if err != nil {
+		return "", err
+	}
+	typeStr := t.String()
+	sb.Grow(len(m.GetValue()) + len(m.GetName()) + len(typeStr))
+	sb.WriteString(m.GetName())
+	sb.WriteString(typeStr)
+	sb.WriteString(m.GetValue())
+	return sb.String(), nil
+}

--- a/pkg/store/cache/matchers_cache_test.go
+++ b/pkg/store/cache/matchers_cache_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storecache
+
+import (
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+func TestMatchersCache(t *testing.T) {
+	testCases := map[string]struct {
+		isCacheable func(matcher ConversionLabelMatcher) bool
+	}{
+		"default": {
+			isCacheable: defaultIsCacheableFunc,
+		},
+		"cache all items": {
+			isCacheable: func(matcher ConversionLabelMatcher) bool {
+				return true
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cache, err := NewMatchersCache(
+				WithSize(2),
+				WithIsCacheableFunc(tc.isCacheable),
+			)
+			testutil.Ok(t, err)
+
+			matcher := &storepb.LabelMatcher{
+				Type:  storepb.LabelMatcher_EQ,
+				Name:  "key",
+				Value: "val",
+			}
+
+			matcher2 := &storepb.LabelMatcher{
+				Type:  storepb.LabelMatcher_RE,
+				Name:  "key2",
+				Value: "val2|val3",
+			}
+
+			matcher3 := &storepb.LabelMatcher{
+				Type:  storepb.LabelMatcher_EQ,
+				Name:  "key3",
+				Value: "val3",
+			}
+
+			var cacheHit bool
+			newItem := func(matcher *storepb.LabelMatcher) func() (*labels.Matcher, error) {
+				return func() (*labels.Matcher, error) {
+					cacheHit = false
+					return storepb.MatcherToPromMatcher(*matcher)
+				}
+			}
+			expected := labels.MustNewMatcher(labels.MatchEqual, "key", "val")
+			expected2 := labels.MustNewMatcher(labels.MatchRegexp, "key2", "val2|val3")
+			expected3 := labels.MustNewMatcher(labels.MatchEqual, "key3", "val3")
+
+			item, err := cache.GetOrSet(matcher, newItem(matcher))
+			testutil.Ok(t, err)
+			testutil.Equals(t, false, cacheHit)
+			testutil.Equals(t, expected.String(), item.String())
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher, newItem(matcher))
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.isCacheable(matcher), cacheHit)
+			testutil.Equals(t, expected.String(), item.String())
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher2, newItem(matcher2))
+			testutil.Ok(t, err)
+			testutil.Equals(t, false, cacheHit)
+			testutil.Equals(t, expected2.String(), item.String())
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher2, newItem(matcher2))
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.isCacheable(matcher2), cacheHit)
+			testutil.Equals(t, expected2.String(), item.String())
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher, newItem(matcher))
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.isCacheable(matcher), cacheHit)
+			testutil.Equals(t, expected, item)
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher3, newItem(matcher3))
+			testutil.Ok(t, err)
+			testutil.Equals(t, false, cacheHit)
+			testutil.Equals(t, expected3, item)
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher2, newItem(matcher2))
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.isCacheable(matcher2) && cache.cache.Len() < 2, cacheHit)
+			testutil.Equals(t, expected2.String(), item.String())
+		})
+	}
+}
+
+func BenchmarkMatchersCache(b *testing.B) {
+	cache, err := NewMatchersCache(WithSize(100))
+	if err != nil {
+		b.Fatalf("failed to create cache: %v", err)
+	}
+
+	matchers := []*storepb.LabelMatcher{
+		{Type: storepb.LabelMatcher_EQ, Name: "key1", Value: "val1"},
+		{Type: storepb.LabelMatcher_EQ, Name: "key2", Value: "val2"},
+		{Type: storepb.LabelMatcher_EQ, Name: "key3", Value: "val3"},
+		{Type: storepb.LabelMatcher_EQ, Name: "key4", Value: "val4"},
+		{Type: storepb.LabelMatcher_RE, Name: "key5", Value: "^(val5|val6|val7|val8|val9).*$"},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		matcher := matchers[i%len(matchers)]
+		_, err := cache.GetOrSet(matcher, func() (*labels.Matcher, error) {
+			return storepb.MatcherToPromMatcher(*matcher)
+		})
+		if err != nil {
+			b.Fatalf("failed to get or set cache item: %v", err)
+		}
+	}
+}

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -130,7 +130,7 @@ func ScanGRPCCurlProtoStreamMessages(data []byte, atEOF bool) (advance int, toke
 // Series returns all series for a requested time range and label matcher. The returned data may
 // exceed the requested time bounds.
 func (s *LocalStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.extLabels, nil)
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.extLabels)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/runutil"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
@@ -130,7 +131,7 @@ func ScanGRPCCurlProtoStreamMessages(data []byte, atEOF bool) (advance int, toke
 // Series returns all series for a requested time range and label matcher. The returned data may
 // exceed the requested time bounds.
 func (s *LocalStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.extLabels)
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.extLabels, storecache.NoopMatchersCache)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -36,6 +36,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/info/infopb"
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/runutil"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
@@ -125,7 +126,7 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Sto
 
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
+	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, storecache.NoopMatchersCache)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -488,8 +489,13 @@ func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, q *prompb.Que
 
 // matchesExternalLabels returns false if given matchers are not matching external labels.
 // If true, matchesExternalLabels also returns Prometheus matchers without those matching external labels.
-func matchesExternalLabels(ms []storepb.LabelMatcher, externalLabels labels.Labels) (bool, []*labels.Matcher, error) {
-	tms, err := storepb.MatchersToPromMatchers(ms...)
+func matchesExternalLabels(ms []storepb.LabelMatcher, externalLabels labels.Labels, cache storecache.MatchersCache) (bool, []*labels.Matcher, error) {
+	var (
+		tms []*labels.Matcher
+		err error
+	)
+
+	tms, err = storecache.MatchersToPromMatchersCached(cache, ms...)
 	if err != nil {
 		return false, nil, err
 	}
@@ -537,7 +543,7 @@ func (p *PrometheusStore) encodeChunk(ss []prompb.Sample) (storepb.Chunk_Encodin
 func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
+	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, storecache.NoopMatchersCache)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -600,7 +606,7 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
+	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, storecache.NoopMatchersCache)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -125,7 +125,7 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Sto
 
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, nil)
+	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -488,14 +488,8 @@ func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, q *prompb.Que
 
 // matchesExternalLabels returns false if given matchers are not matching external labels.
 // If true, matchesExternalLabels also returns Prometheus matchers without those matching external labels.
-func matchesExternalLabels(ms []storepb.LabelMatcher, externalLabels labels.Labels, mc *storepb.MatcherConverter) (bool, []*labels.Matcher, error) {
-	var tms []*labels.Matcher
-	var err error
-	if mc != nil {
-		tms, err = mc.MatchersToPromMatchers(ms...)
-	} else {
-		tms, err = storepb.MatchersToPromMatchers(ms...)
-	}
+func matchesExternalLabels(ms []storepb.LabelMatcher, externalLabels labels.Labels) (bool, []*labels.Matcher, error) {
+	tms, err := storepb.MatchersToPromMatchers(ms...)
 	if err != nil {
 		return false, nil, err
 	}
@@ -543,7 +537,7 @@ func (p *PrometheusStore) encodeChunk(ss []prompb.Sample) (storepb.Chunk_Encodin
 func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, nil)
+	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -606,7 +600,7 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, nil)
+	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -6,22 +6,21 @@ package store
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	"github.com/pkg/errors"
-
 	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -29,11 +28,10 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"google.golang.org/grpc"
 
-	"github.com/efficientgo/core/testutil"
-
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/info/infopb"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
@@ -2662,6 +2660,47 @@ func BenchmarkProxySeries(b *testing.B) {
 	})
 }
 
+func BenchmarkProxySeriesRegex(b *testing.B) {
+	tb := testutil.NewTB(b)
+
+	cache, err := storecache.NewMatchersCache(storecache.WithSize(200))
+	testutil.Ok(b, err)
+
+	q := NewProxyStore(nil,
+		nil,
+		func() []Client { return nil },
+		component.Query,
+		labels.EmptyLabels(), 0*time.Second, EagerRetrieval,
+		WithMatcherCache(cache),
+	)
+
+	words := []string{"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred", "plugh", "xyzzy", "thud"}
+	bigRegex := strings.Builder{}
+	for i := 0; i < 200; i++ {
+		bigRegex.WriteString(words[rand.Intn(len(words))])
+		bigRegex.WriteString("|")
+	}
+
+	matchers := []storepb.LabelMatcher{
+		{Type: storepb.LabelMatcher_RE, Name: "foo", Value: ".*"},
+		{Type: storepb.LabelMatcher_RE, Name: "bar", Value: bigRegex.String()},
+	}
+
+	// Create a regex that matches all series.
+	req := &storepb.SeriesRequest{
+		MinTime:  0,
+		MaxTime:  math.MaxInt64,
+		Matchers: matchers,
+	}
+	s := newStoreSeriesServer(context.Background())
+
+	tb.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testutil.Ok(b, q.Series(req, s))
+	}
+}
+
 func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
 	tmpDir := t.TempDir()
 
@@ -2712,6 +2751,7 @@ func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
 		responseTimeout:   5 * time.Second,
 		retrievalStrategy: EagerRetrieval,
 		tsdbSelector:      DefaultSelector,
+		matcherCache:      storecache.NoopMatchersCache,
 	}
 
 	var allResps []*storepb.SeriesResponse
@@ -2848,6 +2888,7 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 					responseTimeout:   50 * time.Millisecond,
 					retrievalStrategy: respStrategy,
 					tsdbSelector:      DefaultSelector,
+					matcherCache:      storecache.NoopMatchersCache,
 				}
 
 				ctx, cancel := context.WithCancel(context.Background())
@@ -2885,6 +2926,7 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 					responseTimeout:   50 * time.Millisecond,
 					retrievalStrategy: respStrategy,
 					tsdbSelector:      DefaultSelector,
+					matcherCache:      storecache.NoopMatchersCache,
 				}
 
 				ctx := context.Background()
@@ -3045,7 +3087,6 @@ func TestDedupRespHeap_Deduplication(t *testing.T) {
 			tcase.testFn(tcase.responses, h)
 		})
 	}
-
 }
 
 func TestProxyStore_FilterByExclusiveExternalLabels(t *testing.T) {

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -405,28 +405,33 @@ func PromMatchersToMatchers(ms ...*labels.Matcher) ([]LabelMatcher, error) {
 // NOTE: It allocates memory.
 func MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
 	res := make([]*labels.Matcher, 0, len(ms))
-	for _, m := range ms {
-		var t labels.MatchType
-
-		switch m.Type {
-		case LabelMatcher_EQ:
-			t = labels.MatchEqual
-		case LabelMatcher_NEQ:
-			t = labels.MatchNotEqual
-		case LabelMatcher_RE:
-			t = labels.MatchRegexp
-		case LabelMatcher_NRE:
-			t = labels.MatchNotRegexp
-		default:
-			return nil, errors.Errorf("unrecognized label matcher type %d", m.Type)
-		}
-		m, err := labels.NewMatcher(t, m.Name, m.Value)
+	for i := range ms {
+		pm, err := MatcherToPromMatcher(ms[i])
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, m)
+		res = append(res, pm)
 	}
 	return res, nil
+}
+
+// MatcherToPromMatcher converts a Thanos label matcher to Prometheus label matcher.
+func MatcherToPromMatcher(m LabelMatcher) (*labels.Matcher, error) {
+	var t labels.MatchType
+
+	switch m.Type {
+	case LabelMatcher_EQ:
+		t = labels.MatchEqual
+	case LabelMatcher_NEQ:
+		t = labels.MatchNotEqual
+	case LabelMatcher_RE:
+		t = labels.MatchRegexp
+	case LabelMatcher_NRE:
+		t = labels.MatchNotRegexp
+	default:
+		return nil, errors.Errorf("unrecognized label matcher type %d", m.Type)
+	}
+	return labels.NewMatcher(t, m.Name, m.Value)
 }
 
 // MatchersToString converts label matchers to string format.
@@ -457,6 +462,14 @@ func PromMatchersToString(ms ...*labels.Matcher) string {
 
 func (m *LabelMatcher) PromString() string {
 	return fmt.Sprintf("%s%s%q", m.Name, m.Type.PromString(), m.Value)
+}
+
+func (m *LabelMatcher) GetName() string {
+	return m.Name
+}
+
+func (m *LabelMatcher) GetValue() string {
+	return m.Value
 }
 
 func (x LabelMatcher_Type) PromString() string {
@@ -565,4 +578,22 @@ func (c *SeriesStatsCounter) Count(r *SeriesResponse) {
 
 func (m *SeriesRequest) ToPromQL() string {
 	return m.QueryHints.toPromQL(m.Matchers)
+}
+
+func (m *LabelMatcher) MatcherType() (labels.MatchType, error) {
+	var t labels.MatchType
+	switch m.Type {
+	case LabelMatcher_EQ:
+		t = labels.MatchEqual
+	case LabelMatcher_NEQ:
+		t = labels.MatchNotEqual
+	case LabelMatcher_RE:
+		t = labels.MatchRegexp
+	case LabelMatcher_NRE:
+		t = labels.MatchNotRegexp
+	default:
+		return 0, errors.Errorf("unrecognized label matcher type %d", m.Type)
+	}
+
+	return t, nil
 }

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -12,10 +12,7 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/types"
-	cache "github.com/hashicorp/golang-lru/v2"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
 	"google.golang.org/grpc/codes"
 
@@ -404,118 +401,32 @@ func PromMatchersToMatchers(ms ...*labels.Matcher) ([]LabelMatcher, error) {
 	return res, nil
 }
 
-func matcherToPromMatcher(m LabelMatcher) (*labels.Matcher, error) {
-	var t labels.MatchType
-
-	switch m.Type {
-	case LabelMatcher_EQ:
-		t = labels.MatchEqual
-	case LabelMatcher_NEQ:
-		t = labels.MatchNotEqual
-	case LabelMatcher_RE:
-		t = labels.MatchRegexp
-	case LabelMatcher_NRE:
-		t = labels.MatchNotRegexp
-	default:
-		return nil, errors.Errorf("unrecognized label matcher type %d", m.Type)
-	}
-	pm, err := labels.NewMatcher(t, m.Name, m.Value)
-	if err != nil {
-		return nil, err
-	}
-	return pm, nil
-}
-
 // MatchersToPromMatchers returns Prometheus matchers from proto matchers.
 // NOTE: It allocates memory.
 func MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
 	res := make([]*labels.Matcher, 0, len(ms))
 	for _, m := range ms {
-		m, err := matcherToPromMatcher(m)
+		var t labels.MatchType
+
+		switch m.Type {
+		case LabelMatcher_EQ:
+			t = labels.MatchEqual
+		case LabelMatcher_NEQ:
+			t = labels.MatchNotEqual
+		case LabelMatcher_RE:
+			t = labels.MatchRegexp
+		case LabelMatcher_NRE:
+			t = labels.MatchNotRegexp
+		default:
+			return nil, errors.Errorf("unrecognized label matcher type %d", m.Type)
+		}
+		m, err := labels.NewMatcher(t, m.Name, m.Value)
 		if err != nil {
 			return nil, err
 		}
 		res = append(res, m)
 	}
 	return res, nil
-}
-
-type MatcherConverter struct {
-	cache         *cache.TwoQueueCache[LabelMatcher, *labels.Matcher]
-	cacheCapacity int
-	metrics       *matcherConverterMetrics
-}
-
-type matcherConverterMetrics struct {
-	cacheTotalCount prometheus.Counter
-	cacheHitCount   prometheus.Counter
-	cacheSizeGauge  prometheus.Gauge
-}
-
-func newMatcherConverterMetrics(reg prometheus.Registerer) *matcherConverterMetrics {
-	var m matcherConverterMetrics
-
-	m.cacheTotalCount = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_store_matcher_converter_cache_total",
-		Help: "Total number of cache access.",
-	})
-	m.cacheHitCount = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_store_matcher_converter_cache_hit_total",
-		Help: "Total number of cache hits.",
-	})
-	m.cacheSizeGauge = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "thanos_store_matcher_converter_cache_size",
-		Help: "Current size of the cache.",
-	})
-
-	return &m
-}
-
-// NewMatcherConverter creates a new MatcherConverter with given capacity.
-func NewMatcherConverter(cacheCapacity int, reg prometheus.Registerer) (*MatcherConverter, error) {
-	c, err := cache.New2Q[LabelMatcher, *labels.Matcher](cacheCapacity)
-	if err != nil {
-		return nil, err
-	}
-	metrics := newMatcherConverterMetrics(reg)
-	return &MatcherConverter{cache: c, cacheCapacity: cacheCapacity, metrics: metrics}, nil
-}
-
-// MatchersToPromMatchers converts proto label matchers to Prometheus label matchers. It caches regex conversions.
-func (c *MatcherConverter) MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
-	res := make([]*labels.Matcher, 0, len(ms))
-	for _, m := range ms {
-		if m.Type != LabelMatcher_RE && m.Type != LabelMatcher_NRE {
-			// EQ and NEQ are very cheap, so we don't cache them.
-			pm, err := matcherToPromMatcher(m)
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, pm)
-			continue
-		}
-		c.metrics.cacheTotalCount.Inc()
-		if pm, ok := c.cache.Get(m); ok {
-			// cache hit
-			c.metrics.cacheHitCount.Inc()
-			res = append(res, pm)
-			continue
-		}
-		// cache miss
-		pm, err := matcherToPromMatcher(m)
-		if err != nil {
-			return nil, err
-		}
-		c.cache.Add(m, pm)
-		res = append(res, pm)
-	}
-	c.metrics.cacheSizeGauge.Set(float64(c.cache.Len()))
-	return res, nil
-}
-
-// Get all keys from the cache for debugging.
-func (c *MatcherConverter) Keys() []LabelMatcher {
-	return c.cache.Keys()
 }
 
 // MatchersToString converts label matchers to string format.

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/require"
 
 	"github.com/efficientgo/core/testutil"
 

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -11,11 +11,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/stretchr/testify/require"
 
 	"github.com/efficientgo/core/testutil"
 
@@ -674,135 +671,6 @@ func TestSeriesRequestToPromQL(t *testing.T) {
 			}
 		})
 	}
-}
-
-func getMetricValue(m prometheus.Collector) float64 {
-	metric := &dto.Metric{}
-	if err := m.(prometheus.Metric).Write(metric); err != nil {
-		return 0
-	}
-	return metric.GetCounter().GetValue()
-}
-
-type CacheAction_Type int32
-
-const (
-	CacheHit  CacheAction_Type = 0
-	CacheMiss CacheAction_Type = 1
-	NoCache   CacheAction_Type = 2
-)
-
-func TestMatcherConverter_MatchersToPromMatchers(t *testing.T) {
-	reg := prometheus.NewRegistry()
-	converter, err := NewMatcherConverter(2, reg)
-	require.NoError(t, err)
-
-	cases := []struct {
-		name              string
-		inputMatchers     []LabelMatcher
-		expectCacheAction CacheAction_Type
-		expectMatchers    []*labels.Matcher
-		expectError       bool
-	}{
-		{
-			name: "Single EQ matcher, no cache",
-			inputMatchers: []LabelMatcher{
-				{Name: "__name__", Type: LabelMatcher_EQ, Value: "up"},
-			},
-			// EQ matchers are not cached
-			expectCacheAction: NoCache,
-		},
-		{
-			name: "Single RE matcher, cache miss",
-			inputMatchers: []LabelMatcher{
-				{Name: "job", Type: LabelMatcher_RE, Value: "test"},
-			},
-			expectCacheAction: CacheMiss,
-		},
-		{
-			name: "Single RE matcher, cache hit",
-			inputMatchers: []LabelMatcher{
-				{Name: "job", Type: LabelMatcher_RE, Value: "test"},
-			},
-			expectCacheAction: CacheHit,
-		},
-		{
-			name: "Multiple matchers, mixed cache",
-			inputMatchers: []LabelMatcher{
-				{Name: "__name__", Type: LabelMatcher_EQ, Value: "up"},
-				{Name: "job", Type: LabelMatcher_RE, Value: "test"},
-			},
-			// Only RE is cached, so cache hit expected for RE matcher
-			expectCacheAction: CacheHit,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			cacheHitsBefore := getMetricValue(converter.metrics.cacheHitCount)
-			cacheTotalBefore := getMetricValue(converter.metrics.cacheTotalCount)
-
-			promMatchers, err := converter.MatchersToPromMatchers(c.inputMatchers...)
-
-			if c.expectError {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Len(t, promMatchers, len(c.inputMatchers))
-
-			for i, m := range promMatchers {
-				require.Equal(t, c.inputMatchers[i].Name, m.Name)
-				require.Equal(t, c.inputMatchers[i].Value, m.Value)
-			}
-
-			if c.expectCacheAction == CacheHit {
-				require.Equal(t, cacheHitsBefore+1, getMetricValue(converter.metrics.cacheHitCount))
-				require.Equal(t, cacheTotalBefore+1, getMetricValue(converter.metrics.cacheTotalCount))
-			} else if c.expectCacheAction == CacheMiss {
-				require.Equal(t, cacheHitsBefore, getMetricValue(converter.metrics.cacheHitCount))
-				require.Equal(t, cacheTotalBefore+1, getMetricValue(converter.metrics.cacheTotalCount))
-			} else {
-				require.Equal(t, cacheHitsBefore, getMetricValue(converter.metrics.cacheHitCount))
-				require.Equal(t, cacheTotalBefore, getMetricValue(converter.metrics.cacheTotalCount))
-			}
-		})
-	}
-}
-
-func BenchmarkMatcherConverter_REWithAndWithoutCache(b *testing.B) {
-	reg := prometheus.NewRegistry()
-	converter, err := NewMatcherConverter(100, reg)
-	require.NoError(b, err)
-
-	nonTrivialRegexes := []LabelMatcher{
-		{Name: "job", Type: LabelMatcher_RE, Value: "^[a-zA-Z0-9_]+$"},
-		{Name: "env", Type: LabelMatcher_RE, Value: `prod|staging|dev`},
-		{Name: "error", Type: LabelMatcher_RE, Value: "^5\\d{2}$"},
-		{Name: "path", Type: LabelMatcher_RE, Value: "^/api/v[0-9]+/.*$"},
-		{Name: "version", Type: LabelMatcher_RE, Value: "^v[0-9]+\\.[0-9]+\\.[0-9]+$"},
-	}
-
-	b.Run("Without Cache", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, err := MatchersToPromMatchers(nonTrivialRegexes...)
-			require.NoError(b, err)
-		}
-	})
-
-	b.Run("With Cache", func(b *testing.B) {
-		// cache warm-up
-		for _, lm := range nonTrivialRegexes {
-			_, err := converter.MatchersToPromMatchers(lm)
-			require.NoError(b, err)
-		}
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, err := converter.MatchersToPromMatchers(nonTrivialRegexes...)
-			require.NoError(b, err)
-		}
-	})
 }
 
 func TestPromMatchersToMatchers_RedundantMatcherFiltering(t *testing.T) {

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -27,6 +27,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/filter"
 	"github.com/thanos-io/thanos/pkg/info/infopb"
 	"github.com/thanos-io/thanos/pkg/runutil"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
@@ -53,6 +54,12 @@ func WithCuckooMetricNameStoreFilter() TSDBStoreOption {
 	}
 }
 
+func WithMatcherCacheInstance(cache storecache.MatchersCache) TSDBStoreOption {
+	return func(s *TSDBStore) {
+		s.matcherCache = cache
+	}
+}
+
 // TSDBStore implements the store API against a local TSDB instance.
 // It attaches the provided external labels to all results. It only responds with raw data
 // and does not support downsampling.
@@ -62,6 +69,7 @@ type TSDBStore struct {
 	component        component.StoreAPI
 	buffers          sync.Pool
 	maxBytesPerFrame int
+	matcherCache     storecache.MatchersCache
 
 	extLset                labels.Labels
 	startStoreFilterUpdate bool
@@ -112,6 +120,7 @@ func NewTSDBStore(
 			b := make([]byte, 0, initialBufSize)
 			return &b
 		}},
+		matcherCache: storecache.NoopMatchersCache,
 	}
 
 	for _, option := range options {
@@ -177,13 +186,13 @@ func (s *TSDBStore) LabelSet() []labelpb.ZLabelSet {
 	return labelSets
 }
 
-func (p *TSDBStore) TSDBInfos() []infopb.TSDBInfo {
-	labels := p.LabelSet()
+func (s *TSDBStore) TSDBInfos() []infopb.TSDBInfo {
+	labels := s.LabelSet()
 	if len(labels) == 0 {
 		return []infopb.TSDBInfo{}
 	}
 
-	mint, maxt := p.TimeRange()
+	mint, maxt := s.TimeRange()
 	return []infopb.TSDBInfo{
 		{
 			Labels: labelpb.ZLabelSet{
@@ -247,7 +256,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_Ser
 		srv = fs
 	}
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset())
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset(), s.matcherCache)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -374,7 +383,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_Ser
 func (s *TSDBStore) LabelNames(ctx context.Context, r *storepb.LabelNamesRequest) (
 	*storepb.LabelNamesResponse, error,
 ) {
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset())
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset(), s.matcherCache)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -436,7 +445,7 @@ func (s *TSDBStore) LabelValues(ctx context.Context, r *storepb.LabelValuesReque
 		}
 	}
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset())
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset(), s.matcherCache)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -53,13 +53,6 @@ func WithCuckooMetricNameStoreFilter() TSDBStoreOption {
 	}
 }
 
-// WithTSDBStoreMatcherConverter returns a TSDBStoreOption that enables caching matcher converter for TSDBStore.
-func WithTSDBStoreMatcherConverter(mc *storepb.MatcherConverter) TSDBStoreOption {
-	return func(s *TSDBStore) {
-		s.matcherConverter = mc
-	}
-}
-
 // TSDBStore implements the store API against a local TSDB instance.
 // It attaches the provided external labels to all results. It only responds with raw data
 // and does not support downsampling.
@@ -76,7 +69,6 @@ type TSDBStore struct {
 	mtx                    sync.RWMutex
 	close                  func()
 	storepb.UnimplementedStoreServer
-	matcherConverter *storepb.MatcherConverter
 }
 
 func (s *TSDBStore) Close() {
@@ -255,7 +247,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_Ser
 		srv = fs
 	}
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset(), s.matcherConverter)
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset())
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -382,7 +374,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_Ser
 func (s *TSDBStore) LabelNames(ctx context.Context, r *storepb.LabelNamesRequest) (
 	*storepb.LabelNamesResponse, error,
 ) {
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset(), s.matcherConverter)
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -444,7 +436,7 @@ func (s *TSDBStore) LabelValues(ctx context.Context, r *storepb.LabelValuesReque
 		}
 	}
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset(), s.matcherConverter)
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.getExtLset())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

 ### Problem

  Severe lock contention in one db pod caused by TwoQueueCache.Get() taking a write lock on every access. Under high concurrency, 938 goroutines were blocked on this lock, causing:
  - 41x higher mutex wait time vs healthy pod (34M sec vs 823K sec)
  - 5x higher query latency (157ms vs 30ms avg)

###  Root Cause

  TwoQueueCache takes a write lock on Get (to update LRU recency). With many concurrent requests for the same regex matchers, all goroutines serialize on this single lock.

###  Solution

  Adopt upstream's implementation which adds singleflight.Group in front of the LRU cache. This ensures only one goroutine per unique cache key executes the lookup - others wait on a channel and receive the result directly, avoiding lock
  contention.

  Changes

  - Revert MatcherConverter with TwoQueueCache
  - Cherry-pick upstream commits: 626d0e5bf, bed76cf4d, 0d4263616
  - New flag: --matcher-cache-size (replaces --receive.store-matcher-converter-cache-capacity)
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
