### PR TITLE
receive: Disable shuffle sharding for default tenant

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -720,7 +720,7 @@ func setupHashring(g *run.Group,
 					webHandler.Hashring(receive.SingleNodeHashring(conf.endpoint))
 					level.Info(logger).Log("msg", "Empty hashring config. Set up single node hashring.")
 				} else {
-					h, err := receive.NewMultiHashring(algorithm, conf.replicationFactor, c, reg)
+					h, err := receive.NewMultiHashring(algorithm, conf.replicationFactor, c, reg, conf.defaultTenantID)
 					if err != nil {
 						return errors.Wrap(err, "unable to create new hashring from config")
 					}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -336,7 +336,7 @@ func newTestHandlerHashring(
 		hashringAlgo = AlgorithmHashmod
 	}
 
-	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg, prometheus.NewRegistry())
+	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg, prometheus.NewRegistry(), "")
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -361,6 +361,8 @@ type shuffleShardHashring struct {
 
 	replicationFactor uint64
 
+	defaultTenantID string
+
 	nodes []Endpoint
 
 	// cache stores tenant-specific subrings. The value is Hashring to support both
@@ -421,7 +423,7 @@ func newShuffleShardCacheMetrics(reg prometheus.Registerer, hashringName string)
 }
 
 // newShuffleShardHashring creates a new shuffle sharding hashring wrapper.
