### PR TITLE
Implement metrics blocklisting in thanos with negation pattern support

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -305,6 +305,12 @@ func runReceive(
 		return errors.Wrap(err, "creating limiter")
 	}
 
+	// Create blocklist filter if config is provided.
+	blocklistFilter, err := receive.NewBlocklistFilter(conf.blocklistConfigPath, reg, log.With(logger, "component", "blocklist-filter"), conf.blocklistConfigReloadTimer)
+	if err != nil {
+		return errors.Wrap(err, "creating blocklist filter")
+	}
+
 	// Create tenant attributor if config is provided.
 	var tenantAttributor *receive.TenantAttributor
 	if conf.tenantRulesConfig != nil {
@@ -338,6 +344,7 @@ func runReceive(
 		ReplicaHeader:            conf.replicaHeader,
 		ReplicationFactor:        conf.replicationFactor,
 		Relabeller:               relabeller,
+		Blocklist:                blocklistFilter,
 		ReceiverMode:             receiveMode,
 		Tracer:                   tracer,
 		TLSConfig:                rwTLSConfig,
@@ -365,6 +372,24 @@ func runReceive(
 					return err
 				}
 				level.Info(logger).Log("msg", "relabel config reloading initialized.")
+				<-ctx.Done()
+				return nil
+			}, func(error) {
+				cancel()
+			})
+		}
+	}
+
+	{
+		if blocklistFilter.CanReload() {
+			ctx, cancel := context.WithCancel(context.Background())
+			g.Add(func() error {
+				level.Debug(logger).Log("msg", "blocklist config initialized with file watcher.")
+				if err := blocklistFilter.StartConfigReloader(ctx); err != nil {
+					level.Error(logger).Log("msg", "initializing blocklist config reloading.", "err", err)
+					return err
+				}
+				level.Info(logger).Log("msg", "blocklist config reloading initialized.")
 				<-ctx.Done()
 				return nil
 			}, func(error) {
@@ -1043,6 +1068,9 @@ type receiveConfig struct {
 	tenantRulesConfig       *extflag.PathOrContent
 	verifyTenantAttribution bool
 
+	blocklistConfigPath        *extflag.PathOrContent
+	blocklistConfigReloadTimer time.Duration
+
 	// Pool configuration for receive-path buffer reuse.
 	poolingEnabled           bool
 	maxPooledCompressedCap   int
@@ -1253,6 +1281,10 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	rc.tenantRulesConfig = extflag.RegisterPathOrContent(cmd, "receive.tenant-rules", "YAML file that contains tenant attribution rules. Each rule maps label filters to a tenant ID. Rules are evaluated in order, first match wins.", extflag.WithEnvSubstitution())
 	cmd.Flag("receive.verify-tenant-attribution", "When enabled, tenant attribution rules are evaluated but only for verification. The HTTP header tenant is still used for actual routing/storage. Metrics are emitted to compare attributed vs HTTP tenant.").
 		Default("false").BoolVar(&rc.verifyTenantAttribution)
+
+	rc.blocklistConfigPath = extflag.RegisterPathOrContent(cmd, "receive.blocklist-config", "YAML file that contains blocklist filter rules. Each rule is an M3-style filter string. Time series matching any rule are dropped before writing.", extflag.WithEnvSubstitution())
+	cmd.Flag("receive.blocklist-config-reload-timer", "Minimum amount of time to pass for the blocklist configuration to be reloaded. Helps to avoid excessive reloads.").
+		Default("0s").DurationVar(&rc.blocklistConfigReloadTimer)
 
 	cmd.Flag("receive.pooling-enabled", "Enable pooling of buffers for receive-path request handling.").
 		Default("false").

--- a/pkg/receive/blocklist.go
+++ b/pkg/receive/blocklist.go
@@ -1,0 +1,224 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
+	"go.uber.org/atomic"
+	"gopkg.in/yaml.v2"
+)
+
+// blocklistRules is a slice of compiled TagsFilter rules used by BlocklistFilter.
+type blocklistRules []TagsFilter
+
+// BlocklistFilter filters time series against a set of M3-style filter rules.
+// Any time series matching any rule is dropped. The filter supports hot-reload
+// of its configuration via an atomic pointer swap, following the same pattern
+// as Relabeller.
+type BlocklistFilter struct {
+	configPathOrContent       fileContent
+	rules                     *atomic.Pointer[blocklistRules]
+	logger                    log.Logger
+	configReloadTimer         time.Duration
+	configReloadCounter       prometheus.Counter
+	configReloadFailedCounter prometheus.Counter
+
+	droppedSeriesTotal prometheus.Counter
+	activeRulesGauge   prometheus.Gauge
+}
+
+// NewBlocklistFilter creates a new BlocklistFilter and loads the initial configuration.
+// If configFile is nil, the filter is a no-op (drops nothing).
+func NewBlocklistFilter(configFile fileContent, reg prometheus.Registerer, logger log.Logger, configReloadTimer time.Duration) (*BlocklistFilter, error) {
+	var rules atomic.Pointer[blocklistRules]
+	empty := blocklistRules{}
+	rules.Store(&empty)
+
+	bf := &BlocklistFilter{
+		configPathOrContent: configFile,
+		rules:               &rules,
+		logger:              logger,
+		configReloadTimer:   configReloadTimer,
+	}
+
+	if reg != nil {
+		bf.configReloadCounter = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: "thanos",
+			Subsystem: "receive",
+			Name:      "blocklist_config_reload_total",
+			Help:      "Total number of blocklist configuration reloads.",
+		})
+		bf.configReloadFailedCounter = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: "thanos",
+			Subsystem: "receive",
+			Name:      "blocklist_config_reload_err_total",
+			Help:      "Total number of failed blocklist configuration reloads.",
+		})
+		bf.droppedSeriesTotal = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: "thanos",
+			Subsystem: "receive",
+			Name:      "blocklist_dropped_series_total",
+			Help:      "Total number of time series dropped by the blocklist filter.",
+		})
+		bf.activeRulesGauge = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: "thanos",
+			Subsystem: "receive",
+			Name:      "blocklist_active_rules",
+			Help:      "Number of active blocklist filter rules.",
+		})
+	}
+
+	if configFile == nil {
+		return bf, nil
+	}
+
+	if err := bf.loadConfig(); err != nil {
+		return nil, errors.Wrap(err, "load blocklist config")
+	}
+
+	return bf, nil
+}
+
+// loadConfig reads and parses the blocklist config from the configured source.
+func (bf *BlocklistFilter) loadConfig() error {
+	contentYaml, err := bf.configPathOrContent.Content()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			level.Debug(bf.logger).Log("msg", "blocklist config file does not exist")
+			empty := blocklistRules{}
+			bf.rules.Store(&empty)
+			bf.setActiveRulesGauge(0)
+			return nil
+		}
+		return errors.Wrap(err, "getting content of blocklist config")
+	}
+
+	rules, err := parseBlocklistConfig(contentYaml)
+	if err != nil {
+		return errors.Wrap(err, "parsing blocklist config")
+	}
+
+	bf.rules.Store(&rules)
+	bf.setActiveRulesGauge(len(rules))
+	level.Info(bf.logger).Log("msg", "blocklist config loaded", "rules", len(rules))
+	return nil
+}
+
+// parseBlocklistConfig parses a YAML list of M3 filter strings and compiles them.
+func parseBlocklistConfig(data []byte) (blocklistRules, error) {
+	var filterStrings []string
+	if err := yaml.Unmarshal(data, &filterStrings); err != nil {
+		return nil, fmt.Errorf("unmarshaling blocklist config: %w", err)
+	}
+
+	rules := make(blocklistRules, 0, len(filterStrings))
+	for i, fs := range filterStrings {
+		if fs == "" {
+			continue
+		}
+		filterValues, err := ParseTagFilterValueMap(fs)
+		if err != nil {
+			return nil, fmt.Errorf("rule %d: parsing filter %q: %w", i, fs, err)
+		}
+		filter, err := NewTagsFilter(filterValues, Conjunction, TagsFilterOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("rule %d: creating filter %q: %w", i, fs, err)
+		}
+		rules = append(rules, filter)
+	}
+	return rules, nil
+}
+
+// FilterTimeSeries removes any time series from the write request that match
+// any blocklist rule. It returns the number of series dropped.
+func (bf *BlocklistFilter) FilterTimeSeries(wreq *prompb.WriteRequest) int {
+	if bf == nil {
+		return 0
+	}
+
+	rules := *bf.rules.Load()
+	if len(rules) == 0 {
+		return 0
+	}
+
+	dropped := 0
+	for i, ts := range wreq.Timeseries {
+		lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
+		blocked := false
+		for _, rule := range rules {
+			if rule.MatchLabels(lbls) {
+				blocked = true
+				break
+			}
+		}
+		if blocked {
+			dropped++
+		} else if dropped > 0 {
+			wreq.Timeseries[i-dropped] = ts
+		}
+	}
+
+	if dropped > 0 {
+		wreq.Timeseries = wreq.Timeseries[:len(wreq.Timeseries)-dropped]
+		if bf.droppedSeriesTotal != nil {
+			bf.droppedSeriesTotal.Add(float64(dropped))
+		}
+	}
+	return dropped
+}
+
+// StartConfigReloader starts the automatic configuration reloader based off of
+// the file indicated by the configured path/content source.
+func (bf *BlocklistFilter) StartConfigReloader(ctx context.Context) error {
+	if !bf.CanReload() {
+		return nil
+	}
+
+	return extkingpin.PathContentReloader(ctx, bf.configPathOrContent, bf.logger, func() {
+		level.Info(bf.logger).Log("msg", "reloading blocklist config")
+
+		if err := bf.loadConfig(); err != nil {
+			if bf.configReloadFailedCounter != nil {
+				bf.configReloadFailedCounter.Inc()
+			}
+			errMsg := fmt.Sprintf("error reloading blocklist config from %s", bf.configPathOrContent.Path())
+			level.Error(bf.logger).Log("msg", errMsg, "err", err)
+		}
+		if bf.configReloadCounter != nil {
+			bf.configReloadCounter.Inc()
+		}
+	}, bf.configReloadTimer)
+}
+
+// CanReload returns true if the filter is configured with a file path and a reload timer.
+func (bf *BlocklistFilter) CanReload() bool {
+	if bf.configReloadTimer == 0 {
+		return false
+	}
+	if bf.configPathOrContent == nil {
+		return false
+	}
+	if bf.configPathOrContent.Path() == "" {
+		return false
+	}
+	return true
+}
+
+func (bf *BlocklistFilter) setActiveRulesGauge(n int) {
+	if bf.activeRulesGauge != nil {
+		bf.activeRulesGauge.Set(float64(n))
+	}
+}

