### PR TITLE
Add new compactor metrics for tenant-prefixed object store

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -132,6 +132,8 @@ type compactMetrics struct {
 	blockCleanupFailures        prometheus.Counter
 	blocksMarked                *prometheus.CounterVec
 	garbageCollectedBlocks      prometheus.Counter
+	tenantIterations            *prometheus.CounterVec
+	tenantAssigned              *prometheus.GaugeVec
 }
 
 func newCompactMetrics(reg *prometheus.Registry, deleteDelay time.Duration) *compactMetrics {
@@ -185,6 +187,14 @@ func newCompactMetrics(reg *prometheus.Registry, deleteDelay time.Duration) *com
 		Name: "thanos_compact_garbage_collected_blocks_total",
 		Help: "Total number of blocks marked for deletion by compactor.",
 	})
+	m.tenantIterations = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "thanos_compact_tenant_iterations_total",
+		Help: "Total number of compaction iterations completed successfully per tenant.",
+	}, []string{"tenant"})
+	m.tenantAssigned = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		Name: "thanos_compact_tenant_assigned",
+		Help: "Set to 1 for each tenant assigned to this compactor instance.",
+	}, []string{"tenant"})
 	return m
 }
 
@@ -294,6 +304,7 @@ func runCompact(
 	runWebServer(g, ctx, logger, cancel, reg, &conf, component, tracer, progressRegistry, globalBaseMetaFetcher, api, srv)
 
 	for _, tenantPrefix := range tenantPrefixes {
+		compactMetrics.tenantAssigned.WithLabelValues(tenantPrefix).Set(1)
 		bucketConf := &client.BucketConfig{
 			Type:   initialBucketConf.Type,
 			Config: initialBucketConf.Config,
@@ -628,6 +639,7 @@ func runCompactForTenant(
 			err := compactMainFn(progressRegistry.Get(compact.Main))
 			if err == nil {
 				compactMetrics.iterations.Inc()
+				compactMetrics.tenantIterations.WithLabelValues(tenant).Inc()
 				return nil
 			}
 


### PR DESCRIPTION
## Changes

- Add `thanos_compact_tenant_assigned{tenant}` gauge to expose which tenants are assigned to each compactor instance, enabling verification of tenant partitioning across replicas
- Add `thanos_compact_tenant_iterations_total{tenant}` counter to track successful compaction iterations per tenant, enabling verification that compaction is completing end-to-end for every tenant                                                                                                             
                  
The existing compactor metrics are either global (`thanos_compact_iterations_total`) or only carry a resolution label (`thanos_compact_group_compaction_runs_*`). In multitenant mode, there is no way to confirm via metrics that:                                                                                        
1. A specific tenant is assigned to the expected compactor replica
2. Compaction is actually completing for each individual tenant                                           
                                                                 
  These two new metrics close that gap with minimal overhead.
