### PR TITLE
Fix e2e test that broke after change to tenant label name

### DIFF
--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -1063,7 +1063,7 @@ func TestReceiveExtractsTenant(t *testing.T) {
 			})
 		}))
 
-		testutil.Ok(t, i.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"prometheus_tsdb_blocks_loaded"}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", "tenant-1")), e2emon.WaitMissingMetrics()))
+		testutil.Ok(t, i.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"prometheus_tsdb_blocks_loaded"}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", tenantLabelName+":tenant-1")), e2emon.WaitMissingMetrics()))
 	})
 
 	t.Run("tenant label is extracted from one series, default is used for the other one", func(t *testing.T) {
@@ -1148,8 +1148,10 @@ func TestReceiveExtractsTenant(t *testing.T) {
 			return err
 		}))
 
-		testutil.Ok(t, i.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"prometheus_tsdb_blocks_loaded"}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", "http-tenant")), e2emon.WaitMissingMetrics()))
-		testutil.Ok(t, i.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"prometheus_tsdb_blocks_loaded"}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", "tenant-3")), e2emon.WaitMissingMetrics()))
+		// When splitTenantLabelName is configured but the series doesn't have that label,
+		// the handler falls back to DefaultTenantID (not the HTTP header tenant).
+		testutil.Ok(t, i.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"prometheus_tsdb_blocks_loaded"}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", "default-tenant")), e2emon.WaitMissingMetrics()))
+		testutil.Ok(t, i.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"prometheus_tsdb_blocks_loaded"}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", tenantLabelName+":tenant-3")), e2emon.WaitMissingMetrics()))
 
 	})
 }


### PR DESCRIPTION
The label-based tenant attribution change (https://github.com/databricks/thanos/pull/270?timeline_per_page=5) broke one of the e2e tests that checked against the old format.