--- a/pkg/receive/blocklist_test.go
+++ b/pkg/receive/blocklist_test.go
@@ -1,0 +1,368 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
+	"go.uber.org/atomic"
+)
+
+func TestParseBlocklistConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		input   string
+		wantErr bool
+		nRules  int
+	}{
+		{
+			name:    "empty config",
+			input:   "[]",
+			wantErr: false,
+			nRules:  0,
+		},
+		{
+			name:    "single rule",
+			input:   `["__name__:kube_pod_status_phase job:dblet-ksm"]`,
+			wantErr: false,
+			nRules:  1,
+		},
+		{
+			name: "multiple rules",
+			input: `
+- "__name__:logger_messageCount_histogram_bucket kubernetes_namespace:dblet*"
+- "__name__:kube_pod_status_phase job:dblet-ksm phase:!{Running,Succeeded}"
+`,
+			wantErr: false,
+			nRules:  2,
+		},
+		{
+			name:    "empty strings skipped",
+			input:   `["__name__:foo", ""]`,
+			wantErr: false,
+			nRules:  1,
+		},
+		{
+			name:    "invalid filter pattern",
+			input:   `["invalid_no_colon"]`,
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rules, err := parseBlocklistConfig([]byte(tc.input))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, rules, tc.nRules)
+		})
+	}
+}
+
+func TestBlocklistFilter_FilterTimeSeries(t *testing.T) {
+	t.Parallel()
+
+	mkTS := func(lbls ...string) prompb.TimeSeries {
+		zlabels := make([]labelpb.ZLabel, 0, len(lbls)/2)
+		for i := 0; i < len(lbls); i += 2 {
+			zlabels = append(zlabels, labelpb.ZLabel{Name: lbls[i], Value: lbls[i+1]})
+		}
+		return prompb.TimeSeries{
+			Labels:  zlabels,
+			Samples: []prompb.Sample{{Timestamp: 1, Value: 1}},
+		}
+	}
+
+	for _, tc := range []struct {
+		name            string
+		config          string
+		input           []prompb.TimeSeries
+		expectedRemain  int
+		expectedDropped int
+	}{
+		{
+			name:   "no rules drops nothing",
+			config: "[]",
+			input: []prompb.TimeSeries{
+				mkTS("__name__", "foo", "job", "bar"),
+			},
+			expectedRemain:  1,
+			expectedDropped: 0,
+		},
+		{
+			name:   "exact match drops series",
+			config: `["__name__:kube_pod_status_phase job:dblet-ksm"]`,
+			input: []prompb.TimeSeries{
+				mkTS("__name__", "kube_pod_status_phase", "job", "dblet-ksm"),
+				mkTS("__name__", "kube_pod_status_phase", "job", "other"),
+				mkTS("__name__", "up", "job", "dblet-ksm"),
+			},
+			expectedRemain:  2,
+			expectedDropped: 1,
+		},
+		{
+			name:   "wildcard match",
+			config: `["__name__:logger_messageCount_histogram_bucket kubernetes_namespace:dblet*"]`,
+			input: []prompb.TimeSeries{
+				mkTS("__name__", "logger_messageCount_histogram_bucket", "kubernetes_namespace", "dblet-foo"),
+				mkTS("__name__", "logger_messageCount_histogram_bucket", "kubernetes_namespace", "dblet-bar"),
+				mkTS("__name__", "logger_messageCount_histogram_bucket", "kubernetes_namespace", "other-ns"),
+				mkTS("__name__", "other_metric", "kubernetes_namespace", "dblet-foo"),
+			},
+			expectedRemain:  2,
+			expectedDropped: 2,
+		},
+		{
+			name: "negation pattern — drop series NOT matching phase Running or Succeeded",
+			config: `
+- "__name__:kube_pod_status_phase job:dblet-ksm phase:!{Running,Succeeded}"
+`,
+			input: []prompb.TimeSeries{
+				mkTS("__name__", "kube_pod_status_phase", "job", "dblet-ksm", "phase", "Pending"),
+				mkTS("__name__", "kube_pod_status_phase", "job", "dblet-ksm", "phase", "Running"),
+				mkTS("__name__", "kube_pod_status_phase", "job", "dblet-ksm", "phase", "Succeeded"),
+				mkTS("__name__", "kube_pod_status_phase", "job", "dblet-ksm", "phase", "Failed"),
+			},
+			expectedRemain:  2,
+			expectedDropped: 2,
+		},
+		{
+			name: "multi-range alternation pattern",
+			config: `
+- "__name__:envoy_cluster_upstream_cx_connect_ms_bucket kubernetes_namespace:dp-ingress envoy_cluster_name:{SERVERLESS_PLATFORM-,driver-pool-}*"
+`,
+			input: []prompb.TimeSeries{
+				mkTS("__name__", "envoy_cluster_upstream_cx_connect_ms_bucket", "kubernetes_namespace", "dp-ingress", "envoy_cluster_name", "SERVERLESS_PLATFORM-foo"),
+				mkTS("__name__", "envoy_cluster_upstream_cx_connect_ms_bucket", "kubernetes_namespace", "dp-ingress", "envoy_cluster_name", "driver-pool-bar"),
+				mkTS("__name__", "envoy_cluster_upstream_cx_connect_ms_bucket", "kubernetes_namespace", "dp-ingress", "envoy_cluster_name", "other-cluster"),
+				mkTS("__name__", "envoy_cluster_upstream_cx_connect_ms_bucket", "kubernetes_namespace", "other-ns", "envoy_cluster_name", "SERVERLESS_PLATFORM-foo"),
+			},
+			expectedRemain:  2,
+			expectedDropped: 2,
+		},
+		{
+			name: "multiple rules — any matching rule drops",
+			config: `
+- "__name__:metric_a"
+- "__name__:metric_b"
+`,
+			input: []prompb.TimeSeries{
+				mkTS("__name__", "metric_a"),
+				mkTS("__name__", "metric_b"),
+				mkTS("__name__", "metric_c"),
+			},
+			expectedRemain:  1,
+			expectedDropped: 2,
+		},
+		{
+			name:            "empty write request",
+			config:          `["__name__:foo"]`,
+			input:           []prompb.TimeSeries{},
+			expectedRemain:  0,
+			expectedDropped: 0,
+		},
+		{
+			name:   "all series blocked",
+			config: `["__name__:*"]`,
+			input: []prompb.TimeSeries{
+				mkTS("__name__", "foo"),
+				mkTS("__name__", "bar"),
+			},
+			expectedRemain:  0,
+			expectedDropped: 2,
+		},
+		{
+			name:   "no series blocked",
+			config: `["__name__:nonexistent_metric"]`,
+			input: []prompb.TimeSeries{
+				mkTS("__name__", "foo"),
+				mkTS("__name__", "bar"),
+			},
+			expectedRemain:  2,
+			expectedDropped: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rules, err := parseBlocklistConfig([]byte(tc.config))
+			require.NoError(t, err)
+
+			bf := &BlocklistFilter{
+				logger: log.NewNopLogger(),
+			}
+			compiled := blocklistRules(rules)
+			var ptr atomic.Pointer[blocklistRules]
+			ptr.Store(&compiled)
+			bf.rules = &ptr
+
+			wreq := &prompb.WriteRequest{
+				Timeseries: make([]prompb.TimeSeries, len(tc.input)),
+			}
+			copy(wreq.Timeseries, tc.input)
+
+			dropped := bf.FilterTimeSeries(wreq)
+			require.Equal(t, tc.expectedDropped, dropped, "unexpected number of dropped series")
+			require.Len(t, wreq.Timeseries, tc.expectedRemain, "unexpected number of remaining series")
+		})
+	}
+}
+
+func TestBlocklistFilter_NilFilter(t *testing.T) {
+	t.Parallel()
+
+	var bf *BlocklistFilter
+	wreq := &prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels:  []labelpb.ZLabel{{Name: "__name__", Value: "test"}},
+				Samples: []prompb.Sample{{Timestamp: 1, Value: 1}},
+			},
+		},
+	}
+	dropped := bf.FilterTimeSeries(wreq)
+	require.Equal(t, 0, dropped)
+	require.Len(t, wreq.Timeseries, 1)
+}
+
+func TestBlocklistFilter_LoadConfig(t *testing.T) {
+	t.Parallel()
+
+	configYAML := `
+- "__name__:metric_to_block"
+- "__name__:another_metric job:some_job"
+`
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "blocklist.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0644))
+
+	fc, err := extkingpin.NewStaticPathContent(configPath)
+	require.NoError(t, err)
+
+	bf, err := NewBlocklistFilter(fc, nil, log.NewNopLogger(), 0)
+	require.NoError(t, err)
+
+	rules := *bf.rules.Load()
+	require.Len(t, rules, 2)
+}
+
+func TestBlocklistFilter_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	bf, err := NewBlocklistFilter(nil, nil, log.NewNopLogger(), 0)
+	require.NoError(t, err)
+	rules := *bf.rules.Load()
+	require.Len(t, rules, 0)
+}
+
+func TestBlocklistFilter_HotReload(t *testing.T) {
+	t.Parallel()
+
+	initialConfig := `
+- "__name__:metric_a"
+`
+	updatedConfig := `
+- "__name__:metric_a"
+- "__name__:metric_b"
+`
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "blocklist.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(initialConfig), 0644))
+
+	fc, err := extkingpin.NewStaticPathContent(configPath)
+	require.NoError(t, err)
+
+	bf, err := NewBlocklistFilter(fc, nil, log.NewNopLogger(), 1*time.Second)
+	require.NoError(t, err)
+
+	// Verify initial config
+	rules := *bf.rules.Load()
+	require.Len(t, rules, 1)
+
+	// Start the reloader
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testutil.Ok(t, bf.StartConfigReloader(ctx))
+
+	// Update config via Rewrite (which triggers the reloader)
+	testutil.Ok(t, fc.Rewrite([]byte(updatedConfig)))
+
+	// Wait for reload to take effect
+	require.Eventually(t, func() bool {
+		rules := *bf.rules.Load()
+		return len(rules) == 2
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func TestBlocklistFilter_HotReload_InvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	initialConfig := `
+- "__name__:metric_a"
+`
+	invalidConfig := `not a valid yaml list`
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "blocklist.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(initialConfig), 0644))
+
+	fc, err := extkingpin.NewStaticPathContent(configPath)
+	require.NoError(t, err)
+
+	bf, err := NewBlocklistFilter(fc, nil, log.NewNopLogger(), 1*time.Second)
+	require.NoError(t, err)
+
+	// Verify initial config
+	rules := *bf.rules.Load()
+	require.Len(t, rules, 1)
+
+	// Start the reloader
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testutil.Ok(t, bf.StartConfigReloader(ctx))
+
+	// Write invalid config — should not affect the loaded rules
+	testutil.Ok(t, fc.Rewrite([]byte(invalidConfig)))
+	require.Never(t, func() bool {
+		rules := *bf.rules.Load()
+		return len(rules) != 1
+	}, 3*time.Second, 100*time.Millisecond)
+}
+
+func TestBlocklistFilter_CanReload(t *testing.T) {
+	t.Parallel()
+
+	// nil config
+	bf, err := NewBlocklistFilter(nil, nil, log.NewNopLogger(), 1*time.Second)
+	require.NoError(t, err)
+	require.False(t, bf.CanReload())
+
+	// zero timer
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "blocklist.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("[]"), 0644))
+
+	fc, err := extkingpin.NewStaticPathContent(configPath)
+	require.NoError(t, err)
+
+	bf, err = NewBlocklistFilter(fc, nil, log.NewNopLogger(), 0)
+	require.NoError(t, err)
+	require.False(t, bf.CanReload())
+
+	// valid path + timer
+	bf, err = NewBlocklistFilter(fc, nil, log.NewNopLogger(), 1*time.Second)
+	require.NoError(t, err)
+	require.True(t, bf.CanReload())
+}

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -136,6 +136,7 @@ type Options struct {
 	ForwardTimeout          time.Duration
 	MaxBackoff              time.Duration
 	Relabeller              *Relabeller
+	Blocklist               *BlocklistFilter
 	TSDBStats               TSDBStats
 	Limiter                 *Limiter
 	AsyncForwardWorkerCount uint
@@ -825,6 +826,19 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		h.writeRejectedTotal.WithLabelValues("samples_limit", tenantHTTP).Inc()
 		http.Error(w, "too many samples", http.StatusRequestEntityTooLarge)
 		return
+	}
+
+	// Apply blocklist filter before relabeling so that relabel configs
+	// (used by the dynamic quota-blocker) still work on the remaining series.
+	if h.options.Blocklist != nil {
+		dropped := h.options.Blocklist.FilterTimeSeries(wreq)
+		if dropped > 0 {
+			level.Debug(tLogger).Log("msg", "blocklist filter dropped series", "dropped", dropped, "remaining", len(wreq.Timeseries))
+		}
+		if len(wreq.Timeseries) == 0 {
+			level.Debug(tLogger).Log("msg", "remote write request dropped entirely by blocklist filter.")
+			return
+		}
 	}
 
 	// Apply relabeling configs.

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/resolver"
@@ -1740,6 +1741,152 @@ func TestRelabel(t *testing.T) {
 			})
 
 			h.relabel(&tcase.writeRequest)
+			testutil.Equals(t, tcase.expectedWriteRequest, tcase.writeRequest)
+		})
+	}
+}
+
+func newBlocklistFilterWithRules(rules blocklistRules, logger log.Logger) *BlocklistFilter {
+	var ptr atomic.Pointer[blocklistRules]
+	ptr.Store(&rules)
+	return &BlocklistFilter{
+		rules:  &ptr,
+		logger: logger,
+	}
+}
+
+func TestBlocklistFilterIntegration(t *testing.T) {
+	t.Parallel()
+
+	for _, tcase := range []struct {
+		name                 string
+		blocklistConfig      string
+		writeRequest         prompb.WriteRequest
+		expectedWriteRequest prompb.WriteRequest
+		expectedDropped      int
+	}{
+		{
+			name:            "no blocklist rules",
+			blocklistConfig: "[]",
+			writeRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "test_metric"},
+							{Name: "foo", Value: "bar"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedWriteRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "test_metric"},
+							{Name: "foo", Value: "bar"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedDropped: 0,
+		},
+		{
+			name:            "blocklist drops matching series, keeps non-matching",
+			blocklistConfig: `["__name__:test_metric foo:bar"]`,
+			writeRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "test_metric"},
+							{Name: "foo", Value: "bar"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "other_metric"},
+							{Name: "foo", Value: "baz"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 2}},
+					},
+				},
+			},
+			expectedWriteRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "other_metric"},
+							{Name: "foo", Value: "baz"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 2}},
+					},
+				},
+			},
+			expectedDropped: 1,
+		},
+		{
+			name:            "blocklist drops all series",
+			blocklistConfig: `["__name__:*"]`,
+			writeRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "test_metric"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedWriteRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{},
+			},
+			expectedDropped: 1,
+		},
+		{
+			name:            "blocklist with negation pattern",
+			blocklistConfig: `["__name__:kube_pod_status_phase phase:!{Running,Succeeded}"]`,
+			writeRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "kube_pod_status_phase"},
+							{Name: "phase", Value: "Pending"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "kube_pod_status_phase"},
+							{Name: "phase", Value: "Running"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedWriteRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "kube_pod_status_phase"},
+							{Name: "phase", Value: "Running"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedDropped: 1,
+		},
+	} {
+		t.Run(tcase.name, func(t *testing.T) {
+			rules, err := parseBlocklistConfig([]byte(tcase.blocklistConfig))
+			require.NoError(t, err)
+
+			bf := newBlocklistFilterWithRules(rules, log.NewNopLogger())
+			dropped := bf.FilterTimeSeries(&tcase.writeRequest)
+
+			testutil.Equals(t, tcase.expectedDropped, dropped)
 			testutil.Equals(t, tcase.expectedWriteRequest, tcase.writeRequest)
 		})
 	}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -336,7 +336,11 @@ func newTestHandlerHashring(
 		hashringAlgo = AlgorithmHashmod
 	}
 
