### PR TITLE
Adding Telegraf in Pre-Aggregation

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -516,7 +516,7 @@ func secondsSinceFirstSample(toMS int64, ts prompb.TimeSeries) float64 {
 
 func isPreAgged(ts prompb.TimeSeries) bool {
 	for _, l := range ts.Labels {
-		if l.Name == labelPreAgg && (l.Value == "true" || l.Value == "v1") {
+		if l.Name == labelPreAgg && (l.Value == "true" || strings.HasPrefix(l.Value, "v")) {
 			return true
 		}
 	}

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -516,7 +516,7 @@ func secondsSinceFirstSample(toMS int64, ts prompb.TimeSeries) float64 {
 
 func isPreAgged(ts prompb.TimeSeries) bool {
 	for _, l := range ts.Labels {
-		if l.Name == labelPreAgg && l.Value == "true" {
+		if l.Name == labelPreAgg && (l.Value == "true" || l.Value == "v1") {
 			return true
 		}
 	}


### PR DESCRIPTION
## Changes

Adding `rollup=v1` to `isPreAgged` function to include Telegraf in pantheon write e2e latency recording rule. See t[hread here for more context](https://databricks.slack.com/archives/C0571400CK1/p1769458069944399?thread_ts=1767986290.460859&cid=C0571400CK1). 

## Verification

TBD: Did not test explicitly, but see Telegraf has `rollup=v1`
[See rollup for telegraf is `v1`](https://m3-aws-us-east-1-obs1.cloud.databricks.com/?g0.expr=count+by+%28__agg_rule_type__%2C+__rollup__%29+%28up%3Aavg%7Bkubernetes_namespace%3D%22obs-agent%22%7D%29&g0.tab=1&g0.Humanize+Labels=false&g0.Stacked=false&g0.UTC=true&g0.Full+Width=false&g0.startStr=now-1h&g0.endStr=now&g0.range_input=1h)