### PR TITLE
receive: Log resolved per-AZ shard sizes and unify percentage/absolute resolution

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -720,7 +720,7 @@ func setupHashring(g *run.Group,
 					webHandler.Hashring(receive.SingleNodeHashring(conf.endpoint))
 					level.Info(logger).Log("msg", "Empty hashring config. Set up single node hashring.")
 				} else {
-					h, err := receive.NewMultiHashring(algorithm, conf.replicationFactor, c, reg, conf.defaultTenantID)
+					h, err := receive.NewMultiHashring(algorithm, conf.replicationFactor, c, reg, conf.defaultTenantID, logger)
 					if err != nil {
 						return errors.Wrap(err, "unable to create new hashring from config")
 					}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -336,7 +336,7 @@ func newTestHandlerHashring(
 		hashringAlgo = AlgorithmHashmod
 	}
 
-	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg, prometheus.NewRegistry(), "")
+	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg, prometheus.NewRegistry(), "", log.NewNopLogger())
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -423,25 +423,12 @@ func newShuffleShardCacheMetrics(reg prometheus.Registerer, hashringName string)
 }
 
 // newShuffleShardHashring creates a new shuffle sharding hashring wrapper.
-func newShuffleShardHashring(baseRing Hashring, shuffleShardingConfig ShuffleShardingConfig, replicationFactor uint64, reg prometheus.Registerer, name string, defaultTenantID string) (*shuffleShardHashring, error) {
-	l := log.NewNopLogger()
-
-	level.Info(l).Log(
+func newShuffleShardHashring(baseRing Hashring, shuffleShardingConfig ShuffleShardingConfig, replicationFactor uint64, reg prometheus.Registerer, name string, defaultTenantID string, logger log.Logger) (*shuffleShardHashring, error) {
+	level.Info(logger).Log(
 		"msg", "Creating shuffle sharding hashring",
 		"default_shard_size", shuffleShardingConfig.ShardSize,
 		"total_nodes", len(baseRing.Nodes()),
 	)
-
-	if len(shuffleShardingConfig.Overrides) > 0 {
-		for _, override := range shuffleShardingConfig.Overrides {
-			level.Info(l).Log(
-				"msg", "Tenant shard size override",
-				"tenants", override.Tenants,
-				"tenant_matcher_type", override.TenantMatcherType,
-				"shard_size", override.ShardSize,
-			)
-		}
-	}
 
 	const DefaultShuffleShardingCacheSize = 100
 
@@ -487,7 +474,7 @@ func newShuffleShardHashring(baseRing Hashring, shuffleShardingConfig ShuffleSha
 	}
 
 	if !shuffleShardingConfig.ShardSize.IsPercent && shuffleShardingConfig.ShardSize.Value > maxNodesInAZ {
-		level.Warn(l).Log(
+		level.Warn(logger).Log(
 			"msg", "Shard size is larger than the maximum number of nodes in any AZ; some tenants might get all not working nodes if that AZ goes down",
 			"shard_size", shuffleShardingConfig.ShardSize,
 			"max_nodes_in_az", maxNodesInAZ,
@@ -498,7 +485,7 @@ func newShuffleShardHashring(baseRing Hashring, shuffleShardingConfig ShuffleSha
 		if override.ShardSize.IsPercent || override.ShardSize.Value < maxNodesInAZ {
 			continue
 		}
-		level.Warn(l).Log(
+		level.Warn(logger).Log(
 			"msg", "Shard size is larger than the maximum number of nodes in any AZ; some tenants might get all not working nodes if that AZ goes down",
 			"max_nodes_in_az", maxNodesInAZ,
 			"shard_size", override.ShardSize,
@@ -506,7 +493,44 @@ func newShuffleShardHashring(baseRing Hashring, shuffleShardingConfig ShuffleSha
 			"tenant_matcher_type", override.TenantMatcherType,
 		)
 	}
+
+	// Log resolved per-AZ shard sizes for debugging.
+	logResolvedShardSizes(logger, ssh.nodes, shuffleShardingConfig, len(nodeCountByAZ))
+
 	return ssh, nil
+}
+
+// logResolvedShardSizes logs the actual resolved per-AZ shard sizes at hashring creation time.
+// Both percentage and absolute shard sizes are interpreted as total across all AZs,
+// then divided by numAZs to get the per-AZ count.
+func logResolvedShardSizes(logger log.Logger, nodes []Endpoint, cfg ShuffleShardingConfig, numAZs int) {
+	totalNodes := len(nodes)
+	perAZ := resolvePerAZShardSize(cfg.ShardSize, totalNodes, numAZs)
+	level.Info(logger).Log(
+		"msg", "Resolved default shard size",
+		"shard_size", cfg.ShardSize,
+		"total_nodes", totalNodes,
+		"num_azs", numAZs,
+		"resolved_per_az_shard_size", perAZ,
+	)
+
+	for _, override := range cfg.Overrides {
+		perAZ := resolvePerAZShardSize(override.ShardSize, totalNodes, numAZs)
+		level.Info(logger).Log(
+			"msg", "Resolved override shard size",
+			"tenants", override.Tenants,
+			"tenant_matcher_type", override.TenantMatcherType,
+			"shard_size", override.ShardSize,
+			"resolved_per_az_shard_size", perAZ,
+		)
+	}
+}
+
+func resolvePerAZShardSize(s ShardSize, totalNodes, numAZs int) int {
+	if s.IsPercent {
+		return int(math.Ceil(float64(totalNodes) * s.Percent / float64(numAZs)))
+	}
+	return ShuffleShardExpectedInstancesPerZone(s.Value, numAZs)
 }
 
 func (s *shuffleShardHashring) Nodes() []Endpoint {
@@ -878,17 +902,11 @@ func (s *shuffleShardHashring) getTenantShardRendezvous(tenant string) (Hashring
 		return nil, errors.Wrap(err, "failed to extract shard structure")
 	}
 
-	// Determine per-AZ shard count based on shard size type.
+	// Determine per-AZ shard count. Both percentage and absolute shard sizes
+	// are interpreted as total across all AZs, then divided by numAZs (ceil).
 	shardSize := s.getShardSize(tenant)
 	numAZs := len(azShardMap)
-	var perAZShards int
-	if shardSize.IsPercent {
-		// Percentage: resolve directly against per-AZ common shard count.
-		perAZShards = shardSize.ResolveCount(len(commonShards))
-	} else {
-		// Absolute: divide total by number of AZs.
-		perAZShards = shardSize.Value / numAZs // floor
-	}
+	perAZShards := resolvePerAZShardSize(shardSize, len(s.nodes), numAZs)
 	if perAZShards == 0 {
 		return nil, fmt.Errorf("shard size %s too small for %d AZs", shardSize, numAZs)
 	}
@@ -950,15 +968,10 @@ func (s *shuffleShardHashring) GetN(tenant string, ts *prompb.TimeSeries, n uint
 // groups.
 // Which hashring to use for a tenant is determined
 // by the tenants field of the hashring configuration.
-func NewMultiHashring(algorithm HashringAlgorithm, replicationFactor uint64, cfg []HashringConfig, reg prometheus.Registerer, defaultTenantID string) (Hashring, error) {
+func NewMultiHashring(algorithm HashringAlgorithm, replicationFactor uint64, cfg []HashringConfig, reg prometheus.Registerer, defaultTenantID string, logger log.Logger) (Hashring, error) {
 	m := &multiHashring{
 		cache: make(map[string]Hashring),
 	}
-
-	numShardsGauge := promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-		Name: "thanos_receive_hashring_shards",
-		Help: "Number of shards per hashring after groupByAZ alignment.",
-	}, []string{"hashring"})
 
 	for _, h := range cfg {
 		var hashring Hashring
@@ -967,7 +980,7 @@ func NewMultiHashring(algorithm HashringAlgorithm, replicationFactor uint64, cfg
 		if h.Algorithm != "" {
 			activeAlgorithm = h.Algorithm
 		}
-		hashring, err = newHashring(activeAlgorithm, h.Endpoints, replicationFactor, h.Hashring, h.Tenants, h.ShuffleShardingConfig, reg, numShardsGauge, defaultTenantID)
+		hashring, err = newHashring(activeAlgorithm, h.Endpoints, replicationFactor, h.Hashring, h.Tenants, h.ShuffleShardingConfig, reg, defaultTenantID, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -988,7 +1001,7 @@ func NewMultiHashring(algorithm HashringAlgorithm, replicationFactor uint64, cfg
 	return m, nil
 }
 
-func newHashring(algorithm HashringAlgorithm, endpoints []Endpoint, replicationFactor uint64, hashring string, tenants []string, shuffleShardingConfig ShuffleShardingConfig, reg prometheus.Registerer, numShardsGauge *prometheus.GaugeVec, defaultTenantID string) (Hashring, error) {
+func newHashring(algorithm HashringAlgorithm, endpoints []Endpoint, replicationFactor uint64, hashring string, tenants []string, shuffleShardingConfig ShuffleShardingConfig, reg prometheus.Registerer, defaultTenantID string, logger log.Logger) (Hashring, error) {
 
 	switch algorithm {
 	case AlgorithmHashmod:
@@ -1012,7 +1025,7 @@ func newHashring(algorithm HashringAlgorithm, endpoints []Endpoint, replicationF
 			if shuffleShardingConfig.ShardSize.Value > len(endpoints) {
 				return nil, fmt.Errorf("shard size %d is larger than number of nodes in hashring %s (%d)", shuffleShardingConfig.ShardSize.Value, hashring, len(endpoints))
 			}
-			return newShuffleShardHashring(ringImpl, shuffleShardingConfig, replicationFactor, reg, hashring, defaultTenantID)
+			return newShuffleShardHashring(ringImpl, shuffleShardingConfig, replicationFactor, reg, hashring, defaultTenantID, logger)
 		}
 		return ringImpl, nil
 	case AlgorithmRendezvous:
@@ -1020,7 +1033,7 @@ func newHashring(algorithm HashringAlgorithm, endpoints []Endpoint, replicationF
 		if err != nil {
 			return nil, err
 		}
-		numShardsGauge.WithLabelValues(hashring).Set(float64(ringImpl.numShards))
+		level.Info(logger).Log("msg", "Rendezvous hashring created", "hashring", hashring, "num_shards", ringImpl.numShards, "num_azs", len(ringImpl.sortedAZs))
 		if !shuffleShardingConfig.ShardSize.IsZero() {
 			if shuffleShardingConfig.ShardSize.IsPercent {
 				if shuffleShardingConfig.ShardSize.Percent <= 0 || shuffleShardingConfig.ShardSize.Percent > 1.0 {
@@ -1031,12 +1044,11 @@ func newHashring(algorithm HashringAlgorithm, endpoints []Endpoint, replicationF
 					return nil, fmt.Errorf("shard size %d is larger than number of nodes in hashring %s (%d)", shuffleShardingConfig.ShardSize.Value, hashring, len(endpoints))
 				}
 			}
-			return newShuffleShardHashring(ringImpl, shuffleShardingConfig, replicationFactor, reg, hashring, defaultTenantID)
+			return newShuffleShardHashring(ringImpl, shuffleShardingConfig, replicationFactor, reg, hashring, defaultTenantID, logger)
 		}
 		return ringImpl, nil
 	default:
-		l := log.NewNopLogger()
-		level.Warn(l).Log("msg", "Unrecognizable hashring algorithm. Fall back to hashmod algorithm.",
+		level.Warn(logger).Log("msg", "Unrecognizable hashring algorithm. Fall back to hashmod algorithm.",
 			"hashring", hashring,
 			"tenants", tenants)
 		if !shuffleShardingConfig.ShardSize.IsZero() {

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -201,7 +202,7 @@ func TestHashringGet(t *testing.T) {
 			tenant: "t2",
 		},
 	} {
-		hs, err := NewMultiHashring(AlgorithmHashmod, 3, tc.cfg, prometheus.NewRegistry(), "")
+		hs, err := NewMultiHashring(AlgorithmHashmod, 3, tc.cfg, prometheus.NewRegistry(), "", log.NewNopLogger())
 		require.NoError(t, err)
 
 		h, err := hs.Get(tc.tenant, ts)
@@ -669,7 +670,7 @@ func TestInvalidAZHashringCfg(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			_, err := NewMultiHashring(tt.algorithm, tt.replicas, tt.cfg, prometheus.NewRegistry(), "")
+			_, err := NewMultiHashring(tt.algorithm, tt.replicas, tt.cfg, prometheus.NewRegistry(), "", log.NewNopLogger())
 			require.EqualError(t, err, tt.expectedError)
 		})
 	}
@@ -794,7 +795,7 @@ func TestShuffleShardHashring(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create the shuffle shard hashring
-			shardRing, err := newShuffleShardHashring(baseRing, tc.shuffleShardCfg, 2, prometheus.NewRegistry(), "test", "")
+			shardRing, err := newShuffleShardHashring(baseRing, tc.shuffleShardCfg, 2, prometheus.NewRegistry(), "test", "", log.NewNopLogger())
 			require.NoError(t, err)
 
 			// Test that the shuffle sharding is consistent
@@ -969,13 +970,13 @@ func TestShuffleShardHashringStability(t *testing.T) {
 			// Create initial hashring
 			initialBaseRing, err := newKetamaHashring(initialEndpoints, SectionsPerNode, 1)
 			require.NoError(t, err)
-			initialShardRing, err := newShuffleShardHashring(initialBaseRing, shuffleShardCfg, 1, prometheus.NewRegistry(), "test-initial", "")
+			initialShardRing, err := newShuffleShardHashring(initialBaseRing, shuffleShardCfg, 1, prometheus.NewRegistry(), "test-initial", "", log.NewNopLogger())
 			require.NoError(t, err)
 
 			// Create scaled hashring
 			scaledBaseRing, err := newKetamaHashring(scaledEndpoints, SectionsPerNode, 1)
 			require.NoError(t, err)
-			scaledShardRing, err := newShuffleShardHashring(scaledBaseRing, shuffleShardCfg, 1, prometheus.NewRegistry(), "test-scaled", "")
+			scaledShardRing, err := newShuffleShardHashring(scaledBaseRing, shuffleShardCfg, 1, prometheus.NewRegistry(), "test-scaled", "", log.NewNopLogger())
 			require.NoError(t, err)
 
 			totalDiffs := 0
@@ -1178,7 +1179,7 @@ func TestShuffleShardDefaultTenantBypass(t *testing.T) {
 		require.NoError(t, err)
 		shardRing, err := newShuffleShardHashring(baseRing, ShuffleShardingConfig{
 			ShardSize: ShardSize{Value: 3},
-		}, 2, prometheus.NewRegistry(), "test-ketama", defaultTenant)
+		}, 2, prometheus.NewRegistry(), "test-ketama", defaultTenant, log.NewNopLogger())
 		require.NoError(t, err)
 
 		// Default tenant should use all 10 endpoints (base ring).
@@ -1234,7 +1235,7 @@ func TestShuffleShardDefaultTenantBypass(t *testing.T) {
 		require.NoError(t, err)
 		shardRing, err := newShuffleShardHashring(baseRing, ShuffleShardingConfig{
 			ShardSize: ShardSize{Value: 6},
-		}, 3, prometheus.NewRegistry(), "test-rendezvous", defaultTenant)
+		}, 3, prometheus.NewRegistry(), "test-rendezvous", defaultTenant, log.NewNopLogger())
 		require.NoError(t, err)
 
 		// Default tenant should reach all shards in the base ring (4 shards x 3 AZs = 12 endpoints).
@@ -1286,7 +1287,7 @@ func TestShuffleShardDefaultTenantBypass(t *testing.T) {
 		require.NoError(t, err)
 		shardRing, err := newShuffleShardHashring(baseRing, ShuffleShardingConfig{
 			ShardSize: ShardSize{Value: 3},
-		}, 2, prometheus.NewRegistry(), "test-no-bypass", "")
+		}, 2, prometheus.NewRegistry(), "test-no-bypass", "", log.NewNopLogger())
 		require.NoError(t, err)
 
 		nodes := make(map[string]struct{})

--- a/pkg/receive/rendezvous_hashring_test.go
+++ b/pkg/receive/rendezvous_hashring_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
@@ -299,7 +300,7 @@ func TestRendezvousShuffleShardingBasic(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-rendezvous", "")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-rendezvous", "", log.NewNopLogger())
 	require.NoError(t, err)
 
 	tenant := "test-tenant"
@@ -350,7 +351,7 @@ func TestRendezvousShuffleShardingConsistency(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-consistency", "")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-consistency", "", log.NewNopLogger())
 	require.NoError(t, err)
 
 	tenant := "consistent-tenant"
@@ -386,7 +387,7 @@ func TestRendezvousShuffleShardingDifferentTenants(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 9},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-diff-tenants", "")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-diff-tenants", "", log.NewNopLogger())
 	require.NoError(t, err)
 
 	tenantShards := make(map[string][]int)
@@ -425,7 +426,7 @@ func TestRendezvousShuffleShardingPreservesAlignment(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-preserves", "")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-preserves", "", log.NewNopLogger())
 	require.NoError(t, err)
 
 	tenant := "alignment-test-tenant"
@@ -474,7 +475,7 @@ func TestRendezvousShuffleShardingDataDistribution(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-distribution", "")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-distribution", "", log.NewNopLogger())
 	require.NoError(t, err)
 
 	tenant := "distribution-test-tenant"
@@ -584,7 +585,7 @@ func TestRendezvousShuffleShardingValidation(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 30}, // 30 / 3 AZs = 10 per-AZ, but only 5 shards available
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-validation", "")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-validation", "", log.NewNopLogger())
 	require.NoError(t, err)
 
 	_, err = shardRing.getTenantShardRendezvous("test-tenant")
@@ -611,7 +612,7 @@ func TestRendezvousShuffleShardingPercentage(t *testing.T) {
 		cfg := ShuffleShardingConfig{
 			ShardSize: ShardSize{Percent: 0.5, IsPercent: true},
 		}
-		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-50", "")
+		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-50", "", log.NewNopLogger())
 		require.NoError(t, err)
 
 		shard, err := shardRing.getTenantShardRendezvous("test-tenant")
@@ -646,7 +647,7 @@ func TestRendezvousShuffleShardingPercentage(t *testing.T) {
 		cfg := ShuffleShardingConfig{
 			ShardSize: ShardSize{Percent: 0.25, IsPercent: true},
 		}
-		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-25", "")
+		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-25", "", log.NewNopLogger())
 		require.NoError(t, err)
 
 		shard, err := shardRing.getTenantShardRendezvous("test-tenant")
@@ -670,7 +671,7 @@ func TestRendezvousShuffleShardingPercentage(t *testing.T) {
 		cfg := ShuffleShardingConfig{
 			ShardSize: ShardSize{Percent: 1.0, IsPercent: true},
 		}
-		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-100", "")
+		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-100", "", log.NewNopLogger())
 		require.NoError(t, err)
 
 		shard, err := shardRing.getTenantShardRendezvous("test-tenant")
@@ -692,7 +693,7 @@ func TestRendezvousShuffleShardingPercentage(t *testing.T) {
 				},
 			},
 		}
-		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-override", "")
+		shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-override", "", log.NewNopLogger())
 		require.NoError(t, err)
 
 		// Default tenant gets 50%.
@@ -724,7 +725,7 @@ func TestRendezvousShuffleShardingPercentageConsistency(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Percent: 0.5, IsPercent: true},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-consistency", "")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-pct-consistency", "", log.NewNopLogger())
 	require.NoError(t, err)
 
 	tenant := "consistency-tenant"
@@ -764,7 +765,7 @@ func TestKetamaRejectsPercentageShardSize(t *testing.T) {
 		},
 	}
 
-	_, err := NewMultiHashring(AlgorithmKetama, 2, cfg, prometheus.NewRegistry(), "")
+	_, err := NewMultiHashring(AlgorithmKetama, 2, cfg, prometheus.NewRegistry(), "", log.NewNopLogger())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "percentage shard_size is not supported for ketama algorithm")
 }
@@ -788,7 +789,7 @@ func TestRendezvousIntegerShardSizeBackwardCompatibility(t *testing.T) {
 	cfg := ShuffleShardingConfig{
 		ShardSize: ShardSize{Value: 6},
 	}
-	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-int-compat", "")
+	shardRing, err := newShuffleShardHashring(baseRing, cfg, 3, prometheus.NewRegistry(), "test-int-compat", "", log.NewNopLogger())
 	require.NoError(t, err)
 
 	shard, err := shardRing.getTenantShardRendezvous("test-tenant")


### PR DESCRIPTION
Log the resolved per-AZ shard size at hashring creation time for easier debugging. Also unify how percentage and absolute shard sizes are resolved in getTenantShardRendezvous: both are now interpreted as total across all AZs, then divided by numAZs. For percentage this is max(1, totalNodes * pct / numAZs).

Remove the experimental thanos_receive_hashring_shards gauge metric in favor of a log line with the same information.

Co-authored-by: Isaac

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
