### PR TITLE
receive: Add TSDB commit duration metric to receive writer

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -275,7 +275,7 @@ func runReceive(
 	writer := receive.NewWriter(log.With(logger, "component", "receive-writer"), dbs, &receive.WriterOptions{
 		Intern:                   conf.writerInterning,
 		TooFarInFutureTimeWindow: int64(time.Duration(*conf.tsdbTooFarInFutureTimeWindow)),
-	})
+	}, reg)
 
 	var limitsConfig *receive.RootLimitsConfig
 	if conf.writeLimitsConfig != nil {

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -302,7 +302,7 @@ func newTestHandlerHashring(
 			ReplicaHeader:     DefaultReplicaHeader,
 			ReplicationFactor: replicationFactor,
 			ForwardTimeout:    5 * time.Minute,
-			Writer:            NewWriter(log.NewNopLogger(), newFakeTenantAppendable(appendables[i]), wOpts),
+			Writer:            NewWriter(log.NewNopLogger(), newFakeTenantAppendable(appendables[i]), wOpts, prometheus.NewRegistry()),
 			Limiter:           limiter,
 		})
 		handlers = append(handlers, h)
@@ -1166,7 +1166,7 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 		metadata.NoneFunc,
 	)
 	defer func() { testutil.Ok(b, m.Close()) }()
-	handler.writer = NewWriter(logger, m, &WriterOptions{})
+	handler.writer = NewWriter(logger, m, &WriterOptions{}, prometheus.NewRegistry())
 
 	testutil.Ok(b, m.Flush())
 	testutil.Ok(b, m.Open())

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -56,19 +58,28 @@ type WriterOptions struct {
 }
 
 type Writer struct {
-	logger    log.Logger
-	multiTSDB TenantStorage
-	opts      *WriterOptions
+	logger         log.Logger
+	multiTSDB      TenantStorage
+	opts           *WriterOptions
+	commitDuration prometheus.Histogram
 }
 
-func NewWriter(logger log.Logger, multiTSDB TenantStorage, opts *WriterOptions) *Writer {
-	if opts == nil {
+func NewWriter(logger log.Logger, multiTSDB TenantStorage, opts *WriterOptions, reg prometheus.Registerer) *Writer {
+	if opts ==
+		nil {
 		opts = &WriterOptions{}
 	}
 	return &Writer{
 		logger:    logger,
 		multiTSDB: multiTSDB,
 		opts:      opts,
+		commitDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Namespace: "thanos",
+			Subsystem: "receive",
+			Name:      "writer_commit_duration_seconds",
+			Help:      "Duration of TSDB commit calls in seconds.",
+			Buckets:   prometheus.DefBuckets,
+		}),
 	}
 }
 
@@ -163,8 +174,10 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq []prompb.TimeS
 	}
 
 	errs := errorTracker.collectErrors(tLogger)
+	commitStart := time.Now()
 	if err := app.Commit(); err != nil {
 		errs.Add(errors.Wrap(err, "commit samples"))
 	}
+	r.commitDuration.Observe(time.Since(commitStart).Seconds())
 	return errs.ErrOrNil()
 }

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -78,7 +78,7 @@ func NewWriter(logger log.Logger, multiTSDB TenantStorage, opts *WriterOptions, 
 			Subsystem: "receive",
 			Name:      "writer_commit_duration_seconds",
 			Help:      "Duration of TSDB commit calls in seconds.",
-			Buckets:   prometheus.DefBuckets,
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 16),
 		}),
 	}
 }

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -333,7 +333,7 @@ func TestWriter(t *testing.T) {
 			t.Run("proto_writer", func(t *testing.T) {
 				logger, m, app := setupMultitsdb(t, testData.maxExemplars)
 
-				w := NewWriter(logger, m, testData.opts)
+				w := NewWriter(logger, m, testData.opts, prometheus.NewRegistry())
 
 				for idx, req := range testData.reqs {
 					err := w.Write(context.Background(), tenancy.DefaultTenant, req.Timeseries)
@@ -504,7 +504,7 @@ func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int, generateHistogr
 	}
 
 	b.Run("without interning", func(b *testing.B) {
-		w := NewWriter(logger, m, &WriterOptions{Intern: false})
+		w := NewWriter(logger, m, &WriterOptions{Intern: false}, prometheus.NewRegistry())
 
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -515,7 +515,7 @@ func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int, generateHistogr
 	})
 
 	b.Run("with interning", func(b *testing.B) {
-		w := NewWriter(logger, m, &WriterOptions{Intern: true})
+		w := NewWriter(logger, m, &WriterOptions{Intern: true}, prometheus.NewRegistry())
 
 		b.ReportAllocs()
 		b.ResetTimer()


### PR DESCRIPTION
  ## Changes

  Add a new Prometheus histogram metric `thanos_receive_writer_commit_duration_seconds` to track
  the latency of TSDB `Commit()` calls in the receive writer.

  Previously there was no way to observe how quickly metric samples are persisted to disk.
  The existing `thanos_receive_write_e2e_latency_seconds` covers full end-to-end ingestion latency
  but does not isolate the disk commit step. This metric makes that visible so we can track
  changes in storage performance over time.

  ## Verification

  1. Tested with unit tests (`go test -run TestWriter ./pkg/receive/...`).
  2. Passed CI
  3. Verified in integtest env, saw metrics got emitted 

