### PR TITLE
receive: Add --store.disable-series-resorting flag to bypass resortingServer

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -177,6 +177,11 @@ func runReceive(
 		level.Info(logger).Log("msg", "deterministic compaction delay enabled", "interval", conf.compactionDelayInterval.String())
 	}
 
+	if conf.storeDisableSeriesResorting {
+		multiTSDBOptions = append(multiTSDBOptions, receive.WithSeriesResortingDisabled())
+		level.Info(logger).Log("msg", "series resorting disabled for TSDB store queries")
+	}
+
 	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), conf.rwServerCert, conf.rwServerKey, conf.rwServerClientCA, conf.rwServerTlsMinVersion)
 	if err != nil {
 		return err
@@ -990,9 +995,10 @@ type receiveConfig struct {
 	relabelConfigPath        *extflag.PathOrContent
 	relabelConfigReloadTimer time.Duration
 
-	writeLimitsConfig       *extflag.PathOrContent
-	storeRateLimits         store.SeriesSelectLimits
-	limitsConfigReloadTimer time.Duration
+	writeLimitsConfig           *extflag.PathOrContent
+	storeDisableSeriesResorting bool
+	storeRateLimits             store.SeriesSelectLimits
+	limitsConfigReloadTimer     time.Duration
 
 	asyncForwardWorkerCount uint
 
@@ -1013,6 +1019,12 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	rc.httpBindAddr, rc.httpGracePeriod, rc.httpTLSConfig = extkingpin.RegisterHTTPFlags(cmd)
 	rc.grpcConfig.registerFlag(cmd)
 	rc.storeRateLimits.RegisterFlags(cmd)
+
+	cmd.Flag("store.disable-series-resorting",
+		"If true, series from the local TSDB are streamed directly without buffering and re-sorting. "+
+			"This prevents unbounded memory usage for large queries. "+
+			"Only safe when external labels (--label) do not conflict with labels in scraped metrics.").
+		Default("false").Hidden().BoolVar(&rc.storeDisableSeriesResorting)
 
 	cmd.Flag("remote-write.address", "Address to listen on for remote write requests.").
 		Default("0.0.0.0:19291").StringVar(&rc.rwAddress)

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -67,6 +67,7 @@ type MultiTSDB struct {
 	tsdbClients     []store.Client
 	exemplarClients map[string]*exemplars.TSDB
 
+	disableSeriesResorting   bool
 	metricNameFilterEnabled  bool
 	noUploadTenants          []string // Support both exact matches and prefix patterns (e.g., "tenant1", "prod-*")
 	enableTenantPathPrefix   bool
@@ -79,6 +80,13 @@ type MultiTSDB struct {
 
 // MultiTSDBOption is a functional option for MultiTSDB.
 type MultiTSDBOption func(mt *MultiTSDB)
+
+// WithSeriesResortingDisabled disables series resorting on TSDB store queries.
+func WithSeriesResortingDisabled() MultiTSDBOption {
+	return func(s *MultiTSDB) {
+		s.disableSeriesResorting = true
+	}
+}
 
 // WithMetricNameFilterEnabled enables metric name filtering on TSDB clients.
 func WithMetricNameFilterEnabled() MultiTSDBOption {
@@ -880,6 +888,9 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	}
 	if t.matcherCache != nil {
 		options = append(options, store.WithMatcherCacheInstance(t.matcherCache))
+	}
+	if t.disableSeriesResorting {
+		options = append(options, store.WithSeriesResortingDisabled())
 	}
 	tenant.set(store.NewTSDBStore(logger, s, component.Receive, lset, options...), s, ship, exemplars.NewTSDB(s, lset))
 	t.addTenantLocked(tenantID, tenant) // need to update the client list once store is ready & client != nil

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -60,6 +60,12 @@ func WithMatcherCacheInstance(cache storecache.MatchersCache) TSDBStoreOption {
 	}
 }
 
+func WithSeriesResortingDisabled() TSDBStoreOption {
+	return func(s *TSDBStore) {
+		s.disableSeriesResorting = true
+	}
+}
+
 // TSDBStore implements the store API against a local TSDB instance.
 // It attaches the provided external labels to all results. It only responds with raw data
 // and does not support downsampling.
@@ -74,6 +80,7 @@ type TSDBStore struct {
 	extLset                labels.Labels
 	startStoreFilterUpdate bool
 	storeFilter            filter.StoreFilter
+	disableSeriesResorting bool
 	mtx                    sync.RWMutex
 	close                  func()
 	storepb.UnimplementedStoreServer
@@ -251,7 +258,11 @@ func (s *TSDBStore) SeriesLocal(ctx context.Context, r *storepb.SeriesRequest) (
 func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_SeriesServer) error {
 	var srv flushableServer
 	if fs, ok := seriesSrv.(flushableServer); !ok {
-		srv = newFlushableServer(seriesSrv, sortingStrategyStore)
+		strategy := sortingStrategyStore
+		if s.disableSeriesResorting {
+			strategy = sortingStrategyNone
+		}
+		srv = newFlushableServer(seriesSrv, strategy)
 	} else {
 		srv = fs
 	}


### PR DESCRIPTION
resortingServer buffers all series in memory before sorting, causing unbounded memory growth for large queries. When external labels do not conflict with internal TSDB labels, re-sorting is unnecessary. This flag switches to streaming passthroughServer instead.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