+<<<<<<< HEAD
 	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg, prometheus.NewRegistry(), "", log.NewNopLogger())
+=======
+	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg, prometheus.NewRegistry(), "")
+>>>>>>> e85e3001 (receive: Disable shuffle sharding for default tenant (#312))
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
 	"gopkg.in/yaml.v3"
 
 	"github.com/alecthomas/units"
@@ -1736,6 +1737,152 @@ func TestRelabel(t *testing.T) {
 			})
 
 			h.relabel(&tcase.writeRequest)
+			testutil.Equals(t, tcase.expectedWriteRequest, tcase.writeRequest)
+		})
+	}
+}
+
+func newBlocklistFilterWithRules(rules blocklistRules, logger log.Logger) *BlocklistFilter {
+	var ptr atomic.Pointer[blocklistRules]
+	ptr.Store(&rules)
+	return &BlocklistFilter{
+		rules:  &ptr,
+		logger: logger,
+	}
+}
+
+func TestBlocklistFilterIntegration(t *testing.T) {
+	t.Parallel()
+
+	for _, tcase := range []struct {
+		name                 string
+		blocklistConfig      string
+		writeRequest         prompb.WriteRequest
+		expectedWriteRequest prompb.WriteRequest
+		expectedDropped      int
+	}{
+		{
+			name:            "no blocklist rules",
+			blocklistConfig: "[]",
+			writeRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "test_metric"},
+							{Name: "foo", Value: "bar"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedWriteRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "test_metric"},
+							{Name: "foo", Value: "bar"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedDropped: 0,
+		},
+		{
+			name:            "blocklist drops matching series, keeps non-matching",
+			blocklistConfig: `["__name__:test_metric foo:bar"]`,
+			writeRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "test_metric"},
+							{Name: "foo", Value: "bar"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "other_metric"},
+							{Name: "foo", Value: "baz"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 2}},
+					},
+				},
+			},
+			expectedWriteRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "other_metric"},
+							{Name: "foo", Value: "baz"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 2}},
+					},
+				},
+			},
+			expectedDropped: 1,
+		},
+		{
+			name:            "blocklist drops all series",
+			blocklistConfig: `["__name__:*"]`,
+			writeRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "test_metric"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedWriteRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{},
+			},
+			expectedDropped: 1,
+		},
+		{
+			name:            "blocklist with negation pattern",
+			blocklistConfig: `["__name__:kube_pod_status_phase phase:!{Running,Succeeded}"]`,
+			writeRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "kube_pod_status_phase"},
+							{Name: "phase", Value: "Pending"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "kube_pod_status_phase"},
+							{Name: "phase", Value: "Running"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedWriteRequest: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "kube_pod_status_phase"},
+							{Name: "phase", Value: "Running"},
+						},
+						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
+					},
+				},
+			},
+			expectedDropped: 1,
+		},
+	} {
+		t.Run(tcase.name, func(t *testing.T) {
+			rules, err := parseBlocklistConfig([]byte(tcase.blocklistConfig))
+			require.NoError(t, err)
+
+			bf := newBlocklistFilterWithRules(rules, log.NewNopLogger())
+			dropped := bf.FilterTimeSeries(&tcase.writeRequest)
+
+			testutil.Equals(t, tcase.expectedDropped, dropped)
 			testutil.Equals(t, tcase.expectedWriteRequest, tcase.writeRequest)
 		})
 	}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/resolver"
