### PR TITLE
Fixes for multitenant compactor

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -871,7 +871,7 @@ func getTenantsForCompactor(ctx context.Context, logger log.Logger, conf compact
 
 		level.Info(logger).Log("msg", "setting up tenant partitioning", "ordinal", ordinal, "total_shards", totalShards)
 
-		tenantAssignments, err := compact.SetupTenantPartitioning(ctx, discoveryBkt, logger, tenantWeightsPath, conf.commonPathPrefix, totalShards)
+		tenantAssignments, err := compact.SetupTenantPartitioning(ctx, discoveryBkt, logger, tenantWeightsPath, totalShards)
 		runutil.CloseWithLogOnErr(logger, discoveryBkt, "discovery bucket")
 		if err != nil {
 			return nil, true, errors.Wrap(err, "failed to setup tenant partitioning")
@@ -885,10 +885,9 @@ func getTenantsForCompactor(ctx context.Context, logger log.Logger, conf compact
 		// Deduplicate tenants to avoid duplicate metric registration
 		seenTenants := make(map[string]bool)
 		for _, tenant := range assignedTenants {
-			tenantPrefix := path.Join(conf.commonPathPrefix, tenant)
-			if !seenTenants[tenantPrefix] {
-				seenTenants[tenantPrefix] = true
-				tenantPrefixes = append(tenantPrefixes, tenantPrefix)
+			if !seenTenants[tenant] {
+				seenTenants[tenant] = true
+				tenantPrefixes = append(tenantPrefixes, tenant)
 			}
 		}
 
@@ -1105,7 +1104,6 @@ type compactConfig struct {
 	tenantWeights                                  extflag.PathOrContent
 	replicas                                       int
 	replicationFactor                              int
-	commonPathPrefix                               string
 	enableTenantPathPrefix                         bool
 }
 
@@ -1231,10 +1229,7 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("compact.replication-factor", "Replication factor of the stateful set.").
 		Default("1").IntVar(&cc.replicationFactor)
 
-	cmd.Flag("compact.common-path-prefix", "Common path prefix for tenant discovery when using tenant partitioning. This is the prefix before the tenant name in the object storage path. Must align with tsdb.path-segments-before-tenant on the receiver.").
-		Default("v1/raw/").StringVar(&cc.commonPathPrefix)
-
-	cmd.Flag("compact.enable-tenant-path-prefix", "Enable tenant path prefix mode for backward compatibility. When disabled, compactor runs in single-tenant mode.").
+	cmd.Flag("compact.enable-tenant-path-prefix", "Enable multi-tenant compaction with per-tenant path prefixing. Each tenant's blocks are expected under a {tenantID}/ prefix.").
 		Default("false").BoolVar(&cc.enableTenantPathPrefix)
 
 	cc.webConf.registerFlag(cmd)

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -70,7 +70,9 @@ func (r *idempotentRegisterer) Register(c prometheus.Collector) error {
 
 func (r *idempotentRegisterer) MustRegister(cs ...prometheus.Collector) {
 	for _, c := range cs {
-		_ = r.Register(c) // Ignores duplicates
+		if err := r.Register(c); err != nil {
+			panic(err)
+		}
 	}
 }
 
@@ -902,11 +904,17 @@ func getTenantsForCompactor(ctx context.Context, logger log.Logger, conf compact
 func getBucketForTenant(logger log.Logger, isMultiTenant bool, tenantConfYaml []byte, component component.Component, conf compactConfig, bucketConf *client.BucketConfig, globalBkt objstore.Bucket) (objstore.Bucket, error) {
 	if isMultiTenant {
 		bkt, err := client.NewBucket(logger, tenantConfYaml, component.String(), nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "create tenant bucket")
+		}
 		if conf.enableFolderDeletion {
 			bkt, err = block.WrapWithAzDataLakeSdk(logger, tenantConfYaml, bkt)
+			if err != nil {
+				return nil, errors.Wrap(err, "wrap tenant bucket with Azure Data Lake SDK")
+			}
 			level.Info(logger).Log("msg", "azdatalake sdk wrapper enabled", "prefix", bucketConf.Prefix, "name", bkt.Name())
 		}
-		return bkt, err
+		return bkt, nil
 	}
 	return globalBkt, nil
 }
@@ -1049,7 +1057,11 @@ func getRetentionPolicies(logger log.Logger, conf *compactConfig) (map[compact.R
 
 func extractOrdinalFromHostname(hostname string) (int, error) {
 	parts := strings.Split(hostname, "-")
-	return strconv.Atoi(parts[len(parts)-1])
+	ordinal, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		return 0, fmt.Errorf("cannot extract ordinal from hostname %q (expected StatefulSet format 'name-N'): %w", hostname, err)
+	}
+	return ordinal, nil
 }
 
 type compactConfig struct {
@@ -1219,7 +1231,7 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("compact.replication-factor", "Replication factor of the stateful set.").
 		Default("1").IntVar(&cc.replicationFactor)
 
-	cmd.Flag("compact.common-path-prefix", "Common path prefix for tenant discovery when using tenant partitioning. This is the prefix before the tenant name in the object storage path.").
+	cmd.Flag("compact.common-path-prefix", "Common path prefix for tenant discovery when using tenant partitioning. This is the prefix before the tenant name in the object storage path. Must align with tsdb.path-segments-before-tenant on the receiver.").
 		Default("v1/raw/").StringVar(&cc.commonPathPrefix)
 
 	cmd.Flag("compact.enable-tenant-path-prefix", "Enable tenant path prefix mode for backward compatibility. When disabled, compactor runs in single-tenant mode.").

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -1227,9 +1227,10 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("false").Hidden().BoolVar(&rc.tsdbEnableTenantPathPrefix)
 
 	cmd.Flag("tsdb.path-segments-before-tenant",
-		"[EXPERIMENTAL] Specifies the path segments before the tenant for object storage."+
-			"Must only be used in combination with tsdb.enable-tenant-path-prefix.").
-		Default("raw").Hidden().StringsVar(&rc.tsdbPathSegmentsBeforeTenant)
+		"[EXPERIMENTAL] Specifies the path segments before the tenant for object storage. "+
+			"Must only be used in combination with tsdb.enable-tenant-path-prefix. "+
+			"Must align with compact.common-path-prefix on the compactor.").
+		Default("v1", "raw").Hidden().StringsVar(&rc.tsdbPathSegmentsBeforeTenant)
 
 	cmd.Flag("tsdb.head-chunks-write-buffer-size-bytes",
 		"Configures the write buffer size used by the head chunks mapper. "+

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -167,11 +167,6 @@ func runReceive(
 		level.Info(logger).Log("msg", "tenant path prefix feature enabled")
 	}
 
-	if len(conf.tsdbPathSegmentsBeforeTenant) > 0 {
-		multiTSDBOptions = append(multiTSDBOptions, receive.WithPathSegmentsBeforeTenant(conf.tsdbPathSegmentsBeforeTenant))
-		level.Info(logger).Log("msg", "tenant path segments before tenant feature enabled", "segments", path.Join(conf.tsdbPathSegmentsBeforeTenant...))
-	}
-
 	if *conf.compactionDelayInterval > 0 {
 		multiTSDBOptions = append(multiTSDBOptions, receive.WithCompactionDelayInterval(time.Duration(*conf.compactionDelayInterval)))
 		level.Info(logger).Log("msg", "deterministic compaction delay enabled", "interval", conf.compactionDelayInterval.String())
@@ -1028,7 +1023,6 @@ type receiveConfig struct {
 	tsdbDisableFlushOnShutdown    bool
 	tsdbEnableNativeHistograms    bool
 	tsdbEnableTenantPathPrefix    bool
-	tsdbPathSegmentsBeforeTenant  []string
 	tsdbHeadChunksWriteBufferSize int
 	tsdbStripeSize                int
 
@@ -1223,14 +1217,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("false").Hidden().BoolVar(&rc.tsdbEnableNativeHistograms)
 
 	cmd.Flag("tsdb.enable-tenant-path-prefix",
-		"[EXPERIMENTAL] Enables the tenant path prefix for object storage.").
+		"Enables per-tenant path prefixing in object storage. Each tenant's blocks are stored under a {tenantID}/ prefix.").
 		Default("false").Hidden().BoolVar(&rc.tsdbEnableTenantPathPrefix)
-
-	cmd.Flag("tsdb.path-segments-before-tenant",
-		"[EXPERIMENTAL] Specifies the path segments before the tenant for object storage. "+
-			"Must only be used in combination with tsdb.enable-tenant-path-prefix. "+
-			"Must align with compact.common-path-prefix on the compactor.").
-		Default("v1", "raw").Hidden().StringsVar(&rc.tsdbPathSegmentsBeforeTenant)
 
 	cmd.Flag("tsdb.head-chunks-write-buffer-size-bytes",
 		"Configures the write buffer size used by the head chunks mapper. "+

--- a/pkg/compact/partition_tenants.go
+++ b/pkg/compact/partition_tenants.go
@@ -90,9 +90,9 @@ func computeTenantAssignments(numShards int, tenantWeightList []TenantWeight) (m
 	return bucketTenantAssignments, bucketWeights
 }
 
-// Discover tenants from S3 bucket by listing all tenant directories under the path prefix before tenant.
-// e.g., if the path prefix is "v1/raw/", it will list all tenant directories under "v1/raw/".
-func discoverTenantsFromBucket(ctx context.Context, bkt objstore.BucketReader, logger log.Logger, commonPathPrefix string, knownTenants []TenantWeight) ([]string, error) {
+// Discover tenants from bucket by listing all tenant directories at the bucket root.
+// The bucket config prefix is expected to already scope the bucket to the correct hierarchy level.
+func discoverTenantsFromBucket(ctx context.Context, bkt objstore.BucketReader, logger log.Logger, knownTenants []TenantWeight) ([]string, error) {
 	discoveredTenants := []string{}
 	knownTenantSet := make(map[string]bool)
 
@@ -102,14 +102,12 @@ func discoverTenantsFromBucket(ctx context.Context, bkt objstore.BucketReader, l
 		level.Debug(logger).Log("msg", "marking tenant as known", "tenant", tw.TenantName)
 	}
 
-	// List all tenant directories under prefix before tenant
-	err := bkt.Iter(ctx, commonPathPrefix, func(name string) error {
-		// name will be like "v1/raw/tenant-a/"
+	err := bkt.Iter(ctx, "", func(name string) error {
 		if !strings.HasSuffix(name, "/") {
 			return nil // Not a directory
 		}
 
-		tenantName := strings.TrimSuffix(strings.TrimPrefix(name, commonPathPrefix), "/")
+		tenantName := strings.TrimSuffix(name, "/")
 
 		// Skip if already active tenant shown in tenant weight config
 		if knownTenantSet[tenantName] {
@@ -138,7 +136,7 @@ func tenantToShard(tenantName string, numShards int) int {
 	return int(h.Sum32()) % numShards
 }
 
-func SetupTenantPartitioning(ctx context.Context, bkt objstore.Bucket, logger log.Logger, configPath string, commonPathPrefix string, numShards int) (map[int][]string, error) {
+func SetupTenantPartitioning(ctx context.Context, bkt objstore.Bucket, logger log.Logger, configPath string, numShards int) (map[int][]string, error) {
 	// Get active tenants from tenant weight config
 	activeTenants, err := readTenantWeights(configPath)
 	if err != nil {
@@ -150,7 +148,7 @@ func SetupTenantPartitioning(ctx context.Context, bkt objstore.Bucket, logger lo
 	level.Debug(logger).Log("msg", "computed assignments for active tenants", "count", len(activeTenants))
 
 	// Discover additional tenants from S3
-	discoveredTenants, err := discoverTenantsFromBucket(ctx, bkt, logger, commonPathPrefix, activeTenants)
+	discoveredTenants, err := discoverTenantsFromBucket(ctx, bkt, logger, activeTenants)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compact/partition_tenants_test.go
+++ b/pkg/compact/partition_tenants_test.go
@@ -446,44 +446,41 @@ func TestDiscoverTenantsFromBucket(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	for _, tcase := range []struct {
-		name             string
-		setupBucket      func(bkt objstore.Bucket) error
-		commonPathPrefix string
-		knownTenants     []TenantWeight
-		expectedTenants  []string
-		expectError      bool
+		name            string
+		setupBucket     func(bkt objstore.Bucket) error
+		knownTenants    []TenantWeight
+		expectedTenants []string
+		expectError     bool
 	}{
 		{
 			name: "discover multiple new tenants",
 			setupBucket: func(bkt objstore.Bucket) error {
-				if err := bkt.Upload(ctx, "v1/raw/tenant-a/.keep", strings.NewReader("")); err != nil {
+				if err := bkt.Upload(ctx, "tenant-a/.keep", strings.NewReader("")); err != nil {
 					return err
 				}
-				if err := bkt.Upload(ctx, "v1/raw/tenant-b/.keep", strings.NewReader("")); err != nil {
+				if err := bkt.Upload(ctx, "tenant-b/.keep", strings.NewReader("")); err != nil {
 					return err
 				}
-				if err := bkt.Upload(ctx, "v1/raw/tenant-c/.keep", strings.NewReader("")); err != nil {
+				if err := bkt.Upload(ctx, "tenant-c/.keep", strings.NewReader("")); err != nil {
 					return err
 				}
 				return nil
 			},
-			commonPathPrefix: "v1/raw/",
-			knownTenants:     []TenantWeight{},
-			expectedTenants:  []string{"tenant-a", "tenant-b", "tenant-c"},
-			expectError:      false,
+			knownTenants:    []TenantWeight{},
+			expectedTenants: []string{"tenant-a", "tenant-b", "tenant-c"},
+			expectError:     false,
 		},
 		{
 			name: "skip known tenants",
 			setupBucket: func(bkt objstore.Bucket) error {
-				if err := bkt.Upload(ctx, "v1/raw/known-tenant/.keep", strings.NewReader("")); err != nil {
+				if err := bkt.Upload(ctx, "known-tenant/.keep", strings.NewReader("")); err != nil {
 					return err
 				}
-				if err := bkt.Upload(ctx, "v1/raw/new-tenant/.keep", strings.NewReader("")); err != nil {
+				if err := bkt.Upload(ctx, "new-tenant/.keep", strings.NewReader("")); err != nil {
 					return err
 				}
 				return nil
 			},
-			commonPathPrefix: "v1/raw/",
 			knownTenants: []TenantWeight{
 				{TenantName: "known-tenant", Weight: 100},
 			},
@@ -495,23 +492,21 @@ func TestDiscoverTenantsFromBucket(t *testing.T) {
 			setupBucket: func(bkt objstore.Bucket) error {
 				return nil
 			},
-			commonPathPrefix: "v1/raw/",
-			knownTenants:     []TenantWeight{},
-			expectedTenants:  []string{},
-			expectError:      false,
+			knownTenants:    []TenantWeight{},
+			expectedTenants: []string{},
+			expectError:     false,
 		},
 		{
 			name: "all tenants already known",
 			setupBucket: func(bkt objstore.Bucket) error {
-				if err := bkt.Upload(ctx, "v1/raw/tenant-1/.keep", strings.NewReader("")); err != nil {
+				if err := bkt.Upload(ctx, "tenant-1/.keep", strings.NewReader("")); err != nil {
 					return err
 				}
-				if err := bkt.Upload(ctx, "v1/raw/tenant-2/.keep", strings.NewReader("")); err != nil {
+				if err := bkt.Upload(ctx, "tenant-2/.keep", strings.NewReader("")); err != nil {
 					return err
 				}
 				return nil
 			},
-			commonPathPrefix: "v1/raw/",
 			knownTenants: []TenantWeight{
 				{TenantName: "tenant-1", Weight: 50},
 				{TenantName: "tenant-2", Weight: 50},
@@ -524,35 +519,18 @@ func TestDiscoverTenantsFromBucket(t *testing.T) {
 			setupBucket: func(bkt objstore.Bucket) error {
 				tenants := []string{"tenant-a", "tenant-b", "tenant-c", "tenant-d", "tenant-e"}
 				for _, tenant := range tenants {
-					if err := bkt.Upload(ctx, "v1/raw/"+tenant+"/.keep", strings.NewReader("")); err != nil {
+					if err := bkt.Upload(ctx, tenant+"/.keep", strings.NewReader("")); err != nil {
 						return err
 					}
 				}
 				return nil
 			},
-			commonPathPrefix: "v1/raw/",
 			knownTenants: []TenantWeight{
 				{TenantName: "tenant-a", Weight: 100},
 				{TenantName: "tenant-c", Weight: 80},
 			},
 			expectedTenants: []string{"tenant-b", "tenant-d", "tenant-e"},
 			expectError:     false,
-		},
-		{
-			name: "different path prefix",
-			setupBucket: func(bkt objstore.Bucket) error {
-				if err := bkt.Upload(ctx, "data/metrics/tenant-x/.keep", strings.NewReader("")); err != nil {
-					return err
-				}
-				if err := bkt.Upload(ctx, "data/metrics/tenant-y/.keep", strings.NewReader("")); err != nil {
-					return err
-				}
-				return nil
-			},
-			commonPathPrefix: "data/metrics/",
-			knownTenants:     []TenantWeight{},
-			expectedTenants:  []string{"tenant-x", "tenant-y"},
-			expectError:      false,
 		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
@@ -564,7 +542,7 @@ func TestDiscoverTenantsFromBucket(t *testing.T) {
 			}
 
 			// Discover tenants
-			discovered, err := discoverTenantsFromBucket(ctx, bkt, logger, tcase.commonPathPrefix, tcase.knownTenants)
+			discovered, err := discoverTenantsFromBucket(ctx, bkt, logger, tcase.knownTenants)
 
 			if tcase.expectError {
 				if err == nil {
@@ -617,7 +595,6 @@ func TestSetupTenantPartitioning(t *testing.T) {
 		name                      string
 		setupBucket               func(bkt objstore.Bucket) error
 		setupConfigFile           func() (string, error)
-		commonPathPrefix          string
 		numShards                 int
 		expectedActiveTenants     int
 		expectedDiscoveredTenants int
@@ -626,9 +603,8 @@ func TestSetupTenantPartitioning(t *testing.T) {
 		{
 			name: "active and discovered tenants",
 			setupBucket: func(bkt objstore.Bucket) error {
-				// Create some discovered tenants
 				for _, tenant := range []string{"discovered-1", "discovered-2"} {
-					if err := bkt.Upload(ctx, "v1/raw/"+tenant+"/.keep", strings.NewReader("")); err != nil {
+					if err := bkt.Upload(ctx, tenant+"/.keep", strings.NewReader("")); err != nil {
 						return err
 					}
 				}
@@ -646,7 +622,6 @@ func TestSetupTenantPartitioning(t *testing.T) {
 				}
 				return encodeTempFile(t, tempFile, config)
 			},
-			commonPathPrefix:          "v1/raw/",
 			numShards:                 2,
 			expectedActiveTenants:     2,
 			expectedDiscoveredTenants: 2,
@@ -670,7 +645,6 @@ func TestSetupTenantPartitioning(t *testing.T) {
 				}
 				return encodeTempFile(t, tempFile, config)
 			},
-			commonPathPrefix:          "v1/raw/",
 			numShards:                 2,
 			expectedActiveTenants:     3,
 			expectedDiscoveredTenants: 0,
@@ -680,7 +654,7 @@ func TestSetupTenantPartitioning(t *testing.T) {
 			name: "only discovered tenants",
 			setupBucket: func(bkt objstore.Bucket) error {
 				for _, tenant := range []string{"tenant-1", "tenant-2", "tenant-3", "tenant-4"} {
-					if err := bkt.Upload(ctx, "v1/raw/"+tenant+"/.keep", strings.NewReader("")); err != nil {
+					if err := bkt.Upload(ctx, tenant+"/.keep", strings.NewReader("")); err != nil {
 						return err
 					}
 				}
@@ -695,7 +669,6 @@ func TestSetupTenantPartitioning(t *testing.T) {
 				config := map[string]int{} // Empty config
 				return encodeTempFile(t, tempFile, config)
 			},
-			commonPathPrefix:          "v1/raw/",
 			numShards:                 2,
 			expectedActiveTenants:     0,
 			expectedDiscoveredTenants: 4,
@@ -704,10 +677,9 @@ func TestSetupTenantPartitioning(t *testing.T) {
 		{
 			name: "large mixed setup",
 			setupBucket: func(bkt objstore.Bucket) error {
-				// Create many discovered tenants
 				for i := 1; i <= 20; i++ {
 					tenant := "discovered-" + string(rune('a'+i-1))
-					if err := bkt.Upload(ctx, "v1/raw/"+tenant+"/.keep", strings.NewReader("")); err != nil {
+					if err := bkt.Upload(ctx, tenant+"/.keep", strings.NewReader("")); err != nil {
 						return err
 					}
 				}
@@ -728,7 +700,6 @@ func TestSetupTenantPartitioning(t *testing.T) {
 				}
 				return encodeTempFile(t, tempFile, config)
 			},
-			commonPathPrefix:          "v1/raw/",
 			numShards:                 3,
 			expectedActiveTenants:     5,
 			expectedDiscoveredTenants: 20,
@@ -748,7 +719,7 @@ func TestSetupTenantPartitioning(t *testing.T) {
 			}
 			defer os.Remove(configPath)
 
-			tenantAssignments, err := SetupTenantPartitioning(ctx, bkt, logger, configPath, tcase.commonPathPrefix, tcase.numShards)
+			tenantAssignments, err := SetupTenantPartitioning(ctx, bkt, logger, configPath, tcase.numShards)
 
 			if tcase.expectError {
 				if err == nil {
@@ -771,7 +742,7 @@ func TestSetupTenantPartitioning_InvalidConfig(t *testing.T) {
 	logger := log.NewNopLogger()
 	bkt := objstore.NewInMemBucket()
 
-	_, err := SetupTenantPartitioning(ctx, bkt, logger, "/nonexistent/config.json", "v1/raw/", 3)
+	_, err := SetupTenantPartitioning(ctx, bkt, logger, "/nonexistent/config.json", 3)
 	if err == nil {
 		t.Error("expected error for nonexistent config file, got nil")
 	}
@@ -801,20 +772,20 @@ func TestSetupTenantPartitioning_NoDuplicates(t *testing.T) {
 	weightsFile.Close()
 
 	// Create bucket structure with tenant directories including "unknown"
-	testutil.Ok(t, bkt.Upload(ctx, "v1/raw/unknown/meta.json", bytes.NewReader([]byte("{}"))))
-	testutil.Ok(t, bkt.Upload(ctx, "v1/raw/eng-monitoring-platform/meta.json", bytes.NewReader([]byte("{}"))))
-	testutil.Ok(t, bkt.Upload(ctx, "v1/raw/eng-compute-lifecycle-team/meta.json", bytes.NewReader([]byte("{}"))))
-	testutil.Ok(t, bkt.Upload(ctx, "v1/raw/discovered-tenant/meta.json", bytes.NewReader([]byte("{}"))))
+	testutil.Ok(t, bkt.Upload(ctx, "unknown/meta.json", bytes.NewReader([]byte("{}"))))
+	testutil.Ok(t, bkt.Upload(ctx, "eng-monitoring-platform/meta.json", bytes.NewReader([]byte("{}"))))
+	testutil.Ok(t, bkt.Upload(ctx, "eng-compute-lifecycle-team/meta.json", bytes.NewReader([]byte("{}"))))
+	testutil.Ok(t, bkt.Upload(ctx, "discovered-tenant/meta.json", bytes.NewReader([]byte("{}"))))
 
 	// Run tenant partitioning
-	assignments, err := SetupTenantPartitioning(ctx, bkt, logger, weightsFile.Name(), "v1/raw/", 2)
+	assignments, err := SetupTenantPartitioning(ctx, bkt, logger, weightsFile.Name(), 2)
 	testutil.Ok(t, err)
 
 	// Verify no tenant appears more than once across all shards
 	seenTenants := make(map[string]int)
 	for shard, tenants := range assignments {
 		for _, tenant := range tenants {
-			// Verify tenants don't have path prefix (should be just "unknown", not "v1/raw/unknown")
+			// Verify tenants are bare names without path separators
 			if strings.Contains(tenant, "/") {
 				t.Errorf("tenant name %s contains path separator, should be bare tenant name only", tenant)
 			}

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -70,8 +70,7 @@ type MultiTSDB struct {
 	disableSeriesResorting   bool
 	metricNameFilterEnabled  bool
 	noUploadTenants          []string // Support both exact matches and prefix patterns (e.g., "tenant1", "prod-*")
-	enableTenantPathPrefix   bool
-	pathSegmentsBeforeTenant []string
+	enableTenantPathPrefix bool
 
 	compactionDelayInterval time.Duration
 	tenantCounter           atomic.Uint64
@@ -107,13 +106,6 @@ func WithNoUploadTenants(tenants []string) MultiTSDBOption {
 func WithTenantPathPrefix() MultiTSDBOption {
 	return func(s *MultiTSDB) {
 		s.enableTenantPathPrefix = true
-	}
-}
-
-// WithPathSegmentsBeforeTenant sets the path segments before the tenant for object store.
-func WithPathSegmentsBeforeTenant(segments []string) MultiTSDBOption {
-	return func(s *MultiTSDB) {
-		s.pathSegmentsBeforeTenant = segments
 	}
 }
 
@@ -877,10 +869,8 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	if t.bucket != nil && !t.isNoUploadTenant(tenantID) {
 		var tenantBucket objstore.Bucket
 		if t.enableTenantPathPrefix {
-			segmentsBeforeTenant := path.Join(t.pathSegmentsBeforeTenant...)
-			tenantPrefix := path.Join(segmentsBeforeTenant, tenantID)
-			tenantBucket = objstore.NewPrefixedBucket(t.bucket, tenantPrefix)
-			level.Info(logger).Log("msg", "assigning shipper bucket with tenant path prefix", "tenantPrefix", tenantPrefix)
+			tenantBucket = objstore.NewPrefixedBucket(t.bucket, tenantID)
+			level.Info(logger).Log("msg", "assigning shipper bucket with tenant path prefix", "tenantID", tenantID)
 		} else {
 			tenantBucket = t.bucket
 		}

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -1151,7 +1151,9 @@ func TestTenantBucketPrefixInUpload(t *testing.T) {
 	dir := t.TempDir()
 	bucket := objstore.NewInMemBucket()
 
-	// Create MultiTSDB with bucket
+	// Create MultiTSDB with bucket and tenant path prefix enabled.
+	// The bucket config prefix is expected to already include the hierarchy (e.g., v1/{region}/raw),
+	// so the receiver only prefixes with the tenant ID.
 	m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
 		&tsdb.Options{
 			MinBlockDuration:  (2 * time.Hour).Milliseconds(),
@@ -1164,7 +1166,6 @@ func TestTenantBucketPrefixInUpload(t *testing.T) {
 		false,
 		metadata.NoneFunc,
 		WithTenantPathPrefix(),
-		WithPathSegmentsBeforeTenant([]string{"v1", "raw"}),
 	)
 	defer func() { testutil.Ok(t, m.Close()) }()
 
@@ -1191,9 +1192,9 @@ func TestTenantBucketPrefixInUpload(t *testing.T) {
 
 	if uploaded > 0 {
 		// Verify that uploaded blocks are in directories with tenant prefixes
-		// Expected path format: "v1/raw/{tenantID}/{blockID}/{file}"
-		expectedPrefix1 := "v1/raw/tenant-a"
-		expectedPrefix2 := "v1/raw/tenant-b"
+		// Expected path format: "{tenantID}/{blockID}/{file}"
+		expectedPrefix1 := "tenant-a"
+		expectedPrefix2 := "tenant-b"
 		foundTenantA := false
 		foundTenantB := false
 
@@ -1225,12 +1226,10 @@ func TestTenantBucketPrefixInUpload(t *testing.T) {
 		testutil.Assert(t, foundTenantA, "uploaded blocks should contain tenant-a prefix path")
 		testutil.Assert(t, foundTenantB, "uploaded blocks should contain tenant-b prefix path")
 
-		// Also verify that objects don't exist at the block level without tenant prefixes
-		// The only objects at root should be the version directory "v1/"
+		// Verify that all objects at root are tenant directories (no loose block directories)
 		rootObjects := 0
 		testutil.Ok(t, bucket.Iter(context.Background(), "", func(name string) error {
-			// Allow "v1/" directory but no direct block directories
-			if name != "v1/" && !strings.HasPrefix(name, "v1/raw/tenant-") {
+			if !strings.HasPrefix(name, "tenant-") {
 				rootObjects++
 				t.Logf("Found unexpected root object: %s", name)
 			}


### PR DESCRIPTION
## Changes

- Fix a nil dereference panic in `getBucketForTenant` when bucket creation fails and `enableFolderDeletion` is true. The error from `client.NewBucket` was not checked before passing the (nil) bucket to `WrapWithAzDataLakeSdk` and calling `bkt.Name()`
- Stop swallowing non-duplicate metric registration errors in `idempotentRegisterer.MustRegister`. `Register` already filters out `AlreadyRegisteredError`, so the only errors reaching `MustRegister` are genuine failures that should surface
- Align the receiver's default `tsdb.path-segments-before-tenant` from `["raw"]` to `["v1", "raw"]` to match the compactor's default `compact.common-path-prefix` of `v1/raw/`, preventing a silent path mismatch when both components are deployed with defaults
- Improve `extractOrdinalFromHostname` error message to include the hostname and expected format, making StatefulSet misconfiguration easier to diagnose
- Remove hardcoded `v1/raw/` path prefix

## Verification

<!-- How you tested it? How do you know it works? -->
