### PR TITLE
Fix capnp release leak on failed retry attempts

### DIFF
--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -95,6 +95,7 @@ func (r *RemoteWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRe
 		if resp, release, err = r.write(ctx, in); err == nil {
 			break
 		}
+		release()
 		r.conn.setStateErrorIfGeneration(generation)
 		level.Warn(r.logger).Log("msg", "rpc failed, reconnecting", "err", err.Error())
 	}


### PR DESCRIPTION
Release call resources immediately after each failed RPC attempt to prevent leaking Cap'n Proto call resources during retries.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