@@ -337,11 +336,7 @@ func newTestHandlerHashring(
 		hashringAlgo = AlgorithmHashmod
 	}
 
-<<<<<<< HEAD
 	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg, prometheus.NewRegistry(), "", log.NewNopLogger())
-=======
-	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg, prometheus.NewRegistry(), "")
->>>>>>> e85e3001 (receive: Disable shuffle sharding for default tenant (#312))
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1741,152 +1736,6 @@ func TestRelabel(t *testing.T) {
 			})
 
 			h.relabel(&tcase.writeRequest)
-			testutil.Equals(t, tcase.expectedWriteRequest, tcase.writeRequest)
-		})
-	}
-}
-
-func newBlocklistFilterWithRules(rules blocklistRules, logger log.Logger) *BlocklistFilter {
-	var ptr atomic.Pointer[blocklistRules]
-	ptr.Store(&rules)
-	return &BlocklistFilter{
-		rules:  &ptr,
-		logger: logger,
-	}
-}
-
-func TestBlocklistFilterIntegration(t *testing.T) {
-	t.Parallel()
-
-	for _, tcase := range []struct {
-		name                 string
-		blocklistConfig      string
-		writeRequest         prompb.WriteRequest
-		expectedWriteRequest prompb.WriteRequest
-		expectedDropped      int
-	}{
-		{
-			name:            "no blocklist rules",
-			blocklistConfig: "[]",
-			writeRequest: prompb.WriteRequest{
-				Timeseries: []prompb.TimeSeries{
-					{
-						Labels: []labelpb.ZLabel{
-							{Name: "__name__", Value: "test_metric"},
-							{Name: "foo", Value: "bar"},
-						},
-						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
-					},
-				},
-			},
-			expectedWriteRequest: prompb.WriteRequest{
-				Timeseries: []prompb.TimeSeries{
-					{
-						Labels: []labelpb.ZLabel{
-							{Name: "__name__", Value: "test_metric"},
-							{Name: "foo", Value: "bar"},
-						},
-						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
-					},
-				},
-			},
-			expectedDropped: 0,
-		},
-		{
-			name:            "blocklist drops matching series, keeps non-matching",
-			blocklistConfig: `["__name__:test_metric foo:bar"]`,
-			writeRequest: prompb.WriteRequest{
-				Timeseries: []prompb.TimeSeries{
-					{
-						Labels: []labelpb.ZLabel{
-							{Name: "__name__", Value: "test_metric"},
-							{Name: "foo", Value: "bar"},
-						},
-						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
-					},
-					{
-						Labels: []labelpb.ZLabel{
-							{Name: "__name__", Value: "other_metric"},
-							{Name: "foo", Value: "baz"},
-						},
-						Samples: []prompb.Sample{{Timestamp: 0, Value: 2}},
-					},
-				},
-			},
-			expectedWriteRequest: prompb.WriteRequest{
-				Timeseries: []prompb.TimeSeries{
-					{
-						Labels: []labelpb.ZLabel{
-							{Name: "__name__", Value: "other_metric"},
-							{Name: "foo", Value: "baz"},
-						},
-						Samples: []prompb.Sample{{Timestamp: 0, Value: 2}},
-					},
-				},
-			},
-			expectedDropped: 1,
-		},
-		{
-			name:            "blocklist drops all series",
-			blocklistConfig: `["__name__:*"]`,
-			writeRequest: prompb.WriteRequest{
-				Timeseries: []prompb.TimeSeries{
-					{
-						Labels: []labelpb.ZLabel{
-							{Name: "__name__", Value: "test_metric"},
-						},
-						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
-					},
-				},
-			},
-			expectedWriteRequest: prompb.WriteRequest{
-				Timeseries: []prompb.TimeSeries{},
-			},
-			expectedDropped: 1,
-		},
-		{
-			name:            "blocklist with negation pattern",
-			blocklistConfig: `["__name__:kube_pod_status_phase phase:!{Running,Succeeded}"]`,
-			writeRequest: prompb.WriteRequest{
-				Timeseries: []prompb.TimeSeries{
-					{
-						Labels: []labelpb.ZLabel{
-							{Name: "__name__", Value: "kube_pod_status_phase"},
-							{Name: "phase", Value: "Pending"},
-						},
-						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
-					},
-					{
-						Labels: []labelpb.ZLabel{
-							{Name: "__name__", Value: "kube_pod_status_phase"},
-							{Name: "phase", Value: "Running"},
-						},
-						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
-					},
-				},
-			},
-			expectedWriteRequest: prompb.WriteRequest{
-				Timeseries: []prompb.TimeSeries{
-					{
-						Labels: []labelpb.ZLabel{
-							{Name: "__name__", Value: "kube_pod_status_phase"},
-							{Name: "phase", Value: "Running"},
-						},
-						Samples: []prompb.Sample{{Timestamp: 0, Value: 1}},
-					},
-				},
-			},
-			expectedDropped: 1,
-		},
-	} {
-		t.Run(tcase.name, func(t *testing.T) {
-			rules, err := parseBlocklistConfig([]byte(tcase.blocklistConfig))
-			require.NoError(t, err)
-
-			bf := newBlocklistFilterWithRules(rules, log.NewNopLogger())
-			dropped := bf.FilterTimeSeries(&tcase.writeRequest)
-
-			testutil.Equals(t, tcase.expectedDropped, dropped)
 			testutil.Equals(t, tcase.expectedWriteRequest, tcase.writeRequest)
 		})
 	}


### PR DESCRIPTION
## Changes

- Adds a blocklist filter to the receive path that drops time series matching configurable M3-style filter rules (exact, wildcard, negation, alternation) before writing
- Rules are defined as a YAML list of filter strings via `--receive.blocklist-config-file` and applied before relabeling
- Supports optional hot-reload via `--receive.blocklist-config-reload-timer` for emergency blocking without restarts
- Exposes metrics: `blocklist_dropped_series_total`, `blocklist_active_rules`, `blocklist_config_reload_total`, `blocklist_config_reload_err_total`

## Verification

- Unit tests for config parsing (empty, single, multiple rules, invalid input)
- Unit tests for filtering (exact match, wildcard, negation, alternation, multi-rule, all-blocked, none-blocked, nil filter)
- Hot-reload tests (valid update, invalid config preserves old rules)
- Integration tests in `handler_test.go` validating end-to-end blocklist behavior