-func newShuffleShardHashring(baseRing Hashring, shuffleShardingConfig ShuffleShardingConfig, replicationFactor uint64, reg prometheus.Registerer, name string) (*shuffleShardHashring, error) {
+func newShuffleShardHashring(baseRing Hashring, shuffleShardingConfig ShuffleShardingConfig, replicationFactor uint64, reg prometheus.Registerer, name string, defaultTenantID string) (*shuffleShardHashring, error) {
 	l := log.NewNopLogger()
 
 	level.Info(l).Log(
@@ -462,6 +464,7 @@ func newShuffleShardHashring(baseRing Hashring, shuffleShardingConfig ShuffleSha
 		baseRing:              baseRing,
 		shuffleShardingConfig: shuffleShardingConfig,
 		replicationFactor:     replicationFactor,
+		defaultTenantID:       defaultTenantID,
 		cache:                 cache,
 		metrics:               metrics,
 	}
@@ -582,6 +585,10 @@ func ShuffleShardSeed(identifier, zone string) int64 {
 }
 
 func (s *shuffleShardHashring) getTenantShardCached(tenant string) (Hashring, error) {
+	if s.defaultTenantID != "" && tenant == s.defaultTenantID {
+		return s.baseRing, nil
+	}
+
 	s.metrics.requestsTotal.Inc()
 
 	cached, ok := s.cache.Get(tenant)
@@ -943,7 +950,7 @@ func (s *shuffleShardHashring) GetN(tenant string, ts *prompb.TimeSeries, n uint
 // groups.
 // Which hashring to use for a tenant is determined
 // by the tenants field of the hashring configuration.
-func NewMultiHashring(algorithm HashringAlgorithm, replicationFactor uint64, cfg []HashringConfig, reg prometheus.Registerer) (Hashring, error) {
+func NewMultiHashring(algorithm HashringAlgorithm, replicationFactor uint64, cfg []HashringConfig, reg prometheus.Registerer, defaultTenantID string) (Hashring, error) {
 	m := &multiHashring{
 		cache: make(map[string]Hashring),
 	}
@@ -960,7 +967,7 @@ func NewMultiHashring(algorithm HashringAlgorithm, replicationFactor uint64, cfg
 		if h.Algorithm != "" {
 			activeAlgorithm = h.Algorithm
 		}
-		hashring, err = newHashring(activeAlgorithm, h.Endpoints, replicationFactor, h.Hashring, h.Tenants, h.ShuffleShardingConfig, reg, numShardsGauge)
+		hashring, err = newHashring(activeAlgorithm, h.Endpoints, replicationFactor, h.Hashring, h.Tenants, h.ShuffleShardingConfig, reg, numShardsGauge, defaultTenantID)
 		if err != nil {
 			return nil, err
 		}
@@ -981,7 +988,7 @@ func NewMultiHashring(algorithm HashringAlgorithm, replicationFactor uint64, cfg
 	return m, nil
 }
 
-func newHashring(algorithm HashringAlgorithm, endpoints []Endpoint, replicationFactor uint64, hashring string, tenants []string, shuffleShardingConfig ShuffleShardingConfig, reg prometheus.Registerer, numShardsGauge *prometheus.GaugeVec) (Hashring, error) {
+func newHashring(algorithm HashringAlgorithm, endpoints []Endpoint, replicationFactor uint64, hashring string, tenants []string, shuffleShardingConfig ShuffleShardingConfig, reg prometheus.Registerer, numShardsGauge *prometheus.GaugeVec, defaultTenantID string) (Hashring, error) {
 
 	switch algorithm {
 	case AlgorithmHashmod:
@@ -1005,7 +1012,7 @@ func newHashring(algorithm HashringAlgorithm, endpoints []Endpoint, replicationF
 			if shuffleShardingConfig.ShardSize.Value > len(endpoints) {
 				return nil, fmt.Errorf("shard size %d is larger than number of nodes in hashring %s (%d)", shuffleShardingConfig.ShardSize.Value, hashring, len(endpoints))
 			}
-			return newShuffleShardHashring(ringImpl, shuffleShardingConfig, replicationFactor, reg, hashring)
+			return newShuffleShardHashring(ringImpl, shuffleShardingConfig, replicationFactor, reg, hashring, defaultTenantID)
 		}
 		return ringImpl, nil
 	case AlgorithmRendezvous:
@@ -1024,7 +1031,7 @@ func newHashring(algorithm HashringAlgorithm, endpoints []Endpoint, replicationF
 					return nil, fmt.Errorf("shard size %d is larger than number of nodes in hashring %s (%d)", shuffleShardingConfig.ShardSize.Value, hashring, len(endpoints))
 				}
 			}
-			return newShuffleShardHashring(ringImpl, shuffleShardingConfig, replicationFactor, reg, hashring)
+			return newShuffleShardHashring(ringImpl, shuffleShardingConfig, replicationFactor, reg, hashring, defaultTenantID)
 		}
 		return ringImpl, nil
 	default:

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -201,7 +201,7 @@ func TestHashringGet(t *testing.T) {
 			tenant: "t2",
 		},
 	} {
-		hs, err := NewMultiHashring(AlgorithmHashmod, 3, tc.cfg, prometheus.NewRegistry())
+		hs, err := NewMultiHashring(AlgorithmHashmod, 3, tc.cfg, prometheus.NewRegistry(), "")
 		require.NoError(t, err)
 
 		h, err := hs.Get(tc.tenant, ts)
@@ -669,7 +669,7 @@ func TestInvalidAZHashringCfg(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			_, err := NewMultiHashring(tt.algorithm, tt.replicas, tt.cfg, prometheus.NewRegistry())
+			_, err := NewMultiHashring(tt.algorithm, tt.replicas, tt.cfg, prometheus.NewRegistry(), "")
 			require.EqualError(t, err, tt.expectedError)
 		})
 	}
@@ -794,7 +794,7 @@ func TestShuffleShardHashring(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create the shuffle shard hashring
-			shardRing, err := newShuffleShardHashring(baseRing, tc.shuffleShardCfg, 2, prometheus.NewRegistry(), "test")
+			shardRing, err := newShuffleShardHashring(baseRing, tc.shuffleShardCfg, 2, prometheus.NewRegistry(), "test", "")
 			require.NoError(t, err)
 
 			// Test that the shuffle sharding is consistent
@@ -969,13 +969,13 @@ func TestShuffleShardHashringStability(t *testing.T) {
 			// Create initial hashring
 			initialBaseRing, err := newKetamaHashring(initialEndpoints, SectionsPerNode, 1)
 			require.NoError(t, err)
-			initialShardRing, err := newShuffleShardHashring(initialBaseRing, shuffleShardCfg, 1, prometheus.NewRegistry(), "test-initial")
+			initialShardRing, err := newShuffleShardHashring(initialBaseRing, shuffleShardCfg, 1, prometheus.NewRegistry(), "test-initial", "")
 			require.NoError(t, err)
 
 			// Create scaled hashring
 			scaledBaseRing, err := newKetamaHashring(scaledEndpoints, SectionsPerNode, 1)
 			require.NoError(t, err)
-			scaledShardRing, err := newShuffleShardHashring(scaledBaseRing, shuffleShardCfg, 1, prometheus.NewRegistry(), "test-scaled")
+			scaledShardRing, err := newShuffleShardHashring(scaledBaseRing, shuffleShardCfg, 1, prometheus.NewRegistry(), "test-scaled", "")
 			require.NoError(t, err)
 
 			totalDiffs := 0
@@ -1163,4 +1163,144 @@ func TestGroupByAZ(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestShuffleShardDefaultTenantBypass(t *testing.T) {
+	defaultTenant := "default-tenant"
+	regularTenant := "regular-tenant"
+
+	t.Run("ketama", func(t *testing.T) {
+		endpoints := make([]Endpoint, 10)
+		for i := range endpoints {
+			endpoints[i] = Endpoint{Address: fmt.Sprintf("node-%d", i)}
+		}
+		baseRing, err := newKetamaHashring(endpoints, SectionsPerNode, 2)
+		require.NoError(t, err)
+		shardRing, err := newShuffleShardHashring(baseRing, ShuffleShardingConfig{
+			ShardSize: ShardSize{Value: 3},
+		}, 2, prometheus.NewRegistry(), "test-ketama", defaultTenant)
+		require.NoError(t, err)
+
+		// Default tenant should use all 10 endpoints (base ring).
+		defaultNodes := make(map[string]struct{})
+		for i := 0; i < 1000; i++ {
+			ts := &prompb.TimeSeries{
+				Labels: []labelpb.ZLabel{
+					{Name: "series", Value: fmt.Sprintf("%d", i)},
+				},
+			}
+			ep, err := shardRing.GetN(defaultTenant, ts, 0)
+			require.NoError(t, err)
+			defaultNodes[ep.Address] = struct{}{}
+		}
+		require.Len(t, defaultNodes, 10,
+			"default tenant should use all 10 endpoints, got %d", len(defaultNodes))
+
+		// Regular tenant should be sharded to 3 endpoints.
+		regularNodes := make(map[string]struct{})
+		for i := 0; i < 1000; i++ {
+			ts := &prompb.TimeSeries{
+				Labels: []labelpb.ZLabel{
+					{Name: "series", Value: fmt.Sprintf("%d", i)},
+				},
+			}
+			ep, err := shardRing.GetN(regularTenant, ts, 0)
+			require.NoError(t, err)
+			regularNodes[ep.Address] = struct{}{}
+		}
+		require.Len(t, regularNodes, 3,
+			"regular tenant should use exactly 3 endpoints, got %d", len(regularNodes))
+
+		// Default tenant should not occupy LRU cache slot.
+		_, cached := shardRing.cache.Get(defaultTenant)
+		require.False(t, cached, "default tenant should not be in cache")
+	})
+
+	t.Run("rendezvous", func(t *testing.T) {
+		// Create 3 AZs with 4 shards each (replication factor = 3).
+		endpoints := make([]Endpoint, 0, 12)
+		azs := []string{"az-a", "az-b", "az-c"}
+		for _, az := range azs {
+			for ord := 0; ord < 4; ord++ {
+				endpoints = append(endpoints, Endpoint{
+					Address: fmt.Sprintf("node-%s-%d.svc.cluster.local:10901", az, ord),
+					AZ:      az,
+					Shard:   ord,
+				})
+			}
+		}
+
+		baseRing, err := newRendezvousHashring(endpoints, 3)
+		require.NoError(t, err)
+		shardRing, err := newShuffleShardHashring(baseRing, ShuffleShardingConfig{
+			ShardSize: ShardSize{Value: 6},
+		}, 3, prometheus.NewRegistry(), "test-rendezvous", defaultTenant)
+		require.NoError(t, err)
+
+		// Default tenant should reach all shards in the base ring (4 shards x 3 AZs = 12 endpoints).
+		defaultNodes := make(map[string]struct{})
+		for n := uint64(0); n < 3; n++ {
+			for i := 0; i < 1000; i++ {
+				ts := &prompb.TimeSeries{
+					Labels: []labelpb.ZLabel{
+						{Name: "series", Value: fmt.Sprintf("%d", i)},
+					},
+				}
+				ep, err := shardRing.GetN(defaultTenant, ts, n)
+				require.NoError(t, err)
+				defaultNodes[ep.Address] = struct{}{}
+			}
+		}
+		require.Len(t, defaultNodes, 12,
+			"default tenant should use all 12 endpoints, got %d", len(defaultNodes))
+
+		// Regular tenant should use a subset (2 shards x 3 AZs = 6 endpoints).
+		regularNodes := make(map[string]struct{})
+		for n := uint64(0); n < 3; n++ {
+			for i := 0; i < 1000; i++ {
+				ts := &prompb.TimeSeries{
+					Labels: []labelpb.ZLabel{
+						{Name: "series", Value: fmt.Sprintf("%d", i)},
+					},
+				}
+				ep, err := shardRing.GetN(regularTenant, ts, n)
+				require.NoError(t, err)
+				regularNodes[ep.Address] = struct{}{}
+			}
+		}
+		require.Len(t, regularNodes, 6,
+			"regular tenant should use exactly 6 endpoints (2 shards x 3 AZs), got %d", len(regularNodes))
+
+		// Default tenant should not occupy LRU cache slot.
+		_, cached := shardRing.cache.Get(defaultTenant)
+		require.False(t, cached, "default tenant should not be in cache")
+	})
+
+	// Empty defaultTenantID means no bypass.
+	t.Run("empty_default_tenant_id_no_bypass", func(t *testing.T) {
+		endpoints := make([]Endpoint, 10)
+		for i := range endpoints {
+			endpoints[i] = Endpoint{Address: fmt.Sprintf("node-%d", i)}
+		}
+		baseRing, err := newKetamaHashring(endpoints, SectionsPerNode, 2)
+		require.NoError(t, err)
+		shardRing, err := newShuffleShardHashring(baseRing, ShuffleShardingConfig{
+			ShardSize: ShardSize{Value: 3},
+		}, 2, prometheus.NewRegistry(), "test-no-bypass", "")
+		require.NoError(t, err)
+
+		nodes := make(map[string]struct{})
+		for i := 0; i < 1000; i++ {
+			ts := &prompb.TimeSeries{
+				Labels: []labelpb.ZLabel{
+					{Name: "series", Value: fmt.Sprintf("%d", i)},
+				},
+			}
+			ep, err := shardRing.GetN(defaultTenant, ts, 0)
+			require.NoError(t, err)
+			nodes[ep.Address] = struct{}{}
+		}
+		require.Len(t, nodes, 3,
+			"with empty defaultTenantID, 'default-tenant' should still be sharded to 3 endpoints")
+	})
 }

--- a/pkg/receive/rendezvous_hashring_test.go
+++ b/pkg/receive/rendezvous_hashring_test.go
@@ -299,7 +299,7 @@ func TestRendezvousShuffleShardingBasic(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-rendezvous")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-rendezvous", "")
 	require.NoError(t, err)
 
 	tenant := "test-tenant"
@@ -350,7 +350,7 @@ func TestRendezvousShuffleShardingConsistency(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-consistency")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-consistency", "")
 	require.NoError(t, err)
 
 	tenant := "consistent-tenant"
@@ -386,7 +386,7 @@ func TestRendezvousShuffleShardingDifferentTenants(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 9},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-diff-tenants")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-diff-tenants", "")
 	require.NoError(t, err)
 
 	tenantShards := make(map[string][]int)
@@ -425,7 +425,7 @@ func TestRendezvousShuffleShardingPreservesAlignment(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-preserves")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-preserves", "")
 	require.NoError(t, err)
 
 	tenant := "alignment-test-tenant"
@@ -474,7 +474,7 @@ func TestRendezvousShuffleShardingDataDistribution(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-distribution")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-distribution", "")
 	require.NoError(t, err)
 
 	tenant := "distribution-test-tenant"
@@ -584,7 +584,7 @@ func TestRendezvousShuffleShardingValidation(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 30}, // 30 / 3 AZs = 10 per-AZ, but only 5 shards available
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-validation")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-validation", "")
 	require.NoError(t, err)
 
 	_, err = shardRing.getTenantShardRendezvous("test-tenant")
@@ -611,7 +611,7 @@ func TestRendezvousShuffleShardingPercentage(t *testing.T) {
 		cfg := ShuffleShardingConfig{
 			ShardSize: ShardSize{Percent: 0.5, IsPercent: true},
 		}
-		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-50")
+		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-50", "")
 		require.NoError(t, err)
 
 		shard, err := shardRing.getTenantShardRendezvous("test-tenant")
@@ -646,7 +646,7 @@ func TestRendezvousShuffleShardingPercentage(t *testing.T) {
 		cfg := ShuffleShardingConfig{
 			ShardSize: ShardSize{Percent: 0.25, IsPercent: true},
 		}
-		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-25")
+		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-25", "")
 		require.NoError(t, err)
 
 		shard, err := shardRing.getTenantShardRendezvous("test-tenant")
@@ -670,7 +670,7 @@ func TestRendezvousShuffleShardingPercentage(t *testing.T) {
 		cfg := ShuffleShardingConfig{
 			ShardSize: ShardSize{Percent: 1.0, IsPercent: true},
 		}
-		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-100")
+		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-100", "")
 		require.NoError(t, err)
 
 		shard, err := shardRing.getTenantShardRendezvous("test-tenant")
@@ -692,7 +692,7 @@ func TestRendezvousShuffleShardingPercentage(t *testing.T) {
 				},
 			},
 		}
-		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-override")
+		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-override", "")
 		require.NoError(t, err)
 
 		// Default tenant gets 50%.
@@ -724,7 +724,7 @@ func TestRendezvousShuffleShardingPercentageConsistency(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Percent: 0.5, IsPercent: true},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-consistency")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-consistency", "")
 	require.NoError(t, err)
 
 	tenant := "consistency-tenant"
@@ -764,7 +764,7 @@ func TestKetamaRejectsPercentageShardSize(t *testing.T) {
 		},
 	}
 
-	_, err := NewMultiHashring(AlgorithmKetama, 2, cfg, prometheus.NewRegistry())
+	_, err := NewMultiHashring(AlgorithmKetama, 2, cfg, prometheus.NewRegistry(), "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "percentage shard_size is not supported for ketama algorithm")
 }
@@ -788,7 +788,7 @@ func TestRendezvousIntegerShardSizeBackwardCompatibility(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-int-compat")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-int-compat", "")
 	require.NoError(t, err)
 
 	shard, err := shardRing.getTenantShardRendezvous("test-tenant")


### PR DESCRIPTION
The default tenant (catch-all for requests without a tenant header) now writes to ALL endpoints instead of a sharded subset. The default tenant ID is threaded from the CLI flag through the hashring construction chain, and getTenantShardCached short-circuits to return the base ring when the tenant matches the default tenant ID.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
