### PR TITLE
receive: Detach exemplar labels from pooled buffer

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -764,6 +764,10 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	// retention of the whole request buffer via zero-copy label references.
 	for i := range wreq.Timeseries {
 		labelpb.ReAllocZLabelsStrings(&wreq.Timeseries[i].Labels, h.writer.opts.Intern)
+		// Also detach exemplar labels from the pooled buffer.
+		for j := range wreq.Timeseries[i].Exemplars {
+			labelpb.ReAllocZLabelsStrings(&wreq.Timeseries[i].Exemplars[j].Labels, h.writer.opts.Intern)
+		}
 	}
 
 	responseStatusCode := http.StatusOK


### PR DESCRIPTION
Fixes a bug in #283 where exemplar labels were not detached from the pooled buffer, causing potential use-after-free issues when buffers are reused.

Exemplars also contain labels using zero-copy ZLabels that reference the underlying buffer. When the buffer is returned to the pool and reused:
  - Exemplar labels point to garbage data from the new request
  - **Result:** Data corruption, crashes, or incorrect exemplar data in TSDB

  The fix ensures both timeseries labels AND exemplar labels are detached from the pooled buffer before async processing.
