### PR TITLE
receive: Add map pooling and optimize sendLocalWrite to reduce alloca…

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -764,6 +764,10 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	// retention of the whole request buffer via zero-copy label references.
 	for i := range wreq.Timeseries {
 		labelpb.ReAllocZLabelsStrings(&wreq.Timeseries[i].Labels, h.writer.opts.Intern)
+		// Also detach exemplar labels from the pooled buffer.
+		for j := range wreq.Timeseries[i].Exemplars {
+			labelpb.ReAllocZLabelsStrings(&wreq.Timeseries[i].Exemplars[j].Labels, h.writer.opts.Intern)
+		}
 	}
 
 	responseStatusCode := http.StatusOK

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -1052,8 +1052,8 @@ func TestReceiveExtractsTenant(t *testing.T) {
 				Timeseries: []prompb.TimeSeries{
 					{
 						Labels: []prompb.Label{
-							{Name: tenantLabelName, Value: "tenant-1"},
 							{Name: "aa", Value: "bb"},
+							{Name: tenantLabelName, Value: "tenant-1"},
 						},
 						Samples: []prompb.Sample{
 							{Value: 1, Timestamp: time.Now().UnixMilli()},
@@ -1072,8 +1072,8 @@ func TestReceiveExtractsTenant(t *testing.T) {
 				Timeseries: []prompb.TimeSeries{
 					{
 						Labels: []prompb.Label{
-							{Name: tenantLabelName, Value: "tenant-2"},
 							{Name: "aa", Value: "bb"},
+							{Name: tenantLabelName, Value: "tenant-2"},
 						},
 						Samples: []prompb.Sample{
 							{Value: 1, Timestamp: time.Now().UnixMilli()},
@@ -1101,8 +1101,8 @@ func TestReceiveExtractsTenant(t *testing.T) {
 				Timeseries: []prompb.TimeSeries{
 					{
 						Labels: []prompb.Label{
-							{Name: tenantLabelName, Value: "tenant-3"},
 							{Name: "aa", Value: "bb"},
+							{Name: tenantLabelName, Value: "tenant-3"},
 						},
 						Samples: []prompb.Sample{
 							{Value: 1, Timestamp: time.Now().UnixMilli()},


### PR DESCRIPTION
…tions

This commit implements three optimizations targeting ~612GB of allocations (11% of total) identified through production CPU profiling.

**Optimization 1: Distribution Map Pooling (357GB, 6.41%)**
- Added sync.Pools for distribution maps (endpointReplicaMapPool, tenantSeriesMapPool)
- Added helper functions for map clearing with size guards
- Modified distributeTimeseriesToReplicas to use pools
- Added cleanup in fanoutForward

**Optimization 2: sendLocalWrite Improvements (255GB, 4.57%)**

Part A: Pool tenantSeriesMapping (10.30GB)
- Added tenantTimeseriesMappingPool sync.Pool
- Modified sendLocalWrite to get/return map from pool

Part B: Optimize loop and pre-allocate (244.65GB)
- Changed loop iteration from value to index (avoids copying TimeSeries structs)
- Pre-allocate slices with capacity hints (single-tenant and multi-tenant cases)
- Lazy allocation for multi-tenant scenarios

**Memory Safety:**
- Size guards prevent pool ballooning (max 100 entries)
- Maps cleared before reuse (no data leakage)
- Error path cleanup prevents pool leaks

**Testing:**
- Added TestDistributionMapPooling
- Added TestClearMapFunctions
- All existing tests pass

**Profiling Source:**
Cluster: dev-aws-us-east-1-obs-integrationtest
Namespace: pantheon
Pod: pantheon-db-rep0-0
Date: 2026-02-06

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
