### PR TITLE
[ENGMP-365] Add protection statistics to range query log

### DIFF
--- a/pkg/queryfrontend/protection.go
+++ b/pkg/queryfrontend/protection.go
@@ -20,7 +20,7 @@ const (
 type ProtectionResult struct {
 	Triggered bool
 	RuleName  string
-	Action    string // "log" or "block"
+	Action    RuleAction
 }
 
 type protectionContextKey int
@@ -37,4 +37,16 @@ func WithProtectionResult(ctx context.Context, result *ProtectionResult) context
 func GetProtectionResult(ctx context.Context) *ProtectionResult {
 	result, _ := ctx.Value(protectionResultKey).(*ProtectionResult)
 	return result
+}
+
+// RuleActionToString converts a RuleAction to a string.
+func RuleActionToString(action RuleAction) string {
+	switch action {
+	case RuleActionLog:
+		return "RuleActionLog"
+	case RuleActionBlock:
+		return "RuleActionBlock"
+	default:
+		return "Unknown RuleAction"
+	}
 }

--- a/pkg/queryfrontend/protection.go
+++ b/pkg/queryfrontend/protection.go
@@ -1,0 +1,40 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package queryfrontend
+
+import (
+	"context"
+)
+
+// RuleAction represents the action to take when a protection rule is triggered.
+type RuleAction int
+
+const (
+	RuleActionLog   RuleAction = iota
+	RuleActionBlock RuleAction = iota
+)
+
+// ProtectionResult holds the result of evaluating protection rules against a query.
+// It is stored in the context by the protection middleware and read by the logging middleware.
+type ProtectionResult struct {
+	Triggered bool
+	RuleName  string
+	Action    string // "log" or "block"
+}
+
+type protectionContextKey int
+
+const protectionResultKey protectionContextKey = iota
+
+// WithProtectionResult stores a ProtectionResult in the context.
+func WithProtectionResult(ctx context.Context, result *ProtectionResult) context.Context {
+	return context.WithValue(ctx, protectionResultKey, result)
+}
+
+// GetProtectionResult retrieves a ProtectionResult from the context.
+// Returns nil if no result is stored.
+func GetProtectionResult(ctx context.Context) *ProtectionResult {
+	result, _ := ctx.Value(protectionResultKey).(*ProtectionResult)
+	return result
+}

--- a/pkg/queryfrontend/protection.go
+++ b/pkg/queryfrontend/protection.go
@@ -43,10 +43,10 @@ func GetProtectionResult(ctx context.Context) *ProtectionResult {
 func RuleActionToString(action RuleAction) string {
 	switch action {
 	case RuleActionLog:
-		return "RuleActionLog"
+		return "Log"
 	case RuleActionBlock:
-		return "RuleActionBlock"
+		return "Block"
 	default:
-		return "Unknown RuleAction"
+		return "Unknown"
 	}
 }

--- a/pkg/queryfrontend/queryrange_logger.go
+++ b/pkg/queryfrontend/queryrange_logger.go
@@ -61,7 +61,7 @@ type MetricsRangeQueryLogging struct {
 	// Protection fields
 	ProtectionTriggered bool   `json:"protectionTriggered"` // Whether a protection rule was triggered
 	ProtectionRuleName  string `json:"protectionRuleName"`  // Name of the rule that triggered
-	ProtectionAction    string `json:"protectionAction"`    // "RuleActionLog" or "RuleActionBlock"
+	ProtectionAction    string `json:"protectionAction"`    // "Log" or "Block"
 }
 
 // RangeQueryLogConfig holds configuration for range query logging.

--- a/pkg/queryfrontend/queryrange_logger.go
+++ b/pkg/queryfrontend/queryrange_logger.go
@@ -61,7 +61,7 @@ type MetricsRangeQueryLogging struct {
 	// Protection fields
 	ProtectionTriggered bool   `json:"protectionTriggered"` // Whether a protection rule was triggered
 	ProtectionRuleName  string `json:"protectionRuleName"`  // Name of the rule that triggered
-	ProtectionAction    string `json:"protectionAction"`    // Action taken: "log" or "block"
+	ProtectionAction    string `json:"protectionAction"`    // "RuleActionLog" or "RuleActionBlock"
 }
 
 // RangeQueryLogConfig holds configuration for range query logging.
@@ -158,7 +158,7 @@ func (m *rangeQueryLoggingMiddleware) logRangeQuery(ctx context.Context, req *Th
 	if result := GetProtectionResult(ctx); result != nil {
 		protectionTriggered = result.Triggered
 		protectionRuleName = result.RuleName
-		protectionAction = result.Action
+		protectionAction = RuleActionToString(result.Action)
 	}
 
 	// Create the range query log entry.

--- a/pkg/queryfrontend/queryrange_logger.go
+++ b/pkg/queryfrontend/queryrange_logger.go
@@ -58,6 +58,10 @@ type MetricsRangeQueryLogging struct {
 	Shard                 string   `json:"shard"`                 // Pantheon shard name
 	// Store-matcher details
 	StoreMatchers []StoreMatcherSet `json:"storeMatchers"`
+	// Protection fields
+	ProtectionTriggered bool   `json:"protectionTriggered"` // Whether a protection rule was triggered
+	ProtectionRuleName  string `json:"protectionRuleName"`  // Name of the rule that triggered
+	ProtectionAction    string `json:"protectionAction"`    // Action taken: "log" or "block"
 }
 
 // RangeQueryLogConfig holds configuration for range query logging.
@@ -130,13 +134,13 @@ func (m *rangeQueryLoggingMiddleware) Do(ctx context.Context, r queryrange.Reque
 	// Calculate latency.
 	latencyMs := time.Since(startTime).Milliseconds()
 
-	// Log the range query.
-	m.logRangeQuery(rangeReq, resp, err, latencyMs)
+	// Log the range query, passing ctx so protection results can be read.
+	m.logRangeQuery(ctx, rangeReq, resp, err, latencyMs)
 
 	return resp, err
 }
 
-func (m *rangeQueryLoggingMiddleware) logRangeQuery(req *ThanosQueryRangeRequest, resp queryrange.Response, err error, latencyMs int64) {
+func (m *rangeQueryLoggingMiddleware) logRangeQuery(ctx context.Context, req *ThanosQueryRangeRequest, resp queryrange.Response, err error, latencyMs int64) {
 	success := err == nil
 	userInfo := ExtractUserInfoFromHeaders(req.Headers)
 
@@ -146,6 +150,15 @@ func (m *rangeQueryLoggingMiddleware) logRangeQuery(req *ThanosQueryRangeRequest
 	if success && resp != nil {
 		stats = GetResponseStats(resp)
 		metricNames = ExtractMetricNames(resp)
+	}
+
+	// Read protection result from context (written by protection middleware).
+	var protectionTriggered bool
+	var protectionRuleName, protectionAction string
+	if result := GetProtectionResult(ctx); result != nil {
+		protectionTriggered = result.Triggered
+		protectionRuleName = result.RuleName
+		protectionAction = result.Action
 	}
 
 	// Create the range query log entry.
@@ -188,6 +201,10 @@ func (m *rangeQueryLoggingMiddleware) logRangeQuery(req *ThanosQueryRangeRequest
 		Shard:                 os.Getenv("PANTHEON_SHARDNAME"),
 		// Store-matcher details
 		StoreMatchers: ConvertStoreMatchers(req.StoreMatchers),
+		// Protection fields
+		ProtectionTriggered: protectionTriggered,
+		ProtectionRuleName:  protectionRuleName,
+		ProtectionAction:    protectionAction,
 	}
 
 	// Log to file if available.


### PR DESCRIPTION
## What
  Add protection statistics to the range query log to provide visibility into query protection results in Logfood.

  - Added `protection_triggered`, `protection_rule_name`, `protection_action` fields to `MetricsRangeQueryLogging`
  - Added core data structures (`ProtectionResult`, `RuleAction`) to support passing protection results through request context to the logger

  ## Why
  When the protection middleware evaluates a query, the result needs to be visible in Logfood for monitoring and debugging. The protection middleware writes `ProtectionResult` to the request context; the logging middleware reads it and logs the result.

  ## Related
  - Design doc: https://docs.google.com/document/d/1kYmaL_84tU1OfYkKnfsvaOhZuvNwBRS9Anf4C11ZSfA
  - Universe proto PR: [databricks-eng/universe#1696686](https://github.com/databricks-eng/universe/pull/1696686)