### PR TITLE
Add tenant labels to attribution mismatch metric

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -545,7 +545,7 @@ func (h *Handler) tenantKeyForDistribution(tenantHTTP string, ts prompb.TimeSeri
 		if h.options.TenantAttributor.IsVerifyMode() {
 			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
 			attributedTenant := h.options.TenantAttributor.GetTenantFromLabels(lbls)
-			h.options.TenantAttributor.RecordVerification(attributedTenant, tenantHTTP, lbls)
+			h.options.TenantAttributor.RecordVerification(attributedTenant, tenantHTTP)
 			return tenantHTTP
 		}
 

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -545,7 +545,7 @@ func (h *Handler) tenantKeyForDistribution(tenantHTTP string, ts prompb.TimeSeri
 		if h.options.TenantAttributor.IsVerifyMode() {
 			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
 			attributedTenant := h.options.TenantAttributor.GetTenantFromLabels(lbls)
-			h.options.TenantAttributor.RecordVerification(attributedTenant, tenantHTTP)
+			h.options.TenantAttributor.RecordVerification(attributedTenant, tenantHTTP, lbls)
 			return tenantHTTP
 		}
 

--- a/pkg/receive/tenant_attribution.go
+++ b/pkg/receive/tenant_attribution.go
@@ -40,7 +40,7 @@ type TenantAttributor struct {
 	// Metrics (only registered in verify mode)
 	verifyMode            bool
 	attributionMatches    prometheus.Counter
-	attributionMismatches prometheus.Counter
+	attributionMismatches *prometheus.CounterVec
 }
 
 // NewTenantAttributor creates a new TenantAttributor from a config file.
@@ -86,12 +86,12 @@ func NewTenantAttributorFromContent(
 			Name:      "tenant_attribution_matches_total",
 			Help:      "Total number of time series where attributed tenant matches HTTP header tenant.",
 		})
-		ta.attributionMismatches = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		ta.attributionMismatches = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "thanos",
 			Subsystem: "receive",
 			Name:      "tenant_attribution_mismatches_total",
 			Help:      "Total number of time series where attributed tenant differs from HTTP header tenant.",
-		})
+		}, []string{"http_tenant", "attributed_tenant"})
 	}
 
 	var ruleConfigs []TenantRuleConfig
@@ -153,7 +153,7 @@ func (ta *TenantAttributor) RecordVerification(attributedTenant, httpTenant stri
 		}
 	} else {
 		if ta.attributionMismatches != nil {
-			ta.attributionMismatches.Inc()
+			ta.attributionMismatches.WithLabelValues(httpTenant, attributedTenant).Inc()
 		}
 	}
 }

--- a/pkg/receive/tenant_attribution.go
+++ b/pkg/receive/tenant_attribution.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -159,15 +158,6 @@ func (ta *TenantAttributor) RecordVerification(attributedTenant, httpTenant stri
 	} else {
 		if ta.attributionMismatches != nil {
 			ta.attributionMismatches.WithLabelValues(httpTenant, attributedTenant).Inc()
-		}
-		// Log 1 in every 10000 mismatches for debugging
-		if atomic.AddUint64(&ta.sampleCounter, 1)%10000 == 1 {
-			level.Warn(ta.logger).Log(
-				"msg", "tenant attribution mismatch sample",
-				"http_tenant", httpTenant,
-				"attributed_tenant", attributedTenant,
-				"labels", lbls.String(),
-			)
 		}
 	}
 }

--- a/pkg/receive/tenant_attribution.go
+++ b/pkg/receive/tenant_attribution.go
@@ -146,8 +146,7 @@ func (ta *TenantAttributor) GetTenantFromLabels(lbls labels.Labels) string {
 
 // RecordVerification records match/mismatch metrics for verification mode.
 // httpTenant is the tenant from HTTP header (or default if no header).
-// lbls are the time series labels, used for sampled debug logging on mismatches.
-func (ta *TenantAttributor) RecordVerification(attributedTenant, httpTenant string, lbls labels.Labels) {
+func (ta *TenantAttributor) RecordVerification(attributedTenant, httpTenant string) {
 	if !ta.verifyMode {
 		return
 	}

--- a/pkg/receive/tenant_attribution.go
+++ b/pkg/receive/tenant_attribution.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -41,6 +42,9 @@ type TenantAttributor struct {
 	verifyMode            bool
 	attributionMatches    prometheus.Counter
 	attributionMismatches *prometheus.CounterVec
+
+	// Sampled logging for debugging mismatches
+	sampleCounter uint64
 }
 
 // NewTenantAttributor creates a new TenantAttributor from a config file.
@@ -143,7 +147,8 @@ func (ta *TenantAttributor) GetTenantFromLabels(lbls labels.Labels) string {
 
 // RecordVerification records match/mismatch metrics for verification mode.
 // httpTenant is the tenant from HTTP header (or default if no header).
-func (ta *TenantAttributor) RecordVerification(attributedTenant, httpTenant string) {
+// lbls are the time series labels, used for sampled debug logging on mismatches.
+func (ta *TenantAttributor) RecordVerification(attributedTenant, httpTenant string, lbls labels.Labels) {
 	if !ta.verifyMode {
 		return
 	}
@@ -154,6 +159,15 @@ func (ta *TenantAttributor) RecordVerification(attributedTenant, httpTenant stri
 	} else {
 		if ta.attributionMismatches != nil {
 			ta.attributionMismatches.WithLabelValues(httpTenant, attributedTenant).Inc()
+		}
+		// Log 1 in every 10000 mismatches for debugging
+		if atomic.AddUint64(&ta.sampleCounter, 1)%10000 == 1 {
+			level.Warn(ta.logger).Log(
+				"msg", "tenant attribution mismatch sample",
+				"http_tenant", httpTenant,
+				"attributed_tenant", attributedTenant,
+				"labels", lbls.String(),
+			)
 		}
 	}
 }

--- a/pkg/receive/tenant_attribution.go
+++ b/pkg/receive/tenant_attribution.go
@@ -41,9 +41,6 @@ type TenantAttributor struct {
 	verifyMode            bool
 	attributionMatches    prometheus.Counter
 	attributionMismatches *prometheus.CounterVec
-
-	// Sampled logging for debugging mismatches
-	sampleCounter uint64
 }
 
 // NewTenantAttributor creates a new TenantAttributor from a config file.


### PR DESCRIPTION
## Changes

- added expected and attributed tenants labels to mismatched tenants metric for debugging purposes
