### PR TITLE
Fix CapN Proto Retry Issue

### DIFF
--- a/pkg/receive/capnp_server.go
+++ b/pkg/receive/capnp_server.go
@@ -22,7 +22,7 @@ type CapNProtoServer struct {
 	logger   log.Logger
 }
 
-func NewCapNProtoServer(listener net.Listener, handler *CapNProtoHandler, logger log.Logger) *CapNProtoServer {
+func NewCapNProtoServer(listener net.Listener, handler writecapnp.Writer_Server, logger log.Logger) *CapNProtoServer {
 	return &CapNProtoServer{
 		listener: listener,
 		server:   writecapnp.Writer_ServerToClient(handler),

--- a/pkg/receive/capnproto_server_test.go
+++ b/pkg/receive/capnproto_server_test.go
@@ -111,12 +111,11 @@ func TestCapNProtoServer_MultipleSerialClientsWithReconnect(t *testing.T) {
 		wg.Wait()
 	}
 	require.NoError(t, client.Close())
-	require.NoError(t, errors.Join(listener.Close()))
+	require.NoError(t, listener.Close())
 }
 
 type faultyHandler struct {
 	mu          sync.Mutex
-	numReqs     int
 	numFailures int
 }
 

--- a/pkg/receive/capnproto_server_test.go
+++ b/pkg/receive/capnproto_server_test.go
@@ -5,11 +5,14 @@ package receive
 
 import (
 	"context"
+	"errors"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/testutil/custom"
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/thanos-io/thanos/pkg/receive/writecapnp"
@@ -77,4 +80,78 @@ func TestCapNProtoServer_MultipleConcurrentClients(t *testing.T) {
 	}
 
 	require.NoError(t, listener.Close())
+}
+
+func TestCapNProtoServer_MultipleSerialClientsWithReconnect(t *testing.T) {
+	custom.TolerantVerifyLeak(t)
+	var (
+		logger   = log.NewNopLogger()
+		listener = bufconn.Listen(1024)
+		handler  = newFaultyHandler(2)
+	)
+
+	srv := NewCapNProtoServer(listener, handler, logger)
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(srv.Shutdown)
+
+	client := writecapnp.NewRemoteWriteClient(listener, logger)
+	const numRuns = 100
+	const numRequests = 10
+	for range numRuns {
+		handler.numFailures = 2
+		var wg sync.WaitGroup
+		for range numRequests {
+			wg.Go(func() {
+				_, err := client.RemoteWrite(context.Background(), &storepb.WriteRequest{
+					Tenant: "default",
+				})
+				require.NoError(t, err)
+			})
+		}
+		wg.Wait()
+	}
+	require.NoError(t, client.Close())
+	require.NoError(t, errors.Join(listener.Close()))
+}
+
+type faultyHandler struct {
+	mu          sync.Mutex
+	numReqs     int
+	numFailures int
+}
+
+func newFaultyHandler(failEach int) *faultyHandler {
+	return &faultyHandler{numFailures: failEach}
+}
+
+func (f *faultyHandler) Write(ctx context.Context, call writecapnp.Writer_write) error {
+	call.Go()
+	if err := f.checkFailures(); err != nil {
+		return err
+	}
+
+	arg, err := call.Args().Wr()
+	if err != nil {
+		return err
+	}
+	if _, err := arg.Tenant(); err != nil {
+		return err
+	}
+	results, err := call.AllocResults()
+	if err != nil {
+		return err
+	}
+	results.SetError(writecapnp.WriteError_none)
+	return nil
+}
+
+func (f *faultyHandler) checkFailures() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.numFailures--
+	if f.numFailures > 0 {
+		return errors.New("handler failure")
+	}
+	return nil
 }

--- a/pkg/receive/capnproto_server_test.go
+++ b/pkg/receive/capnproto_server_test.go
@@ -98,17 +98,24 @@ func TestCapNProtoServer_MultipleSerialClientsWithReconnect(t *testing.T) {
 	const numRuns = 100
 	const numRequests = 10
 	for range numRuns {
+		handler.mu.Lock()
 		handler.numFailures = 2
+		handler.mu.Unlock()
 		var wg sync.WaitGroup
+		errs := make(chan error, numRequests)
 		for range numRequests {
-			wg.Go(func() {
-				_, err := client.RemoteWrite(context.Background(), &storepb.WriteRequest{
-					Tenant: "default",
-				})
-				require.NoError(t, err)
-			})
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := client.RemoteWrite(context.Background(), &storepb.WriteRequest{Tenant: "default"})
+				errs <- err
+			}()
 		}
 		wg.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
 	}
 	require.NoError(t, client.Close())
 	require.NoError(t, listener.Close())

--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -5,19 +5,38 @@ package writecapnp
 
 import (
 	"context"
+	"io"
 	"net"
 	"sync"
 
+	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/rpc"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/runutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
+
+type connState int
+
+const (
+	connStateDisconnected = iota
+	connStateError
+	connStateConnected
+)
+
+type conn struct {
+	mu sync.RWMutex
+
+	state  connState
+	closer io.Closer
+	writer Writer
+}
 
 type Dialer interface {
 	Dial() (net.Conn, error)
@@ -44,12 +63,9 @@ func (t TCPDialer) Dial() (net.Conn, error) {
 }
 
 type RemoteWriteClient struct {
-	mu sync.Mutex
-
 	dialer Dialer
-	conn   *rpc.Conn
+	conn   *conn
 
-	writer Writer
 	logger log.Logger
 }
 
@@ -57,38 +73,33 @@ func NewRemoteWriteClient(dialer Dialer, logger log.Logger) *RemoteWriteClient {
 	return &RemoteWriteClient{
 		dialer: dialer,
 		logger: logger,
+		conn:   &conn{},
 	}
 }
 
 func (r *RemoteWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRequest, _ ...grpc.CallOption) (*storepb.WriteResponse, error) {
-	return r.writeWithReconnect(ctx, 2, in)
-}
-
-func (r *RemoteWriteClient) writeWithReconnect(ctx context.Context, numReconnects int, in *storepb.WriteRequest) (*storepb.WriteResponse, error) {
-	if err := r.connect(ctx); err != nil {
+	const numAttempts = 3
+	var (
+		resp    Writer_write_Results
+		release func()
+		err     error
+	)
+	for range numAttempts {
+		if err := r.conn.connect(ctx, r.logger, r.dialer); err != nil {
+			return nil, err
+		}
+		if resp, release, err = r.write(ctx, in); err == nil {
+			break
+		}
+		r.conn.setStateError()
+		level.Warn(r.logger).Log("msg", "rpc failed, reconnecting", "err", err.Error())
+	}
+	if err != nil {
 		return nil, err
 	}
-
-	result, release := r.writer.Write(ctx, func(params Writer_write_Params) error {
-		wr, err := params.NewWr()
-		if err != nil {
-			return err
-		}
-		return BuildInto(wr, in.Tenant, in.Timeseries)
-	})
 	defer release()
 
-	s, err := result.Struct()
-	if err != nil {
-		if numReconnects > 0 {
-			level.Warn(r.logger).Log("msg", "rpc failed, reconnecting", "err", err)
-			r.Close()
-			return r.writeWithReconnect(ctx, numReconnects-1, in)
-		}
-		r.Close()
-		return nil, errors.Wrap(err, "failed writing to peer")
-	}
-	switch s.Error() {
+	switch resp.Error() {
 	case WriteError_unavailable:
 		return nil, status.Error(codes.Unavailable, "rpc failed")
 	case WriteError_alreadyExists:
@@ -102,29 +113,87 @@ func (r *RemoteWriteClient) writeWithReconnect(ctx context.Context, numReconnect
 	}
 }
 
-func (r *RemoteWriteClient) connect(ctx context.Context) error {
+func (r *RemoteWriteClient) write(ctx context.Context, in *storepb.WriteRequest) (Writer_write_Results, func(), error) {
+	r.conn.mu.RLock()
+	defer r.conn.mu.RUnlock()
+
+	arena := capnp.SingleSegment(nil)
+	defer arena.Release()
+
+	result, release := r.conn.writer.Write(ctx, func(params Writer_write_Params) error {
+		_, seg, err := capnp.NewMessage(arena)
+		if err != nil {
+			return err
+		}
+		wr, err := NewRootWriteRequest(seg)
+		if err != nil {
+			return err
+		}
+		if err := params.SetWr(wr); err != nil {
+			return err
+		}
+		wr, err = params.Wr()
+		if err != nil {
+			return err
+		}
+		return BuildInto(wr, in.Tenant, in.Timeseries)
+	})
+
+	resp, err := result.Struct()
+	return resp, release, err
+}
+
+func (r *conn) setStateError() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.conn != nil {
-		return nil
-	}
 
-	conn, err := r.dialer.Dial()
-	if err != nil {
-		return errors.Wrap(err, "failed to dial peer")
+	r.state = connStateError
+}
+
+func (r *conn) connect(ctx context.Context, logger log.Logger, dialer Dialer) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	switch r.state {
+	case connStateConnected:
+		return nil
+	case connStateError:
+		r.close(logger)
+		fallthrough
+	case connStateDisconnected:
+		cc, err := dialer.Dial()
+		if err != nil {
+			return errors.Wrap(err, "failed to dial peer")
+		}
+		codec := rpc.NewPackedStreamTransport(cc)
+		r.closer = codec
+
+		rpcConn := rpc.NewConn(codec, nil)
+		r.writer = Writer(rpcConn.Bootstrap(ctx))
+		r.state = connStateConnected
 	}
-	r.conn = rpc.NewConn(rpc.NewPackedStreamTransport(conn), nil)
-	r.writer = Writer(r.conn.Bootstrap(ctx))
 	return nil
 }
 
 func (r *RemoteWriteClient) Close() error {
-	r.mu.Lock()
-	if r.conn != nil {
-		conn := r.conn
-		r.conn = nil
-		go conn.Close()
-	}
-	r.mu.Unlock()
+	r.conn.closeLocked(r.logger)
 	return nil
+}
+
+func (r *conn) closeLocked(logger log.Logger) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.close(logger)
+}
+
+func (r *conn) close(logger log.Logger) {
+	if r.state != connStateDisconnected {
+		codec := r.closer
+		r.closer = nil
+		go func() {
+			runutil.CloseWithLogOnErr(logger, codec, "capnp closer")
+		}()
+	}
+	r.state = connStateDisconnected
 }

--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -5,7 +5,6 @@ package writecapnp
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -112,13 +111,7 @@ func (r *RemoteWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRe
 	case WriteError_invalidArgument:
 		return nil, status.Error(codes.InvalidArgument, "rpc failed")
 	case WriteError_internal:
-		extraContext, err := resp.ExtraErrorContext()
-		if err != nil || extraContext == "" {
-			extraContext = " (no additional context provided)"
-		} else {
-			extraContext = ": " + extraContext
-		}
-		return nil, status.Error(codes.Internal, fmt.Sprintf("rpc failed%s", extraContext))
+		return nil, status.Error(codes.Internal, "rpc failed")
 	default:
 		return &storepb.WriteResponse{}, nil
 	}

--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -5,6 +5,7 @@ package writecapnp
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -111,7 +112,13 @@ func (r *RemoteWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRe
 	case WriteError_invalidArgument:
 		return nil, status.Error(codes.InvalidArgument, "rpc failed")
 	case WriteError_internal:
-		return nil, status.Error(codes.Internal, "rpc failed")
+		extraContext, err := resp.ExtraErrorContext()
+		if err != nil || extraContext == "" {
+			extraContext = " (no additional context provided)"
+		} else {
+			extraContext = ": " + extraContext
+		}
+		return nil, status.Error(codes.Internal, fmt.Sprintf("rpc failed%s", extraContext))
 	default:
 		return &storepb.WriteResponse{}, nil
 	}

--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -5,7 +5,6 @@ package writecapnp
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -91,7 +90,7 @@ func (r *RemoteWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRe
 	for range numAttempts {
 		generation, err = r.conn.connect(ctx, r.logger, r.dialer)
 		if err != nil {
-			return nil, err
+			return nil, status.Error(codes.Unavailable, err.Error())
 		}
 		if resp, release, err = r.write(ctx, in); err == nil {
 			break
@@ -112,13 +111,7 @@ func (r *RemoteWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRe
 	case WriteError_invalidArgument:
 		return nil, status.Error(codes.InvalidArgument, "rpc failed")
 	case WriteError_internal:
-		extraContext, err := resp.ExtraErrorContext()
-		if err != nil || extraContext == "" {
-			extraContext = " (no additional context provided)"
-		} else {
-			extraContext = ": " + extraContext
-		}
-		return nil, status.Error(codes.Internal, fmt.Sprintf("rpc failed%s", extraContext))
+		return nil, status.Error(codes.Internal, "rpc failed")
 	default:
 		return &storepb.WriteResponse{}, nil
 	}
@@ -185,7 +178,13 @@ func (r *conn) connect(ctx context.Context, logger log.Logger, dialer Dialer) (u
 		r.closer = codec
 
 		rpcConn := rpc.NewConn(codec, nil)
-		r.writer = Writer(rpcConn.Bootstrap(ctx))
+		writer := Writer(rpcConn.Bootstrap(ctx))
+		if err := writer.Resolve(ctx); err != nil {
+			level.Warn(logger).Log("msg", "failed to bootstrap capnp writer, closing connection", "err", err)
+			r.close(logger)
+			return 0, errors.Wrap(err, "failed to bootstrap capnp writer")
+		}
+		r.writer = writer
 		r.state = connStateConnected
 		r.generation++
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
The Cap'n Proto client enters an infinite retry loop when a server becomes unavailable (e.g., during pod restarts). The root cause is that the client uses a lazy Bootstrap during connection setup, which returns a promise without verifying the server is actually reachable. Once a TCP connection is established, it's cached as "connected" — but the server is unresponsive at the RPC level. All subsequent writes hang until timeout, and since the stale connection is never cleaned up, the caller retries endlessly against the same broken connection.

1. Introduce a connection state machine (disconnected/error/connected) so that failed writes mark the connection as errored, forcing a reconnect on the next attempt instead of reusing the broken connection
2. Add a generation counter to prevent concurrent writers from accidentally marking a newly established connection as errored due to a failure from the previous one
3. Eagerly validate the connection via Resolve() during setup to fail fast when the server is unreachable, instead of discovering the failure only after sending a full write request
4. Return codes.Unavailable on connection failure so callers can correctly identify the error and apply appropriate retry strategies
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
